### PR TITLE
docs: enforce shell backtick and escaping rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 - Do not guess; rather search for the web.
 - Debug by logging. You should write enough logging code.
 - Prioritize Connect RPC-based communication for business flows over Tauri-specific bindings.
+- When writing shell commands or scripts, treat backticks and command substitution carefully, prefer `$(...)` over legacy backticks, and apply strict escaping for all dynamic values.
 
 ### Monorepo Structure Map
 

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -103,6 +103,10 @@ enum ThenvComponent {
 - Use `project-` prefix for all project docs.
 - Use enum-like canonical identifiers in documents where values must remain stable.
 
+## Shell Command Safety Rules
+- Use `$(...)` for command substitution; do not use legacy backticks in new scripts.
+- Apply strict quoting and escaping for all dynamic shell values to prevent command injection and parsing bugs.
+
 ## Documentation Lifecycle Rules
 - Every structural repository change must update relevant `docs/project-*.md` files in the same change set.
 - New project creation is blocked until its project document exists.


### PR DESCRIPTION
## Summary
- add AGENTS.md instruction to prefer modern command substitution over legacy backticks
- require strict escaping of dynamic shell values
- mirror the same shell safety rules in docs/monorepo.md to keep policy alignment

## Testing
- not run (docs-only changes)