### PR TITLE
docs: add commit and PR review resolution workflow rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 - If you modified frontend code, run `pnpm test` from the frontend directory before finishing your task.
 - Commit your work as frequent as possible using git. Do NOT use `--no-verify` flag.
 - After `git add`, run `git commit` without unnecessary delay so staged changes are preserved in history.
+- After addressing pull request review comments and pushing updates, mark the corresponding review threads as resolved.
 - Do not guess; rather search for the web.
 - Debug by logging. You should write enough logging code.
 - Prioritize Connect RPC-based communication for business flows over Tauri-specific bindings.

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -108,5 +108,6 @@ enum ThenvComponent {
 - New project creation is blocked until its project document exists.
 - Domain-level `AGENTS.md` files are policy mirrors and must stay aligned with `docs/`.
 - After staging files with `git add`, create a commit with `git commit` without unnecessary delay.
+- After addressing pull request review comments and pushing updates, resolve the corresponding review threads.
 - If a project splits into multiple deployables, the project doc must include path ownership and integration boundaries.
 - `docs/project-devkit-commit-tracker.md` remains the canonical single document for commit tracker UI/API/collector contracts.


### PR DESCRIPTION
## Summary
- require immediate git commit after git add in repository instructions
- require resolving PR review threads after applying feedback and pushing updates
- mirror both rules in docs/monorepo.md to keep docs as source of truth

## Testing
- not applicable (documentation-only changes)