### PR TITLE
fix(cargo-mono): update root workspace dependency pins on bump

### DIFF
--- a/docs/project-cargo-mono.md
+++ b/docs/project-cargo-mono.md
@@ -96,6 +96,7 @@ Target selection contract (`bump`, `publish`):
 - Skips non-publishable crates and reports skip reasons.
 - Updates `package.version` for selected crates.
 - Updates internal dependency version requirements for bumped crates.
+- Updates root `Cargo.toml` `[workspace.dependencies]` version pins for bumped internal crates when present.
 - Optional dependent patch propagation via `--bump-dependents`.
 - Requires clean working tree unless `--allow-dirty` is provided.
 - Creates one commit: `chore(release): bump <n> crate(s)`.


### PR DESCRIPTION
## Summary
- update `apply_workspace_bump` to also process the virtual root manifest (`Cargo.toml`)
- ensure `[workspace.dependencies]` version pins are updated for bumped internal crates
- add a regression test for virtual workspaces and keep `workspace = true` behavior unchanged
- update cargo-mono project docs to capture the root manifest bump contract

## Testing
- cargo test -p cargo-mono versioning::tests::apply_workspace_bump_updates_root_workspace_dependencies_for_virtual_workspace
- cargo test -p cargo-mono
- cargo test

Closes #89