### PR TITLE
fix(nodeup): keep run --output json machine-parseable

### DIFF
--- a/crates/nodeup/src/commands/run_cmd.rs
+++ b/crates/nodeup/src/commands/run_cmd.rs
@@ -7,7 +7,7 @@ use crate::{
     cli::OutputFormat,
     commands::print_output,
     errors::{NodeupError, Result},
-    process::run_command,
+    process::{run_command, DelegatedStdioPolicy},
     resolver::ResolvedRuntimeTarget,
     types::RuntimeSelectorSource,
     NodeupApp,
@@ -76,7 +76,17 @@ pub fn execute(
         "Running delegated command"
     );
 
-    let exit_code = run_command(&executable, &delegated_args, "nodeup.run.process")?;
+    let stdio_policy = match output {
+        OutputFormat::Human => DelegatedStdioPolicy::Inherit,
+        OutputFormat::Json => DelegatedStdioPolicy::StdoutToStderr,
+    };
+
+    let exit_code = run_command(
+        &executable,
+        &delegated_args,
+        stdio_policy,
+        "nodeup.run.process",
+    )?;
 
     let response = RunResponse {
         runtime: resolved.runtime_id(),

--- a/crates/nodeup/src/dispatch.rs
+++ b/crates/nodeup/src/dispatch.rs
@@ -4,7 +4,7 @@ use tracing::info;
 
 use crate::{
     errors::{NodeupError, Result},
-    process::run_command,
+    process::{run_command, DelegatedStdioPolicy},
     resolver::ResolvedRuntimeTarget,
     NodeupApp,
 };
@@ -46,6 +46,11 @@ pub fn dispatch_managed_alias_if_needed(app: &NodeupApp) -> Result<Option<i32>> 
         "Dispatching managed alias"
     );
 
-    let exit_code = run_command(&executable, &delegated_args, "nodeup.dispatch.process")?;
+    let exit_code = run_command(
+        &executable,
+        &delegated_args,
+        DelegatedStdioPolicy::Inherit,
+        "nodeup.dispatch.process",
+    )?;
     Ok(Some(exit_code))
 }

--- a/crates/nodeup/src/process.rs
+++ b/crates/nodeup/src/process.rs
@@ -1,36 +1,68 @@
 use std::{
     ffi::OsString,
     path::Path,
-    process::{Command, ExitStatus},
+    process::{Command, ExitStatus, Stdio},
 };
 
 use tracing::info;
 
 use crate::errors::{NodeupError, Result};
 
-pub fn run_command(command_path: &Path, args: &[OsString], command_path_key: &str) -> Result<i32> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DelegatedStdioPolicy {
+    Inherit,
+    StdoutToStderr,
+}
+
+impl DelegatedStdioPolicy {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Inherit => "inherit",
+            Self::StdoutToStderr => "stdout-to-stderr",
+        }
+    }
+}
+
+pub fn run_command(
+    command_path: &Path,
+    args: &[OsString],
+    stdio_policy: DelegatedStdioPolicy,
+    command_path_key: &str,
+) -> Result<i32> {
     info!(
         command_path = command_path_key,
         executable = %command_path.display(),
         args_len = args.len(),
+        stdio_policy = stdio_policy.as_str(),
         "Spawning delegated process"
     );
 
-    let status = Command::new(command_path)
-        .args(args)
-        .status()
-        .map_err(|error| {
-            NodeupError::not_found(format!(
-                "Failed to execute {}: {error}",
-                command_path.display()
-            ))
-        })?;
+    let mut command = Command::new(command_path);
+    command.args(args);
+
+    match stdio_policy {
+        DelegatedStdioPolicy::Inherit => {
+            command.stdout(Stdio::inherit()).stderr(Stdio::inherit());
+        }
+        DelegatedStdioPolicy::StdoutToStderr => {
+            command.stdout(Stdio::from(std::io::stderr()));
+            command.stderr(Stdio::inherit());
+        }
+    }
+
+    let status = command.status().map_err(|error| {
+        NodeupError::not_found(format!(
+            "Failed to execute {}: {error}",
+            command_path.display()
+        ))
+    })?;
 
     let termination = status_details(status);
 
     info!(
         command_path = command_path_key,
         executable = %command_path.display(),
+        stdio_policy = stdio_policy.as_str(),
         exit_code = termination.exit_code,
         signal = ?termination.signal,
         "Delegated process finished"

--- a/docs/project-nodeup.md
+++ b/docs/project-nodeup.md
@@ -183,6 +183,9 @@ Subcommand contracts:
 : Input: explicit runtime selector and delegated argv (at least one command token is required).
 : Behavior: if resolved runtime version is missing, command fails unless `--install` is provided.
 : Output: delegated command result with runtime, delegated command name, and exit code.
+: Output channels:
+: In `--output human`, delegated stdout/stderr inherit terminal streams.
+: In `--output json`, stdout is reserved for the JSON result object and delegated stdout/stderr are streamed to stderr.
 : Exit code: returns delegated process exit code on success path.
 - `nodeup self update`
 : Output: deterministic `NotImplemented` error in current phase.


### PR DESCRIPTION
## Summary
- add typed delegated stdio policy in `process.rs` and include policy in structured logs
- route delegated stdout to stderr for `nodeup run --output json` so stdout remains pure JSON
- keep shim dispatch behavior unchanged (inherit stdio)
- add integration regression test for JSON parseability with delegated stdout/stderr and non-zero exit code
- update `docs/project-nodeup.md` run contract with explicit output-channel behavior

## Testing
- cargo test -p nodeup run_json_output_is_machine_parseable_with_delegated_output -- --nocapture
- cargo test

Closes #82