### PR TITLE
fix(derun): block session artifact symlink escape

### DIFF
--- a/docs/project-derun.md
+++ b/docs/project-derun.md
@@ -170,7 +170,7 @@ Write consistency contract:
 - Directory permissions: `0700`
 - File permissions: `0600`
 - Persist output stream only by default; stdin is proxied but not persisted.
-- Resolve canonical real paths before session artifact IO and reject path traversal or symlink escape outside `sessions/<session-id>`.
+- Resolve canonical real paths before session artifact IO and reject path traversal or symlink escape outside `sessions/<session-id>`, including dangling symlink targets.
 - Apply traversal/symlink checks consistently for `meta.json`, `final.json`, `output.bin`, `index.jsonl`, and `append.lock` across read and write flows.
 - Keep MCP tool surface read-only in v1.
 - Do not emit secret values into operational logs.


### PR DESCRIPTION
## Summary
- harden derun session artifact path resolution with symlink-aware real-path containment checks
- reject symlink escapes outside sessions/<session-id> while allowing in-session symlink targets
- pre-validate append.lock, output.bin, and index.jsonl paths before append writes
- add traversal/symlink security tests across read and write entrypoints
- update derun project docs with the implemented security and test contract

## Validation
- go test ./cmds/derun/internal/state
- go test ./cmds/derun/...

Closes #42