### PR TITLE
fix(derun): reject duplicate session ids and harden tty detection

### DIFF
--- a/cmds/derun/internal/cli/run_test.go
+++ b/cmds/derun/internal/cli/run_test.go
@@ -52,3 +52,50 @@ func TestExecuteRunPipeModeCapturesOutputAndExitCode(t *testing.T) {
 		t.Fatalf("final metadata should exist: %v", err)
 	}
 }
+
+func TestExecuteRunRejectsDuplicateSessionID(t *testing.T) {
+	stateRoot := t.TempDir()
+	if err := os.Setenv("DERUN_STATE_ROOT", stateRoot); err != nil {
+		t.Fatalf("Setenv DERUN_STATE_ROOT: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Unsetenv("DERUN_STATE_ROOT") })
+
+	sessionID := "01J0S444444444444444444444"
+	firstExitCode := ExecuteRun([]string{"--session-id", sessionID, "--", "sh", "-c", "printf 'first'"})
+	if firstExitCode != 0 {
+		t.Fatalf("unexpected first exit code: got=%d want=0", firstExitCode)
+	}
+
+	store, err := state.New(stateRoot)
+	if err != nil {
+		t.Fatalf("state.New returned error: %v", err)
+	}
+	firstDetail, err := store.GetSession(sessionID)
+	if err != nil {
+		t.Fatalf("GetSession after first run returned error: %v", err)
+	}
+
+	secondExitCode := ExecuteRun([]string{"--session-id", sessionID, "--", "sh", "-c", "printf 'second'; exit 9"})
+	if secondExitCode != 2 {
+		t.Fatalf("unexpected second exit code: got=%d want=2", secondExitCode)
+	}
+
+	secondDetail, err := store.GetSession(sessionID)
+	if err != nil {
+		t.Fatalf("GetSession after duplicate rejection returned error: %v", err)
+	}
+	if secondDetail.OutputBytes != firstDetail.OutputBytes {
+		t.Fatalf("duplicate session attempt should not append output: before=%d after=%d", firstDetail.OutputBytes, secondDetail.OutputBytes)
+	}
+	if secondDetail.ExitCode == nil || *secondDetail.ExitCode != 0 {
+		t.Fatalf("duplicate session attempt should preserve first final metadata: %v", secondDetail.ExitCode)
+	}
+
+	sessions, total, err := store.ListSessions("", 10)
+	if err != nil {
+		t.Fatalf("ListSessions returned error: %v", err)
+	}
+	if total != 1 || len(sessions) != 1 {
+		t.Fatalf("unexpected sessions after duplicate rejection: total=%d len=%d", total, len(sessions))
+	}
+}

--- a/cmds/derun/internal/cli/terminal_other.go
+++ b/cmds/derun/internal/cli/terminal_other.go
@@ -1,0 +1,9 @@
+//go:build !unix && !windows
+
+package cli
+
+import "os"
+
+func isTerminal(_ *os.File) bool {
+	return false
+}

--- a/cmds/derun/internal/cli/terminal_test.go
+++ b/cmds/derun/internal/cli/terminal_test.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsTerminalRejectsNilFile(t *testing.T) {
+	if isTerminal(nil) {
+		t.Fatalf("nil file should not be treated as terminal")
+	}
+}
+
+func TestIsTerminalRejectsDevNull(t *testing.T) {
+	devNull, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("Open DevNull returned error: %v", err)
+	}
+	defer devNull.Close()
+
+	if isTerminal(devNull) {
+		t.Fatalf("dev null should not be treated as terminal")
+	}
+}
+
+func TestIsTerminalRejectsRegularFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sample.txt")
+	if err := os.WriteFile(path, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer file.Close()
+
+	if isTerminal(file) {
+		t.Fatalf("regular file should not be treated as terminal")
+	}
+}

--- a/cmds/derun/internal/cli/terminal_unix.go
+++ b/cmds/derun/internal/cli/terminal_unix.go
@@ -1,0 +1,17 @@
+//go:build unix
+
+package cli
+
+import (
+	"os"
+
+	"github.com/creack/pty"
+)
+
+func isTerminal(file *os.File) bool {
+	if file == nil {
+		return false
+	}
+	_, _, err := pty.Getsize(file)
+	return err == nil
+}

--- a/cmds/derun/internal/cli/terminal_windows.go
+++ b/cmds/derun/internal/cli/terminal_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package cli
+
+import (
+	"os"
+	"syscall"
+)
+
+func isTerminal(file *os.File) bool {
+	if file == nil {
+		return false
+	}
+	var mode uint32
+	return syscall.GetConsoleMode(syscall.Handle(file.Fd()), &mode) == nil
+}

--- a/cmds/derun/internal/state/store.go
+++ b/cmds/derun/internal/state/store.go
@@ -56,6 +56,30 @@ func (s *Store) EnsureSessionDir(sessionID string) error {
 	return EnsureDir(dir)
 }
 
+func (s *Store) HasSessionMetadata(sessionID string) (bool, error) {
+	metaPath, err := s.sessionFile(sessionID, metaFileName)
+	if err != nil {
+		return false, err
+	}
+	if _, err := os.Stat(metaPath); err == nil {
+		return true, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, fmt.Errorf("stat meta file: %w", err)
+	}
+
+	finalPath, err := s.sessionFile(sessionID, finalFileName)
+	if err != nil {
+		return false, err
+	}
+	if _, err := os.Stat(finalPath); err == nil {
+		return true, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, fmt.Errorf("stat final file: %w", err)
+	}
+
+	return false, nil
+}
+
 func (s *Store) WriteMeta(meta session.Meta) error {
 	if err := s.EnsureSessionDir(meta.SessionID); err != nil {
 		return err

--- a/docs/project-derun.md
+++ b/docs/project-derun.md
@@ -113,6 +113,7 @@ enum DerunMcpTool {
 Command contracts:
 - `derun run [--session-id <id>] [--retention <duration>] -- <command> [args...]`
 : Executes user command with terminal-fidelity proxying and side-channel transcript capture.
+- `derun run` must reject explicit `--session-id` values when persisted metadata already exists (`meta.json` or `final.json`), returning exit code `2` without mutating existing artifacts.
 - `derun mcp`
 : Starts stdio MCP server for AI-driven session/output retrieval.
 
@@ -137,6 +138,7 @@ Terminal fidelity rules:
 - Interactive sessions must forward stdin bytes, resize events, and termination signals.
 - Child exit code or signal must be propagated as `derun run` process exit result.
 - Capture pipeline must be side-channel only and must not transform forwarded bytes.
+- PTY eligibility must use OS terminal probing (`isatty` semantics, e.g. ioctl/GetConsoleMode), not character-device-only checks.
 
 Session discovery/attach contract:
 - Explicit session identifier attach model only.


### PR DESCRIPTION
## Summary
- reject explicit --session-id values when metadata already exists to prevent transcript corruption
- detect terminal eligibility using OS-level terminal probing (isatty semantics) instead of char-device checks
- add regression tests for duplicate session-id rejection and non-terminal detection
- sync derun project contract docs with the new behavior

## Validation
- go test ./cmds/derun/...

## Context
- addresses feedback from https://github.com/delinoio/oss/pull/11#pullrequestreview-3836177730