### PR TITLE
fix(nodeup): preserve signal-derived exits for delegated processes

### DIFF
--- a/crates/nodeup/src/process.rs
+++ b/crates/nodeup/src/process.rs
@@ -82,10 +82,14 @@ fn status_details(status: ExitStatus) -> ProcessTermination {
     {
         use std::os::unix::process::ExitStatusExt;
 
-        ProcessTermination {
-            exit_code: status.code().unwrap_or(1),
-            signal: status.signal(),
-        }
+        let signal = status.signal();
+        let exit_code = match (status.code(), signal) {
+            (Some(code), _) => code,
+            (None, Some(signal)) => 128 + signal,
+            (None, None) => 1,
+        };
+
+        ProcessTermination { exit_code, signal }
     }
 
     #[cfg(not(unix))]

--- a/docs/project-nodeup.md
+++ b/docs/project-nodeup.md
@@ -187,7 +187,9 @@ Subcommand contracts:
 : Output channels:
 : In `--output human`, delegated stdout/stderr inherit terminal streams.
 : In `--output json`, stdout is reserved for the JSON result object and delegated stdout/stderr are streamed to stderr.
-: Exit code: returns delegated process exit code on success path.
+: Exit code:
+: Returns delegated process exit code on success path.
+: On Unix, when delegated process terminates by signal, returns `128 + signal` (for example `143` for `SIGTERM`) and reports the same mapped value in JSON `exit_code`.
 - `nodeup self update`
 : Behavior: replaces the nodeup binary with the staged binary at `NODEUP_SELF_UPDATE_SOURCE` (target defaults to current executable and can be overridden by `NODEUP_SELF_BIN_PATH`).
 : Status field (`--output json`): `updated` or `already-up-to-date`.
@@ -214,6 +216,7 @@ Resolution precedence contract:
 
 Dispatch contract:
 - If invoked as `node`, `npm`, or `npx`, nodeup resolves target Node.js version and forwards execution.
+- Managed-alias dispatch preserves delegated process exit semantics, including Unix signal mapping (`128 + signal`).
 - If invoked as `nodeup`, nodeup performs management commands.
 
 Symlink contract:


### PR DESCRIPTION
## Summary
- preserve signal termination semantics in shared delegated process handling on Unix (`128 + signal`)
- cover both `nodeup run` and managed alias dispatch (`node`/`npm`/`npx`) via the shared helper
- add Unix integration regressions for signal-terminated delegated commands
- document the signal-derived exit behavior in `docs/project-nodeup.md`

## Testing
- cargo test -p nodeup
- cargo test
- manual reproduction from issue #83 now returns `143` for SIGTERM

Closes #83