### PR TITLE
fix(cargo-mono): add configurable changed path filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,7 @@ dependencies = [
  "assert_cmd",
  "cargo_metadata",
  "clap",
+ "globset",
  "predicates",
  "semver",
  "serde",
@@ -578,6 +579,19 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]

--- a/crates/cargo-mono/Cargo.toml
+++ b/crates/cargo-mono/Cargo.toml
@@ -8,6 +8,7 @@ description = "Cargo subcommand for Rust monorepo management"
 [dependencies]
 cargo_metadata = "0.19.2"
 clap = { version = "4.5.32", features = ["derive"] }
+globset = "0.4.15"
 semver = { version = "1.0.26", features = ["serde"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"

--- a/crates/cargo-mono/src/commands/changed.rs
+++ b/crates/cargo-mono/src/commands/changed.rs
@@ -21,7 +21,12 @@ pub fn execute(args: &ChangedArgs, output: OutputFormat, app: &CargoMonoApp) -> 
     let changed_files = git::changed_files(&args.base, args.include_uncommitted)?;
     let changed_packages = app
         .workspace
-        .changed_packages(&changed_files.paths, !args.direct_only)
+        .changed_packages_with_filters(
+            &changed_files.paths,
+            !args.direct_only,
+            &args.include_path,
+            &args.exclude_path,
+        )?
         .into_iter()
         .collect::<Vec<_>>();
 

--- a/crates/cargo-mono/src/commands/mod.rs
+++ b/crates/cargo-mono/src/commands/mod.rs
@@ -93,7 +93,9 @@ fn changed_arg_shape(args: &ChangedArgs, output: OutputFormat) -> Value {
         "output": output.as_str(),
         "base_ref": args.base,
         "include_uncommitted": args.include_uncommitted,
-        "direct_only": args.direct_only
+        "direct_only": args.direct_only,
+        "include_path": args.include_path,
+        "exclude_path": args.exclude_path
     })
 }
 
@@ -105,6 +107,8 @@ fn bump_arg_shape(args: &BumpArgs, output: OutputFormat) -> Value {
         "base_ref": args.changed.base,
         "include_uncommitted": args.changed.include_uncommitted,
         "direct_only": args.changed.direct_only,
+        "include_path": args.changed.include_path,
+        "exclude_path": args.changed.exclude_path,
         "level": args.level.as_str(),
         "preid_provided": args.preid.is_some(),
         "bump_dependents": args.bump_dependents,
@@ -120,6 +124,8 @@ fn publish_arg_shape(args: &PublishArgs, output: OutputFormat) -> Value {
         "base_ref": args.changed.base,
         "include_uncommitted": args.changed.include_uncommitted,
         "direct_only": args.changed.direct_only,
+        "include_path": args.changed.include_path,
+        "exclude_path": args.changed.exclude_path,
         "dry_run": args.dry_run,
         "allow_dirty": args.allow_dirty,
         "registry_provided": args.registry.is_some()

--- a/crates/cargo-mono/src/commands/targeting.rs
+++ b/crates/cargo-mono/src/commands/targeting.rs
@@ -23,7 +23,12 @@ pub fn resolve_targets(
 ) -> Result<ResolvedTargets> {
     if target.changed {
         let changed_files = git::changed_files(&changed.base, changed.include_uncommitted)?;
-        let names = workspace.changed_packages(&changed_files.paths, !changed.direct_only);
+        let names = workspace.changed_packages_with_filters(
+            &changed_files.paths,
+            !changed.direct_only,
+            &changed.include_path,
+            &changed.exclude_path,
+        )?;
 
         return Ok(ResolvedTargets {
             selector: TargetSelector::Changed,

--- a/docs/project-cargo-mono.md
+++ b/docs/project-cargo-mono.md
@@ -84,13 +84,19 @@ Target selection contract (`bump`, `publish`):
 - `--changed` uses `changed` computation contract.
 - `--package <name>` supports repeated explicit package targeting.
 - Selectors are mutually exclusive (`--all`, `--changed`, `--package`).
+- `--changed` honors `--include-path` and `--exclude-path` filters from `ChangedArgs`.
 
 `changed` contract:
 - Base ref default: `origin/main`.
 - Computes merge base with `git merge-base <base> HEAD`.
 - Uses `git diff --name-only <merge-base> HEAD` as baseline.
 - `--include-uncommitted` additionally includes staged, unstaged, and untracked paths.
+- `--exclude-path <glob>` is repeatable and defaults to excluding `**/AGENTS.md`.
+- `--include-path <glob>` is repeatable and acts as an override for excluded paths.
+- Include/exclude glob matching is evaluated against workspace-relative paths using `/`.
+- Invalid include/exclude glob values fail with an invalid-input error.
 - Global impact files (`Cargo.toml`, `Cargo.lock`, `rust-toolchain`) mark all workspace packages as changed.
+- Global impact files cannot be filtered out by include/exclude path rules.
 - Default mode includes direct changes plus reverse dependency propagation.
 - `--direct-only` disables reverse dependency propagation.
 


### PR DESCRIPTION
## Summary
- add repeatable `--include-path` and `--exclude-path` flags to changed path resolution
- default `--exclude-path` to `**/AGENTS.md` so docs-only AGENTS edits do not mark crates as changed
- apply the same filtering behavior to `changed` and `--changed` targeting in `bump`/`publish`
- keep global impact files (`Cargo.toml`, `Cargo.lock`, `rust-toolchain`) unfilterable
- document the new contract in `docs/project-cargo-mono.md`

## Testing
- cargo test -p cargo-mono
- cargo test

Closes #112