### PR TITLE
fix(derun): clean expired unreadable sessions in retention sweep

### DIFF
--- a/cmds/derun/internal/retention/gc.go
+++ b/cmds/derun/internal/retention/gc.go
@@ -29,6 +29,7 @@ type cleanupLogReason string
 const (
 	cleanupLogReasonNotExpired           cleanupLogReason = "not_expired"
 	cleanupLogReasonActiveSession        cleanupLogReason = "active_session"
+	cleanupLogReasonExpired              cleanupLogReason = "expired"
 	cleanupLogReasonUnreadableExpired    cleanupLogReason = "unreadable_expired"
 	cleanupLogReasonUnreadableNotExpired cleanupLogReason = "unreadable_not_expired"
 	cleanupLogReasonUnreadableStatErr    cleanupLogReason = "unreadable_stat_error"
@@ -100,7 +101,7 @@ func Sweep(store *state.Store, ttl time.Duration, logger *logging.Logger) (Resul
 			continue
 		}
 		result.Removed++
-		logCleanupResult(logger, sessionID, cleanupLogResultRemoved, "", nil)
+		logCleanupResult(logger, sessionID, cleanupLogResultRemoved, cleanupLogReasonExpired, nil)
 	}
 	return result, nil
 }

--- a/cmds/derun/internal/retention/gc_test.go
+++ b/cmds/derun/internal/retention/gc_test.go
@@ -113,7 +113,7 @@ func TestSweepRemovesOnlyExpiredCompletedSessions(t *testing.T) {
 	}
 
 	cleanupEvents := readCleanupEventsBySession(t, root)
-	assertCleanupEvent(t, cleanupEvents, shortRetentionExpired, cleanupLogResultRemoved, "")
+	assertCleanupEvent(t, cleanupEvents, shortRetentionExpired, cleanupLogResultRemoved, cleanupLogReasonExpired)
 	assertCleanupEvent(t, cleanupEvents, longRetentionActive, cleanupLogResultSkipped, cleanupLogReasonNotExpired)
 	assertCleanupEvent(t, cleanupEvents, running, cleanupLogResultSkipped, cleanupLogReasonActiveSession)
 }

--- a/docs/project-derun.md
+++ b/docs/project-derun.md
@@ -193,7 +193,7 @@ Required baseline logs:
 Logging boundary rules:
 - Structured logs must go to internal log sink.
 - Child stdout/stderr streams must remain unmodified terminal payload.
-- Retention sweep must emit per-session `cleanup_result` logs for skip/remove/error outcomes with explicit `cleanup_reason` values (`not_expired`, `active_session`, `unreadable_not_expired`, `unreadable_expired`, `unreadable_stat_error`, `remove_error`).
+- Retention sweep must emit per-session `cleanup_result` logs for skip/remove/error outcomes with explicit `cleanup_reason` values (`not_expired`, `active_session`, `expired`, `unreadable_not_expired`, `unreadable_expired`, `unreadable_stat_error`, `remove_error`).
 
 ## Build and Test
 Validation commands:


### PR DESCRIPTION
## Summary
- handle retention sweep failures from `store.GetSession` by applying fallback expiration for unreadable/orphan session directories
- remove expired unreadable/orphan session directories and keep non-expired ones based on directory/artifact `lastTouchedAt + sweepTTL`
- add structured per-session `cleanup_result`/`cleanup_reason` logs for skipped/removed/error outcomes
- add retention regressions for orphan and malformed-meta sessions plus log assertions
- update derun retention/logging contract docs

## Testing
- go test ./cmds/derun/internal/retention -run Sweep
- go test ./cmds/derun/...

Closes #68