### PR TITLE
fix(devkit): align home status copy with live mini-app maturity

### DIFF
--- a/apps/devkit/src/app/page.test.tsx
+++ b/apps/devkit/src/app/page.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+
+import HomePage from "./page";
+
+describe("HomePage", () => {
+  it("renders live mini-app platform status copy and excludes stale bootstrap copy", () => {
+    render(<HomePage />);
+
+    expect(
+      screen.getByRole("heading", { name: "Live mini-app platform is active" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Devkit now serves live mini apps at \/apps\/<id> with enum-based registration\. Commit Tracker, Remote File Picker, and Thenv are active routes\./,
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("heading", { name: "Shell-only bootstrap is active" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Devkit routes are now reserved with enum-based registration and static pages for each canonical mini app.",
+      ),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/devkit/src/app/page.tsx
+++ b/apps/devkit/src/app/page.tsx
@@ -14,10 +14,11 @@ export default function HomePage() {
       <section className="dk-stack" aria-label="devkit home">
         <div className="dk-card">
           <p className="dk-eyebrow">Platform Status</p>
-          <h2 className="dk-section-title">Shell-only bootstrap is active</h2>
+          <h2 className="dk-section-title">Live mini-app platform is active</h2>
           <p className="dk-paragraph">
-            Devkit routes are now reserved with enum-based registration and static
-            pages for each canonical mini app.
+            Devkit now serves live mini apps at /apps/&lt;id&gt; with enum-based
+            registration. Commit Tracker, Remote File Picker, and Thenv are active
+            routes.
           </p>
         </div>
 

--- a/docs/project-devkit.md
+++ b/docs/project-devkit.md
@@ -41,6 +41,7 @@ The shell visual baseline follows Toss Design System-inspired foundations (color
 - Enum-based registration lives in `src/lib/mini-app-registry.ts`.
 - Shell navigation menu order is fixed as `Home (/)` first, then registered mini apps from `MINI_APP_REGISTRATIONS`.
 - Current route maturity mix: `commit-tracker`, `remote-file-picker`, and `thenv` are live.
+- Home route platform status messaging reflects live mini-app maturity and must not describe shell-only bootstrap state.
 - Backend-coupled mini apps consume backend APIs while preserving shell-owned auth/session/navigation behavior.
 
 ## Interfaces


### PR DESCRIPTION
## Summary
- update Devkit Home platform-status copy to reflect live mini-app maturity
- add a Home route regression test to prevent stale shell-bootstrap wording from returning
- sync `docs/project-devkit.md` with the Home status messaging contract

## Testing
- pnpm test (apps/devkit)

Closes #97