### PR TITLE
fix(derun): reject dot-alias session ids

### DIFF
--- a/cmds/derun/internal/state/store.go
+++ b/cmds/derun/internal/state/store.go
@@ -27,7 +27,10 @@ const (
 	lockFileName   = "append.lock"
 )
 
-var ErrSessionNotFound = errors.New("session not found")
+var (
+	ErrSessionNotFound  = errors.New("session not found")
+	ErrInvalidSessionID = errors.New("invalid session id")
+)
 
 type Store struct {
 	root string
@@ -476,13 +479,16 @@ func (s *Store) readIndexEntries(sessionID string) ([]session.IndexEntry, error)
 
 func validateSessionID(sessionID string) error {
 	if sessionID == "" {
-		return errors.New("session id is empty")
+		return fmt.Errorf("%w: session id is empty", ErrInvalidSessionID)
+	}
+	if sessionID == "." {
+		return fmt.Errorf("%w: session id contains invalid path segment alias", ErrInvalidSessionID)
 	}
 	if strings.Contains(sessionID, "..") {
-		return fmt.Errorf("session id contains invalid path segment")
+		return fmt.Errorf("%w: session id contains invalid path segment", ErrInvalidSessionID)
 	}
 	if strings.ContainsAny(sessionID, `/\\`) {
-		return fmt.Errorf("session id contains path separator")
+		return fmt.Errorf("%w: session id contains path separator", ErrInvalidSessionID)
 	}
 	return nil
 }

--- a/cmds/derun/internal/state/store_test.go
+++ b/cmds/derun/internal/state/store_test.go
@@ -213,6 +213,7 @@ func TestStoreRejectsTraversalSessionIDAcrossEntrypoints(t *testing.T) {
 	}
 
 	invalidSessionIDs := []string{
+		".",
 		"..",
 		"../escape",
 		"with/slash",
@@ -274,6 +275,9 @@ func TestStoreRejectsTraversalSessionIDAcrossEntrypoints(t *testing.T) {
 				err := operation.run(sessionID)
 				if err == nil {
 					t.Fatalf("expected error for invalid session id: %q", sessionID)
+				}
+				if !errors.Is(err, ErrInvalidSessionID) {
+					t.Fatalf("expected ErrInvalidSessionID for session id %q, got: %v", sessionID, err)
 				}
 				if !strings.Contains(err.Error(), "session id") {
 					t.Fatalf("unexpected error for session id %q: %v", sessionID, err)

--- a/docs/project-derun.md
+++ b/docs/project-derun.md
@@ -114,6 +114,7 @@ Command contracts:
 - `derun run [--session-id <id>] [--retention <duration>] -- <command> [args...]`
 : Executes user command with terminal-fidelity proxying and side-channel transcript capture.
 - `derun run` must reject explicit `--session-id` values when persisted metadata already exists (`meta.json` or `final.json`), returning exit code `2` without mutating existing artifacts.
+- `derun run` must reject explicit invalid `--session-id` values (including path-segment alias `"."`), returning exit code `2` without mutating session artifacts.
 - `derun mcp`
 : Starts stdio MCP server for AI-driven session/output retrieval.
 
@@ -176,6 +177,7 @@ Write consistency contract:
 - File permissions: `0600`
 - Persist output stream only by default; stdin is proxied but not persisted.
 - Resolve canonical real paths before session artifact IO and reject path traversal or symlink escape outside `sessions/<session-id>`, including dangling symlink targets.
+- Reject path-segment alias session IDs (for example `"."`) so all artifacts remain under `sessions/<session-id>/...` and never directly under `sessions/`.
 - Apply traversal/symlink checks consistently for `meta.json`, `final.json`, `output.bin`, `index.jsonl`, and `append.lock` across read and write flows.
 - Keep MCP tool surface read-only in v1.
 - Do not emit secret values into operational logs.


### PR DESCRIPTION
## Summary
- add `state.ErrInvalidSessionID` and reject explicit `"."` session IDs in storage validation
- treat invalid explicit `--session-id` values as CLI usage errors (exit code `2`) with structured `session_id_rejected` reason values
- add regression tests for state + CLI and update `docs/project-derun.md` contracts for invalid session ID rejection

## Testing
- go test ./cmds/derun/internal/state -run TestStoreRejectsTraversalSessionIDAcrossEntrypoints
- go test ./cmds/derun/internal/cli -run TestExecuteRunRejectsInvalidSessionID
- go test ./cmds/derun/...

Closes #74