### PR TITLE
fix(cargo-mono): allow help/version outside workspaces

### DIFF
--- a/crates/cargo-mono/src/main.rs
+++ b/crates/cargo-mono/src/main.rs
@@ -14,7 +14,7 @@ fn main() {
 }
 
 fn run() -> Result<i32, CargoMonoError> {
-    let app = CargoMonoApp::new()?;
     let cli = Cli::parse();
+    let app = CargoMonoApp::new()?;
     commands::execute(cli, &app)
 }

--- a/crates/cargo-mono/tests/cli.rs
+++ b/crates/cargo-mono/tests/cli.rs
@@ -14,6 +14,45 @@ fn help_lists_top_level_commands() {
 }
 
 #[test]
+fn help_succeeds_outside_workspace() {
+    let temp_dir = tempfile::tempdir().expect("failed to create tempdir");
+
+    Command::new(assert_cmd::cargo::cargo_bin!("cargo-mono"))
+        .current_dir(temp_dir.path())
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("list"))
+        .stdout(predicate::str::contains("changed"))
+        .stdout(predicate::str::contains("bump"))
+        .stdout(predicate::str::contains("publish"));
+}
+
+#[test]
+fn version_succeeds_outside_workspace() {
+    let temp_dir = tempfile::tempdir().expect("failed to create tempdir");
+
+    Command::new(assert_cmd::cargo::cargo_bin!("cargo-mono"))
+        .current_dir(temp_dir.path())
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
+}
+
+#[test]
+fn list_still_requires_workspace() {
+    let temp_dir = tempfile::tempdir().expect("failed to create tempdir");
+
+    Command::new(assert_cmd::cargo::cargo_bin!("cargo-mono"))
+        .current_dir(temp_dir.path())
+        .arg("list")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cargo metadata error"));
+}
+
+#[test]
 fn list_outputs_workspace_packages() {
     Command::new(assert_cmd::cargo::cargo_bin!("cargo-mono"))
         .args(["--output", "json", "list"])

--- a/docs/project-cargo-mono.md
+++ b/docs/project-cargo-mono.md
@@ -74,6 +74,8 @@ enum CargoMonoBumpLevel {
 
 CLI entrypoint:
 - `cargo mono [--output <human|json>] <subcommand> ...`
+- `cargo mono --help` and `cargo mono --version` must succeed without workspace discovery.
+- Workspace loading occurs after CLI parsing for executable subcommands (`list`, `changed`, `bump`, `publish`).
 
 Target selection contract (`bump`, `publish`):
 - `--all` default when no target selector is provided.


### PR DESCRIPTION
## Summary
- parse CLI args before initializing `CargoMonoApp` so clap can handle `--help`/`--version` without workspace discovery
- add regression tests for running from a non-workspace directory (`--help`, `--version`, and `list` failure contract)
- update `docs/project-cargo-mono.md` interface contract for workspace-independent help/version behavior

## Testing
- cargo test -p cargo-mono
- cargo test
- manual checks from `/tmp`:
  - `cargo-mono --help` exits 0
  - `cargo-mono --version` exits 0
  - `cargo-mono list` exits non-zero with `cargo metadata error`

Closes #87