### PR TITLE
fix(derun): persist startup-failure sessions for MCP discovery

### DIFF
--- a/cmds/derun/internal/state/store.go
+++ b/cmds/derun/internal/state/store.go
@@ -219,7 +219,7 @@ func (s *Store) GetSession(sessionID string) (session.Detail, error) {
 		return session.Detail{}, fmt.Errorf("read meta file: %w", err)
 	}
 
-	state := contracts.DerunSessionStateRunning
+	state := contracts.DerunSessionStateStarting
 	var endedAt *time.Time
 	var exitCode *int
 	var signal string
@@ -240,8 +240,10 @@ func (s *Store) GetSession(sessionID string) (session.Detail, error) {
 	} else if !os.IsNotExist(err) {
 		return session.Detail{}, fmt.Errorf("read final file: %w", err)
 	} else {
-		if !processAlive(meta.PID) {
+		if meta.PID > 0 && !processAlive(meta.PID) {
 			state = contracts.DerunSessionStateFailed
+		} else if meta.PID > 0 {
+			state = contracts.DerunSessionStateRunning
 		}
 	}
 

--- a/docs/project-derun.md
+++ b/docs/project-derun.md
@@ -114,6 +114,7 @@ Command contracts:
 - `derun run [--session-id <id>] [--retention <duration>] -- <command> [args...]`
 : Executes user command with terminal-fidelity proxying and side-channel transcript capture.
 - `derun run` must reject explicit `--session-id` values when persisted metadata already exists (`meta.json` or `final.json`), returning exit code `2` without mutating existing artifacts.
+- `derun run` must persist `meta.json` before process spawn, then update `pid` after successful start; startup failures must still persist `final.json` with failed state so the session remains discoverable through MCP list/get.
 - `derun mcp`
 : Starts stdio MCP server for AI-driven session/output retrieval.
 
@@ -212,6 +213,7 @@ Required behavioral test scenarios:
 7. TTL expiration removes only expired sessions and preserves active sessions.
 8. Windows ConPTY parity tests and POSIX PTY parity tests.
 9. Session artifact traversal and symlink-escape attempts are rejected for both read and write operations.
+10. Startup failures persist discoverable metadata and remain queryable via `derun_list_sessions` and `derun_get_session`.
 
 ## Roadmap
 - Phase 1: Terminal-fidelity `run` execution and transcript persistence.


### PR DESCRIPTION
## Summary
- persist `meta.json` before process spawn in `derun run` and update PID after successful start
- persist failed sessions as discoverable metadata so startup failures are visible in MCP list/get
- refine no-final state derivation: `pid<=0` => `starting`, live positive PID => `running`, dead positive PID => `failed`
- add regression tests for startup-failure discoverability and PID-based no-final state derivation
- update `docs/project-derun.md` contract and required behavioral scenarios

## Testing
- go test ./cmds/derun/...

Closes #67