### PR TITLE
docs(derun): define run/mcp session bridge contract

### DIFF
--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -15,7 +15,7 @@ The monorepo is documentation-first: structure, ownership, and contracts must be
 - `docs/project-template.md`: Required structure for new project docs.
 - `docs/monorepo.md`: Monorepo-wide rules and contracts.
 - `docs/project-nodeup.md`: Rust-based Node.js version manager.
-- `docs/project-derun.md`: Go tool for AI coding-agent workflows.
+- `docs/project-derun.md`: Go CLI for terminal-fidelity run execution and MCP output bridge access for AI.
 - `docs/project-mpapp.md`: Expo React Native mobile app.
 - `docs/project-devkit.md`: Next.js 16 web micro-app platform.
 - `docs/project-devkit-commit-tracker.md`: Commit Tracker mini app.


### PR DESCRIPTION
## Summary
- Refocus derun docs from generic workflow orchestration to a run/mcp two-command model
- Define terminal-fidelity proxy contract for derun run with side-channel transcript capture
- Specify MCP read-only session/output interfaces for replay and live tail
- Lock defaults for retention, capture format, discovery mode, and cross-platform support
- Update monorepo canonical map description for derun

## Changed Files
- docs/project-derun.md
- docs/monorepo.md

## Notes
- Documentation-only change
- No Rust/frontend code changes