### PR TITLE
fix(mpapp): refresh touchpad responder when move callback changes

### DIFF
--- a/apps/mpapp/src/components/touchpad-surface.tsx
+++ b/apps/mpapp/src/components/touchpad-surface.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import {
   PanResponder,
   Pressable,
@@ -18,30 +18,33 @@ export function TouchpadSurface({ disabled, onMove }: TouchpadSurfaceProps) {
   const previousDxRef = useRef(0);
   const previousDyRef = useRef(0);
 
-  const resetDeltaAccumulator = () => {
+  const resetDeltaAccumulator = useCallback(() => {
     previousDxRef.current = 0;
     previousDyRef.current = 0;
-  };
+  }, []);
 
-  const handleMove = (
-    _event: GestureResponderEvent,
-    gestureState: PanResponderGestureState,
-  ) => {
-    if (disabled) {
-      return;
-    }
+  const handleMove = useCallback(
+    (
+      _event: GestureResponderEvent,
+      gestureState: PanResponderGestureState,
+    ) => {
+      if (disabled) {
+        return;
+      }
 
-    const deltaX = gestureState.dx - previousDxRef.current;
-    const deltaY = gestureState.dy - previousDyRef.current;
-    previousDxRef.current = gestureState.dx;
-    previousDyRef.current = gestureState.dy;
+      const deltaX = gestureState.dx - previousDxRef.current;
+      const deltaY = gestureState.dy - previousDyRef.current;
+      previousDxRef.current = gestureState.dx;
+      previousDyRef.current = gestureState.dy;
 
-    if (deltaX === 0 && deltaY === 0) {
-      return;
-    }
+      if (deltaX === 0 && deltaY === 0) {
+        return;
+      }
 
-    onMove(deltaX, deltaY);
-  };
+      onMove(deltaX, deltaY);
+    },
+    [disabled, onMove],
+  );
 
   const panResponder = useMemo(
     () =>
@@ -53,7 +56,7 @@ export function TouchpadSurface({ disabled, onMove }: TouchpadSurfaceProps) {
         onPanResponderRelease: resetDeltaAccumulator,
         onPanResponderTerminate: resetDeltaAccumulator,
       }),
-    [disabled],
+    [disabled, handleMove, resetDeltaAccumulator],
   );
 
   return (

--- a/docs/project-mpapp.md
+++ b/docs/project-mpapp.md
@@ -39,6 +39,7 @@ The core user flow is:
   - A touchpad region for drag capture
   - Dedicated left-click and right-click controls
 - Input translation module converts gesture deltas into pointer movement samples with sensitivity applied.
+- Touchpad gesture responder instances must be recreated when movement callback dependencies change so runtime sensitivity updates take effect without reconnecting.
 - Android HID transport adapter is implemented as a TypeScript `HidAdapter` contract with a stub transport implementation for MVP integration stability.
 - Diagnostics module records structured events, failures, and latency observations in local storage.
 


### PR DESCRIPTION
## Summary
- fix stale PanResponder move callback capture in TouchpadSurface
- memoize gesture handlers with useCallback and include handleMove in responder memo dependencies
- update mpapp project docs to codify responder recreation when movement callback dependencies change

## Why
Codex review on https://github.com/delinoio/oss/pull/14#pullrequestreview-3836166758 identified that responder callbacks could become stale when runtime sensitivity changes while connected.

## Testing
- pnpm test (from apps/mpapp)