### PR TITLE
fix(mpapp): model disconnect reasons and reconnect guidance

### DIFF
--- a/apps/mpapp/src/__tests__/disconnect-reason.test.ts
+++ b/apps/mpapp/src/__tests__/disconnect-reason.test.ts
@@ -1,0 +1,43 @@
+import { MpappAndroidHidNativeErrorCode } from "../../modules/mpapp-android-hid";
+import { MpappDisconnectReason, MpappErrorCode } from "../contracts/enums";
+import { resolveDisconnectReasonFromFailure } from "../state/disconnect-reason";
+
+describe("disconnect reason resolver", () => {
+  it("prefers native error mapping when both native and canonical codes exist", () => {
+    const reason = resolveDisconnectReasonFromFailure(
+      MpappErrorCode.PairingTimeout,
+      MpappAndroidHidNativeErrorCode.PermissionDenied,
+    );
+
+    expect(reason).toBe(MpappDisconnectReason.PermissionRevoked);
+  });
+
+  it.each([
+    [MpappErrorCode.PermissionDenied, MpappDisconnectReason.PermissionRevoked],
+    [MpappErrorCode.PairingTimeout, MpappDisconnectReason.Timeout],
+    [MpappErrorCode.TransportFailure, MpappDisconnectReason.TransportLost],
+    [MpappErrorCode.BluetoothUnavailable, MpappDisconnectReason.TransportLost],
+    [MpappErrorCode.UnsupportedPlatform, MpappDisconnectReason.TransportLost],
+  ])("maps %s canonical error to %s", (errorCode, expectedReason) => {
+    const reason = resolveDisconnectReasonFromFailure(errorCode);
+    expect(reason).toBe(expectedReason);
+  });
+
+  it("maps known transport-related native errors to transport-lost", () => {
+    const reason = resolveDisconnectReasonFromFailure(
+      MpappErrorCode.PermissionDenied,
+      MpappAndroidHidNativeErrorCode.TransportFailure,
+    );
+
+    expect(reason).toBe(MpappDisconnectReason.TransportLost);
+  });
+
+  it("falls back to unknown for unmapped native and canonical codes", () => {
+    const reason = resolveDisconnectReasonFromFailure(
+      "future-error" as MpappErrorCode,
+      "native-future-error",
+    );
+
+    expect(reason).toBe(MpappDisconnectReason.Unknown);
+  });
+});

--- a/apps/mpapp/src/__tests__/session-status-guidance.test.ts
+++ b/apps/mpapp/src/__tests__/session-status-guidance.test.ts
@@ -1,0 +1,62 @@
+import {
+  MpappConnectionEvent,
+  MpappDisconnectReason,
+  MpappMode,
+} from "../contracts/enums";
+import {
+  readableDisconnectReason,
+  reconnectGuidanceForState,
+} from "../components/session-status";
+
+describe("session status reconnect guidance", () => {
+  it("does not return guidance when disconnect reason is missing", () => {
+    expect(
+      reconnectGuidanceForState({
+        mode: MpappMode.Idle,
+        lastConnectionEvent: MpappConnectionEvent.Disconnect,
+        lastDisconnectReason: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("does not return guidance when last connection event is unrelated", () => {
+    expect(
+      reconnectGuidanceForState({
+        mode: MpappMode.Error,
+        lastConnectionEvent: MpappConnectionEvent.ConnectFailure,
+        lastDisconnectReason: MpappDisconnectReason.TransportLost,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns idle guidance for user-action disconnect", () => {
+    expect(
+      reconnectGuidanceForState({
+        mode: MpappMode.Idle,
+        lastConnectionEvent: MpappConnectionEvent.Disconnect,
+        lastDisconnectReason: MpappDisconnectReason.UserAction,
+      }),
+    ).toBe(
+      "Disconnect was user initiated. Tap Pair and Connect when you are ready to reconnect.",
+    );
+  });
+
+  it("returns error guidance for transport-lost disconnect failure", () => {
+    expect(
+      reconnectGuidanceForState({
+        mode: MpappMode.Error,
+        lastConnectionEvent: MpappConnectionEvent.DisconnectFailure,
+        lastDisconnectReason: MpappDisconnectReason.TransportLost,
+      }),
+    ).toBe(
+      "Connection dropped while disconnecting. Check Bluetooth and host availability, then tap Pair and Connect.",
+    );
+  });
+
+  it("returns expected reason labels", () => {
+    expect(readableDisconnectReason(MpappDisconnectReason.PermissionRevoked)).toBe(
+      "Permission Revoked",
+    );
+    expect(readableDisconnectReason(MpappDisconnectReason.Unknown)).toBe("Unknown");
+  });
+});

--- a/apps/mpapp/src/components/session-status.tsx
+++ b/apps/mpapp/src/components/session-status.tsx
@@ -1,12 +1,16 @@
 import { StyleSheet, Text, View } from "react-native";
-import { MpappMode } from "../contracts/enums";
+import {
+  MpappConnectionEvent,
+  MpappDisconnectReason,
+  MpappMode,
+} from "../contracts/enums";
 import type { MpappSessionState } from "../state/session-machine";
 
 type SessionStatusProps = {
   state: MpappSessionState;
 };
 
-function readableMode(mode: MpappMode): string {
+export function readableMode(mode: MpappMode): string {
   switch (mode) {
     case MpappMode.PermissionCheck:
       return "Permission Check";
@@ -24,7 +28,76 @@ function readableMode(mode: MpappMode): string {
   }
 }
 
+export function readableDisconnectReason(reason: MpappDisconnectReason): string {
+  switch (reason) {
+    case MpappDisconnectReason.UserAction:
+      return "User Action";
+    case MpappDisconnectReason.TransportLost:
+      return "Transport Lost";
+    case MpappDisconnectReason.Timeout:
+      return "Timeout";
+    case MpappDisconnectReason.PermissionRevoked:
+      return "Permission Revoked";
+    case MpappDisconnectReason.Unknown:
+    default:
+      return "Unknown";
+  }
+}
+
+function guidanceByReason(
+  reason: MpappDisconnectReason,
+  mode: MpappMode,
+): string {
+  const encounteredError = mode === MpappMode.Error;
+
+  switch (reason) {
+    case MpappDisconnectReason.UserAction:
+      return encounteredError
+        ? "Disconnect was user initiated but ended with an error. Tap Pair and Connect to start a fresh session."
+        : "Disconnect was user initiated. Tap Pair and Connect when you are ready to reconnect.";
+    case MpappDisconnectReason.TransportLost:
+      return encounteredError
+        ? "Connection dropped while disconnecting. Check Bluetooth and host availability, then tap Pair and Connect."
+        : "Connection was lost. Move closer to the host, verify Bluetooth is enabled, then tap Pair and Connect.";
+    case MpappDisconnectReason.Timeout:
+      return encounteredError
+        ? "Disconnect timed out and returned an error. Wait a moment, then tap Pair and Connect."
+        : "Disconnect timed out. Wait a moment, then tap Pair and Connect to recover.";
+    case MpappDisconnectReason.PermissionRevoked:
+      return encounteredError
+        ? "Bluetooth permission is missing. Re-grant permissions and tap Pair and Connect."
+        : "Bluetooth permission changed. Re-grant permissions, then tap Pair and Connect.";
+    case MpappDisconnectReason.Unknown:
+    default:
+      return encounteredError
+        ? "Disconnect failed for an unknown reason. Tap Pair and Connect to retry."
+        : "Disconnect reason was not reported. Tap Pair and Connect to attempt recovery.";
+  }
+}
+
+export function reconnectGuidanceForState(
+  state: Pick<
+    MpappSessionState,
+    "mode" | "lastConnectionEvent" | "lastDisconnectReason"
+  >,
+): string | null {
+  if (!state.lastDisconnectReason) {
+    return null;
+  }
+
+  if (
+    state.lastConnectionEvent !== MpappConnectionEvent.Disconnect &&
+    state.lastConnectionEvent !== MpappConnectionEvent.DisconnectFailure
+  ) {
+    return null;
+  }
+
+  return guidanceByReason(state.lastDisconnectReason, state.mode);
+}
+
 export function SessionStatus({ state }: SessionStatusProps) {
+  const reconnectGuidance = reconnectGuidanceForState(state);
+
   return (
     <View style={styles.wrapper}>
       <Text style={styles.label}>Session</Text>
@@ -40,6 +113,16 @@ export function SessionStatus({ state }: SessionStatusProps) {
 
       {state.lastConnectionEvent ? (
         <Text style={styles.event}>Last Event: {state.lastConnectionEvent}</Text>
+      ) : null}
+
+      {state.lastDisconnectReason && reconnectGuidance ? (
+        <Text style={styles.reason}>
+          Disconnect Reason: {readableDisconnectReason(state.lastDisconnectReason)}
+        </Text>
+      ) : null}
+
+      {reconnectGuidance ? (
+        <Text style={styles.guidance}>Reconnect Guidance: {reconnectGuidance}</Text>
       ) : null}
     </View>
   );
@@ -76,5 +159,15 @@ const styles = StyleSheet.create({
   event: {
     color: "#334155",
     fontSize: 12,
+  },
+  reason: {
+    color: "#334155",
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  guidance: {
+    color: "#0f766e",
+    fontSize: 12,
+    fontWeight: "600",
   },
 });

--- a/apps/mpapp/src/contracts/enums.ts
+++ b/apps/mpapp/src/contracts/enums.ts
@@ -28,7 +28,16 @@ export enum MpappConnectionEvent {
   ConnectSuccess = "connect-success",
   ConnectFailure = "connect-failure",
   Disconnect = "disconnect",
+  DisconnectFailure = "disconnect-failure",
   PermissionDenied = "permission-denied",
+}
+
+export enum MpappDisconnectReason {
+  UserAction = "user-action",
+  TransportLost = "transport-lost",
+  Timeout = "timeout",
+  PermissionRevoked = "permission-revoked",
+  Unknown = "unknown",
 }
 
 export enum MpappErrorCode {

--- a/apps/mpapp/src/state/disconnect-reason.ts
+++ b/apps/mpapp/src/state/disconnect-reason.ts
@@ -1,0 +1,50 @@
+import { MpappDisconnectReason, MpappErrorCode } from "../contracts/enums";
+import { MpappAndroidHidNativeErrorCode } from "../../modules/mpapp-android-hid";
+
+function resolveDisconnectReasonFromNativeError(
+  nativeErrorCode?: string | null,
+): MpappDisconnectReason | null {
+  switch (nativeErrorCode) {
+    case MpappAndroidHidNativeErrorCode.PermissionDenied:
+      return MpappDisconnectReason.PermissionRevoked;
+    case MpappAndroidHidNativeErrorCode.PairingTimeout:
+      return MpappDisconnectReason.Timeout;
+    case MpappAndroidHidNativeErrorCode.TransportFailure:
+    case MpappAndroidHidNativeErrorCode.BluetoothUnavailable:
+    case MpappAndroidHidNativeErrorCode.UnsupportedPlatform:
+    case MpappAndroidHidNativeErrorCode.HostAddressRequired:
+    case MpappAndroidHidNativeErrorCode.InvalidHostAddress:
+      return MpappDisconnectReason.TransportLost;
+    default:
+      return null;
+  }
+}
+
+function resolveDisconnectReasonFromErrorCode(
+  errorCode: MpappErrorCode,
+): MpappDisconnectReason {
+  switch (errorCode) {
+    case MpappErrorCode.PermissionDenied:
+      return MpappDisconnectReason.PermissionRevoked;
+    case MpappErrorCode.PairingTimeout:
+      return MpappDisconnectReason.Timeout;
+    case MpappErrorCode.TransportFailure:
+    case MpappErrorCode.BluetoothUnavailable:
+    case MpappErrorCode.UnsupportedPlatform:
+      return MpappDisconnectReason.TransportLost;
+    default:
+      return MpappDisconnectReason.Unknown;
+  }
+}
+
+export function resolveDisconnectReasonFromFailure(
+  errorCode: MpappErrorCode,
+  nativeErrorCode?: string | null,
+): MpappDisconnectReason {
+  const nativeReason = resolveDisconnectReasonFromNativeError(nativeErrorCode);
+  if (nativeReason) {
+    return nativeReason;
+  }
+
+  return resolveDisconnectReasonFromErrorCode(errorCode);
+}

--- a/docs/project-mpapp.md
+++ b/docs/project-mpapp.md
@@ -104,7 +104,20 @@ enum MpappConnectionEvent {
   ConnectSuccess = "connect-success",
   ConnectFailure = "connect-failure",
   Disconnect = "disconnect",
+  DisconnectFailure = "disconnect-failure",
   PermissionDenied = "permission-denied",
+}
+```
+
+Canonical disconnect reasons:
+
+```ts
+enum MpappDisconnectReason {
+  UserAction = "user-action",
+  TransportLost = "transport-lost",
+  Timeout = "timeout",
+  PermissionRevoked = "permission-revoked",
+  Unknown = "unknown",
 }
 ```
 
@@ -215,6 +228,7 @@ MVP interface constraints:
 - `MpappInputAction` values are stable contracts and must not be renamed without a documented migration.
 - Click payloads must preserve valid `actionId` and `button` pairs by the `PointerClickSample` discriminated union.
 - `MpappHidTransportMode` values are stable runtime contract values and must not be renamed without migration.
+- `MpappDisconnectReason` values are stable lifecycle contract values and must not be renamed without migration.
 - Native transport failures may include `nativeErrorCode` for diagnostics, but `MpappErrorCode` remains the canonical app-facing error contract.
 
 Android and iOS scope contract:
@@ -278,6 +292,10 @@ Additional transport diagnostics fields when available:
 - `nativeErrorCode`
 - `availabilityState`
 
+Disconnect diagnostics payload contract:
+- Disconnect transition logs must include `disconnectReason` as a machine-readable `MpappDisconnectReason` value for both success and failure paths.
+- Disconnect failure logs must continue to include `nativeErrorCode` when available.
+
 Connection state logging contract:
 - `connectionState` must be captured from the latest session state snapshot at log emission time, including async lifecycle and transport callbacks.
 
@@ -312,7 +330,7 @@ MVP acceptance criteria scenarios:
 3. Tapping the right-click button emits exactly one `right-click` action.
 4. Attempting input before a connected state shows a clear disabled or error state.
 5. Permission denial shows a retry path and logs required structured fields.
-6. Disconnect events follow the documented state transition order and provide reconnect guidance.
+6. Disconnect events follow the documented state transition order, persist machine-readable disconnect reasons, and provide reason-specific reconnect guidance in the session status UI.
 7. High input frequency follows documented sampling or throttle limits and remains observable in logs.
 8. Runtime transport switch can intentionally select `native-android-hid` or `stub` and logs selected mode.
 9. Native transport failures preserve canonical `MpappErrorCode` while recording `nativeErrorCode` in diagnostics.


### PR DESCRIPTION
## Summary
- add `MpappDisconnectReason` and `disconnect-failure` lifecycle contracts
- propagate disconnect reasons through session state and disconnect transitions
- enrich disconnect diagnostics payloads with machine-readable reason fields
- add reason-specific reconnect guidance copy in session status UI
- add reducer/reason-mapping/guidance tests and update mpapp project docs

## Testing
- pnpm test (apps/mpapp)

Closes #44