### PR TITLE
fix(derun): persist startup-failure sessions for MCP discovery

### DIFF
--- a/cmds/derun/internal/cli/run.go
+++ b/cmds/derun/internal/cli/run.go
@@ -122,6 +122,10 @@ func ExecuteRun(args []string) int {
 		TTYAttached:      ttyAttached,
 		PID:              0,
 	}
+	if err := store.WriteMeta(meta); err != nil {
+		fmt.Fprintf(os.Stderr, "write metadata: %v\n", err)
+		return 1
+	}
 
 	logger.Event("state_transition", map[string]any{
 		"session_id":       sessionID,
@@ -132,6 +136,9 @@ func ExecuteRun(args []string) int {
 
 	ctx := context.Background()
 	onStart := func(pid int) error {
+		if pid <= 0 {
+			return nil
+		}
 		meta.PID = pid
 		if err := store.WriteMeta(meta); err != nil {
 			return fmt.Errorf("write meta file: %w", err)

--- a/docs/project-derun.md
+++ b/docs/project-derun.md
@@ -163,6 +163,8 @@ Retention contract:
 
 Write consistency contract:
 - `meta.json` and `final.json` are written atomically via temp-file + rename.
+- `derun run` writes initial `meta.json` before transport startup so startup-failure sessions remain discoverable via MCP list/get flows.
+- On successful process launch, `meta.json` is rewritten to persist the child PID while keeping session identity metadata stable.
 - `output.bin` and `index.jsonl` append operations are guarded by per-session advisory file lock (`append.lock`).
 
 ## Security


### PR DESCRIPTION
## Summary
- persist initial `meta.json` before transport startup in `derun run` so startup failures still leave discoverable session metadata
- keep PID backfill behavior by rewriting `meta.json` on successful process start
- add a regression test proving failed startup sessions are visible via list/get flows and retain `meta.json`
- update `docs/project-derun.md` write-consistency contract with the startup-failure metadata guarantee

## Testing
- go test ./cmds/derun/...

Closes #67