### PR TITLE
docs(policy): add sandbox retry guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 - Prefer structured logging libraries for business and system logs (Go: `log/slog`, Rust: `tracing`).
 - Prioritize Connect RPC-based communication for business flows over Tauri-specific bindings.
 - When writing shell commands or scripts, treat backticks and command substitution carefully, prefer `$(...)` over legacy backticks, and apply strict escaping for all dynamic values.
+- If an operation is blocked by sandbox restrictions, retry it without sandbox restrictions using the required approval flow.
 
 ### Monorepo Structure Map
 

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -109,6 +109,7 @@ enum ThenvComponent {
 ## Shell Command Safety Rules
 - Use `$(...)` for command substitution; do not use legacy backticks in new scripts.
 - Apply strict quoting and escaping for all dynamic shell values to prevent command injection and parsing bugs.
+- If an operation is blocked by sandbox restrictions, retry it without sandbox restrictions using the required approval flow.
 
 ## Logging Rules
 - Write sufficient logs to support debugging, incident analysis, and operational troubleshooting.


### PR DESCRIPTION
## Summary
- add sandbox retry guidance to AGENTS.md
- mirror the same policy in docs/monorepo.md to keep policy docs aligned

## Testing
- not run (docs-only change)