### PR TITLE
fix(cargo-mono): normalize cargo external-subcommand argv

### DIFF
--- a/crates/cargo-mono/src/main.rs
+++ b/crates/cargo-mono/src/main.rs
@@ -1,10 +1,9 @@
 use cargo_mono::{
-    cli::{Cli, Command as CargoMonoCommand},
+    cli::{self, Cli, Command as CargoMonoCommand},
     commands,
     errors::CargoMonoError,
     git, logging, CargoMonoApp,
 };
-use clap::Parser;
 use tracing::info;
 
 fn main() {
@@ -20,7 +19,7 @@ fn main() {
 }
 
 fn run() -> Result<i32, CargoMonoError> {
-    let cli = Cli::parse();
+    let cli = cli::parse_from_env();
     commands::log_invocation(&cli.command, cli.output);
     run_preflight_checks(&cli)?;
     let app = CargoMonoApp::new()?;

--- a/crates/cargo-mono/tests/cli.rs
+++ b/crates/cargo-mono/tests/cli.rs
@@ -43,6 +43,33 @@ fn version_succeeds_outside_workspace() {
 }
 
 #[test]
+fn cargo_external_mode_help_succeeds_outside_workspace() {
+    let temp_dir = tempfile::tempdir().expect("failed to create tempdir");
+
+    Command::new(assert_cmd::cargo::cargo_bin!("cargo-mono"))
+        .current_dir(temp_dir.path())
+        .args(["mono", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("list"))
+        .stdout(predicate::str::contains("changed"))
+        .stdout(predicate::str::contains("bump"))
+        .stdout(predicate::str::contains("publish"));
+}
+
+#[test]
+fn cargo_external_mode_version_succeeds_outside_workspace() {
+    let temp_dir = tempfile::tempdir().expect("failed to create tempdir");
+
+    Command::new(assert_cmd::cargo::cargo_bin!("cargo-mono"))
+        .current_dir(temp_dir.path())
+        .args(["mono", "--version"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
+}
+
+#[test]
 fn list_still_requires_workspace() {
     let temp_dir = tempfile::tempdir().expect("failed to create tempdir");
 
@@ -58,6 +85,16 @@ fn list_still_requires_workspace() {
 fn list_outputs_workspace_packages() {
     cargo_mono_command()
         .args(["--output", "json", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"packages\""))
+        .stdout(predicate::str::contains("\"nodeup\""));
+}
+
+#[test]
+fn cargo_external_mode_list_outputs_workspace_packages() {
+    Command::new(assert_cmd::cargo::cargo_bin!("cargo-mono"))
+        .args(["mono", "--output", "json", "list"])
         .assert()
         .success()
         .stdout(predicate::str::contains("\"packages\""))

--- a/docs/project-cargo-mono.md
+++ b/docs/project-cargo-mono.md
@@ -75,6 +75,7 @@ enum CargoMonoBumpLevel {
 CLI entrypoint:
 - `cargo mono [--output <human|json>] <subcommand> ...`
 - `cargo mono --help` and `cargo mono --version` must succeed without workspace discovery.
+- When invoked through Cargo external-subcommand mode, a forwarded leading `mono` token is normalized before parsing so `cargo mono <args>` matches direct `cargo-mono <args>` behavior.
 - `bump` and `publish` run a clean-working-tree preflight immediately after CLI parsing and before workspace loading.
 - Workspace loading occurs after CLI parsing for executable subcommands; for `bump`/`publish`, it occurs only after clean-tree preflight passes.
 


### PR DESCRIPTION
## Summary
- normalize Cargo external-subcommand argv by stripping a forwarded leading `mono` token before clap parsing
- route startup parsing through the new normalization helper and emit a debug trace when normalization occurs
- add unit/integration regressions for `cargo mono list`, `cargo mono --help`, and `cargo mono --version`
- update cargo-mono project docs with the external-subcommand normalization contract

## Testing
- cargo test -p cargo-mono
- cargo test
- PATH=/Users/kdy1/.codex/worktrees/90d3/oss/target/debug:$PATH cargo mono list
- PATH=/Users/kdy1/.codex/worktrees/90d3/oss/target/debug:$PATH cargo mono --help
- PATH=/Users/kdy1/.codex/worktrees/90d3/oss/target/debug:$PATH cargo mono --version

Closes #105