### PR TITLE
docs: specify commit tracker metric and PR reporting contracts

### DIFF
--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -18,7 +18,7 @@ The monorepo is documentation-first: structure, ownership, and contracts must be
 - `docs/project-derun.md`: Go tool for AI coding-agent workflows.
 - `docs/project-mpapp.md`: Expo React Native mobile app.
 - `docs/project-devkit.md`: Next.js 16 web micro-app platform.
-- `docs/project-devkit-commit-tracker.md`: Commit Tracker mini app.
+- `docs/project-devkit-commit-tracker.md`: Commit Tracker contracts (Web UI + API server + collector).
 - `docs/project-devkit-remote-camera.md`: Remote Camera mini app.
 - `docs/project-thenv.md`: Secure `.env` sharing system (CLI + Server + Web).
 
@@ -46,6 +46,22 @@ enum DevkitMiniAppId {
   Thenv = "thenv",
 }
 ```
+
+## Commit Tracker Component Contract
+`devkit-commit-tracker` is documented as a single project with three planned components:
+
+```ts
+enum CommitTrackerComponent {
+  WebApp = "web-app",
+  ApiServer = "api-server",
+  Collector = "collector",
+}
+```
+
+Component mapping:
+- `WebApp` -> `apps/devkit/src/apps/commit-tracker`
+- `ApiServer` -> `servers/commit-tracker` (planned)
+- `Collector` -> `cmds/commit-tracker` (planned)
 
 ## Devkit Routing Contract
 All Devkit mini apps must be exposed at:
@@ -92,3 +108,4 @@ enum ThenvComponent {
 - New project creation is blocked until its project document exists.
 - Domain-level `AGENTS.md` files are policy mirrors and must stay aligned with `docs/`.
 - If a project splits into multiple deployables, the project doc must include path ownership and integration boundaries.
+- `docs/project-devkit-commit-tracker.md` remains the canonical single document for commit tracker UI/API/collector contracts.

--- a/docs/project-devkit-commit-tracker.md
+++ b/docs/project-devkit-commit-tracker.md
@@ -1,34 +1,46 @@
 # Project: devkit-commit-tracker
 
 ## Goal
-`devkit-commit-tracker` is the first Devkit mini app for tracking commit activity and visibility.
-It provides a focused UI for commit-oriented workflows inside Devkit.
+`devkit-commit-tracker` tracks commit-level engineering metrics and highlights regressions.
+It provides commit history visualization, pull-request base-vs-head comparisons, and provider feedback via comments and status checks.
 
 ## Path
-- `apps/devkit/src/apps/commit-tracker`
+- Web app: `apps/devkit/src/apps/commit-tracker`
+- API server and provider reporter: `servers/commit-tracker` (planned)
+- CI collector and ingestion CLI: `cmds/commit-tracker` (planned)
 
 ## Runtime and Language
-- Next.js 16 mini app module (TypeScript)
+- Web app: Next.js 16 mini app module (TypeScript)
+- API server: Go (planned)
+- Collector CLI: Go (planned)
 
 ## Users
-- Developers tracking commit progress
-- Team leads reviewing commit trends and activity status
+- Developers tracking performance and artifact-size changes by commit
+- Reviewers validating pull request impact against base commits
+- Engineering leads monitoring trend and regression risk
 
 ## In Scope
-- Commit list and commit detail views
-- Basic filtering and search
-- Status-oriented summaries for recent activity
-- Integration with backend commit data endpoints
+- Commit metric ingestion from CI and benchmark pipelines
+- Multi-provider pull request comparison reporting for cloud providers:
+  GitHub, GitLab, Bitbucket
+- Graph-based visualization for metric trends and distribution views
+- Metric-specific evaluation rules for increase/decrease semantics
+- Pull request comment publishing and status check publishing
+- Commit, branch, repository, and environment filters for metric exploration
+- Connect RPC contracts for ingestion, query, and reporting flows
 
 ## Out of Scope
-- Full repository analytics platform
-- Code review tooling replacement
-- Release management automation
+- Self-hosted provider support in v1
+- Built-in statistical noise-correction algorithms for benchmark data
+- Replacement of code review systems or approval workflows
+- Full release orchestration and deployment automation
 
 ## Architecture
-- UI module for list/detail pages.
-- Data adapter for commit endpoint integration.
-- Shared Devkit shell integration for navigation and routing.
+- Collector uploads commit metrics from CI and benchmark tools through Connect RPC ingestion endpoints.
+- API server stores metric definitions and measurements, then computes commit and pull request comparisons (`base` vs `head`).
+- Provider reporter emits markdown comparison comments and aggregate status checks to provider APIs.
+- Web app visualizes metric timelines, pull request deltas, and percentile/histogram summaries.
+- Devkit shell continues to own global auth/session/navigation concerns.
 
 ## Interfaces
 Canonical mini app identifier:
@@ -42,41 +54,166 @@ enum MiniAppId {
 Route contract:
 - `/apps/commit-tracker`
 
-Conceptual data contract:
-- Commit summary list item
-- Commit detail object
-- Filter query parameters
+Canonical component identifiers:
+
+```ts
+enum CommitTrackerComponent {
+  WebApp = "web-app",
+  ApiServer = "api-server",
+  Collector = "collector",
+}
+```
+
+Provider and metric contract identifiers:
+
+```ts
+enum GitProviderKind {
+  GitHub = "github",
+  GitLab = "gitlab",
+  Bitbucket = "bitbucket",
+}
+
+enum MetricValueKind {
+  UnitNumber = "unit-number",
+  Ratio = "ratio",
+  DeltaOnly = "delta-only",
+  BooleanGate = "boolean-gate",
+  Histogram = "histogram",
+  Percentiles = "percentiles",
+}
+
+enum MetricDirection {
+  IncreaseIsBetter = "increase-is-better",
+  DecreaseIsBetter = "decrease-is-better",
+}
+
+enum EvaluationLevel {
+  Pass = "pass",
+  Warn = "warn",
+  Fail = "fail",
+  Neutral = "neutral",
+}
+```
+
+Connect RPC service contract:
+
+```proto
+service MetricIngestionService {
+  rpc UpsertCommitMetrics(UpsertCommitMetricsRequest) returns (UpsertCommitMetricsResponse);
+}
+
+service MetricQueryService {
+  rpc ListMetricSeries(ListMetricSeriesRequest) returns (ListMetricSeriesResponse);
+  rpc GetPullRequestComparison(GetPullRequestComparisonRequest) returns (GetPullRequestComparisonResponse);
+}
+
+service ProviderReportService {
+  rpc PublishPullRequestReport(PublishPullRequestReportRequest) returns (PublishPullRequestReportResponse);
+}
+```
+
+Pull request reporting contract:
+- Publish markdown table comment containing:
+  metric key, `base`, `head`, absolute delta, delta percent, evaluation level.
+- Publish aggregate status check for pull request head commit:
+  `pass`, `warn`, or `fail`.
+- Use metric-specific rule profile with:
+  `warning_threshold_percent`, `fail_threshold_percent`, `direction`.
+
+Graph and visualization contract:
+- Commit timeline line chart per metric.
+- Pull request delta table/bar view (`base`, `head`, `delta`, `delta%`, `verdict`).
+- Histogram and percentile visualization for latency/memory distributions.
+- Color mapping is driven by metric direction and thresholds, not fixed increase/decrease assumptions.
+- Required filter dimensions: provider, repository, branch, metric, time range, environment.
+
+v1 metric catalog contract:
+- Binary size (`bytes`, `UnitNumber`)
+- Benchmark duration (`ms`, `UnitNumber`)
+- Peak memory (`bytes`, `UnitNumber`)
+- Throughput (`ops/s`, `UnitNumber`)
+- CPU time (`ms`, `UnitNumber`)
+- Error rate (`%`, `Ratio`)
+- Success rate (`%`, `Ratio`)
+- Test/benchmark gate (`pass/fail`, `BooleanGate`)
+- Latency percentiles (`p50/p95/p99`, `Percentiles`)
+- Histogram summary from external benchmark tooling (`Histogram`)
 
 ## Storage
-- Client-side filter and view preferences.
-- Server-backed commit data owned by backend source.
-- No standalone database in mini app scope.
+- Web app stores local filter/view preferences.
+- API server owns persistent comparison data.
+- Collector does not require long-lived local storage by default.
+
+Core entity contracts:
+- `MetricDefinition`:
+  metric key, display name, unit, value kind, direction, thresholds.
+- `CommitMeasurement`:
+  provider, repository, branch, commit SHA, run ID, environment, metric values.
+- `PullRequestComparison`:
+  provider pull request reference, base/head SHAs, per-metric comparisons, aggregate verdict.
+- `RuleProfile`:
+  metric-specific `direction`, `warning_threshold_percent`, `fail_threshold_percent`.
+
+Noise policy contract:
+- v1 stores and compares values produced by external benchmark tools.
+- No internal noise-correction or re-sampling algorithm in v1.
 
 ## Security
-- Respect Devkit auth/session controls.
-- Mask sensitive metadata if backend marks fields restricted.
+- Respect Devkit auth/session controls in the web app.
+- Use provider tokens with minimum scopes required for comment and status APIs.
+- Avoid storing provider secrets in frontend contexts.
+- Do not expose sensitive environment metadata in default responses.
 
 ## Logging
 Required baseline logs:
-- Data fetch lifecycle and failures
-- Route/load failures
-- Filter application errors
+- Data ingestion lifecycle and failures
+- Pull request comparison generation lifecycle and failures
+- Provider comment/status publication attempts and outcomes
+- Route/load failures and filter application errors in the web app
+
+Required structured fields:
+- `provider`
+- `repository`
+- `pull_request`
+- `commit`
+- `run_id`
+- `metric_key`
+- `evaluation_level`
+- `delta_percent`
 
 ## Build and Test
 Planned commands:
-- `pnpm --filter devkit... test`
-- Targeted tests for commit tracker module when test project layout is available.
+- Web app tests: `pnpm --filter devkit... test`
+- API server tests (planned): `go test ./servers/commit-tracker/...`
+- Collector tests (planned): `go test ./cmds/commit-tracker/...`
+
+Acceptance-focused test scenarios:
+- Idempotent behavior when the same commit metrics are uploaded repeatedly.
+- `Neutral` comparison behavior when base commit metric is missing.
+- `IncreaseIsBetter` metrics pass on increase and degrade on decrease.
+- `DecreaseIsBetter` metrics pass on decrease and degrade on increase.
+- Pull request comment verdicts stay consistent with status check verdicts.
+- Provider adapters stay isolated per provider integration path.
+- Histogram/percentile metrics appear in both graph views and pull request comparisons.
+- External benchmark outputs are stored directly without internal recalculation.
 
 ## Roadmap
-- Phase 1: List/detail MVP with basic filtering.
-- Phase 2: Activity summaries and richer query controls.
-- Phase 3: Team-focused views and export options.
+- Phase 1: Contracts, ingestion flow, and base-vs-head comparison core.
+- Phase 2: Graph UX expansion and provider adapter hardening.
+- Phase 3: Advanced metric families and governance controls.
 
 ## Open Questions
-- Final backend endpoint contract and pagination format.
-- Priority sort rules for timeline and summary cards.
+- Long-term retention and archival policy for high-volume metric time-series.
+- Access-control granularity for cross-team repository visibility.
+- Optional support timeline for self-hosted provider variants.
 
 ## References
 - `docs/project-template.md`
 - `docs/monorepo.md`
 - `docs/project-devkit.md`
+- [GitHub REST API: Pull request comments](https://docs.github.com/en/rest/pulls/comments)
+- [GitHub REST API: Create a commit status](https://docs.github.com/en/rest/commits/statuses#create-a-commit-status)
+- [GitLab API: Notes (merge request notes)](https://docs.gitlab.com/api/notes/#create-new-merge-request-note)
+- [GitLab API: Commits (set commit pipeline status)](https://docs.gitlab.com/api/commits/#set-commit-pipeline-status)
+- [Bitbucket Cloud REST API: Pull requests](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pullrequests/)
+- [Bitbucket Cloud REST API: Commit statuses](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-commit-statuses/)

--- a/docs/project-devkit.md
+++ b/docs/project-devkit.md
@@ -20,6 +20,7 @@ It provides shared navigation, shared auth/session surface, and consistent routi
 - Mini app registration/discovery conventions
 - Stable route contract for micro apps
 - Common observability and UI baseline across apps
+- Integration patterns for backend-coupled mini apps via typed API contracts
 
 ## Out of Scope
 - Replacing full standalone product websites
@@ -31,6 +32,7 @@ It provides shared navigation, shared auth/session surface, and consistent routi
 - Mini apps live under `src/apps/<id>`.
 - Router maps each mini app to `/apps/<id>`.
 - Shared services layer exposes standard platform utilities.
+- Backend-coupled mini apps consume backend APIs while preserving shell-owned auth/session/navigation behavior.
 
 ## Interfaces
 Canonical mini app IDs:
@@ -60,6 +62,11 @@ Mini app registration contract (conceptual):
 - `title`
 - `route`
 - `entry`
+- `integrationMode` (`shell-only` or `backend-coupled`)
+
+Backend-coupled mini app example:
+- `commit-tracker` uses Connect RPC APIs from `servers/commit-tracker` (planned).
+- Devkit shell remains the owner of global auth/session/navigation concerns.
 
 ## Storage
 - Session-level web state in browser storage as needed.


### PR DESCRIPTION
## Summary
- expand docs/project-devkit-commit-tracker.md from UI-only scope to Web UI + API server + collector contracts
- define typed enums and Connect RPC service contracts for ingestion, query, and provider reporting
- document multi-provider cloud scope (GitHub/GitLab/Bitbucket), graph/reporting requirements, and PR comment/status-check behavior
- align docs/project-devkit.md and docs/monorepo.md with backend-coupled mini app and component mapping contracts

## Notes
- docs-only change (no runtime code changes)
- keeps docs/project-devkit-commit-tracker.md as the single canonical contract doc for commit tracker