### PR TITLE
fix(devkit): preserve commit-tracker rpc status in series/report proxies

### DIFF
--- a/apps/devkit/src/app/api/commit-tracker/report/route.test.ts
+++ b/apps/devkit/src/app/api/commit-tracker/report/route.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { POST } from "./route";
+import {
+  CommitTrackerApiError,
+  callCommitTrackerRpc,
+} from "@/app/api/commit-tracker/_lib/connect";
+
+vi.mock("@/app/api/commit-tracker/_lib/connect", () => {
+  class CommitTrackerApiError extends Error {
+    readonly status: number;
+    readonly procedure: string;
+    readonly body: string;
+
+    constructor(params: {
+      status: number;
+      procedure: string;
+      message: string;
+      body: string;
+    }) {
+      super(params.message);
+      this.name = "CommitTrackerApiError";
+      this.status = params.status;
+      this.procedure = params.procedure;
+      this.body = params.body;
+    }
+  }
+
+  return {
+    CommitTrackerApiError,
+    callCommitTrackerRpc: vi.fn(),
+  };
+});
+
+function buildRequest(): Request {
+  return new Request("http://localhost/api/commit-tracker/report", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      provider: "GIT_PROVIDER_KIND_GITHUB",
+      repository: "acme/repo",
+      pullRequest: 42,
+      baseCommitSha: "base",
+      headCommitSha: "head",
+      environment: "ci",
+      metricKeys: ["binary-size"],
+    }),
+  });
+}
+
+describe("commit-tracker report route", () => {
+  beforeEach(() => {
+    vi.mocked(callCommitTrackerRpc).mockReset();
+  });
+
+  it.each([400, 401, 412])(
+    "propagates upstream status %s for RPC errors",
+    async (status) => {
+      vi.mocked(callCommitTrackerRpc).mockRejectedValue(
+        new CommitTrackerApiError({
+          status,
+          procedure:
+            "/committracker.v1.ProviderReportService/PublishPullRequestReport",
+          message: `rpc error ${status}`,
+          body: "{\"code\":\"rpc_error\"}",
+        }),
+      );
+
+      const response = await POST(buildRequest());
+      expect(response.status).toBe(status);
+      await expect(response.json()).resolves.toEqual({
+        error: `rpc error ${status}`,
+      });
+    },
+  );
+
+  it("returns 502 for unexpected errors", async () => {
+    vi.mocked(callCommitTrackerRpc).mockRejectedValue(new Error("network down"));
+
+    const response = await POST(buildRequest());
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({ error: "network down" });
+  });
+});

--- a/apps/devkit/src/app/api/commit-tracker/report/route.ts
+++ b/apps/devkit/src/app/api/commit-tracker/report/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
 
-import { callCommitTrackerRpc } from "@/app/api/commit-tracker/_lib/connect";
+import {
+  CommitTrackerApiError,
+  callCommitTrackerRpc,
+} from "@/app/api/commit-tracker/_lib/connect";
 
 interface PublishPullRequestReportBody {
   provider?: string;
@@ -40,6 +43,13 @@ export async function POST(request: Request) {
 
     return NextResponse.json(response);
   } catch (error) {
+    if (error instanceof CommitTrackerApiError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: error.status },
+      );
+    }
+
     const message = error instanceof Error ? error.message : "Unknown error";
     return NextResponse.json({ error: message }, { status: 502 });
   }

--- a/apps/devkit/src/app/api/commit-tracker/series/route.test.ts
+++ b/apps/devkit/src/app/api/commit-tracker/series/route.test.ts
@@ -1,0 +1,74 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GET } from "./route";
+import {
+  CommitTrackerApiError,
+  callCommitTrackerRpc,
+} from "@/app/api/commit-tracker/_lib/connect";
+
+vi.mock("@/app/api/commit-tracker/_lib/connect", () => {
+  class CommitTrackerApiError extends Error {
+    readonly status: number;
+    readonly procedure: string;
+    readonly body: string;
+
+    constructor(params: {
+      status: number;
+      procedure: string;
+      message: string;
+      body: string;
+    }) {
+      super(params.message);
+      this.name = "CommitTrackerApiError";
+      this.status = params.status;
+      this.procedure = params.procedure;
+      this.body = params.body;
+    }
+  }
+
+  return {
+    CommitTrackerApiError,
+    callCommitTrackerRpc: vi.fn(),
+  };
+});
+
+function buildRequest(): NextRequest {
+  return new NextRequest(
+    "http://localhost/api/commit-tracker/series?provider=GIT_PROVIDER_KIND_GITHUB&repository=acme/repo&branch=main&environment=ci&metricKey=binary-size&fromTime=2026-02-01T00:00:00Z&toTime=2026-02-28T23:59:59Z&limit=25",
+  );
+}
+
+describe("commit-tracker series route", () => {
+  beforeEach(() => {
+    vi.mocked(callCommitTrackerRpc).mockReset();
+  });
+
+  it.each([400, 401, 412])(
+    "propagates upstream status %s for RPC errors",
+    async (status) => {
+      vi.mocked(callCommitTrackerRpc).mockRejectedValue(
+        new CommitTrackerApiError({
+          status,
+          procedure: "/committracker.v1.MetricQueryService/ListMetricSeries",
+          message: `rpc error ${status}`,
+          body: "{\"code\":\"rpc_error\"}",
+        }),
+      );
+
+      const response = await GET(buildRequest());
+      expect(response.status).toBe(status);
+      await expect(response.json()).resolves.toEqual({
+        error: `rpc error ${status}`,
+      });
+    },
+  );
+
+  it("returns 502 for unexpected errors", async () => {
+    vi.mocked(callCommitTrackerRpc).mockRejectedValue(new Error("network down"));
+
+    const response = await GET(buildRequest());
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({ error: "network down" });
+  });
+});

--- a/apps/devkit/src/app/api/commit-tracker/series/route.ts
+++ b/apps/devkit/src/app/api/commit-tracker/series/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { callCommitTrackerRpc } from "@/app/api/commit-tracker/_lib/connect";
+import {
+  CommitTrackerApiError,
+  callCommitTrackerRpc,
+} from "@/app/api/commit-tracker/_lib/connect";
 
 export async function GET(request: NextRequest) {
   try {
@@ -32,6 +35,13 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json(response);
   } catch (error) {
+    if (error instanceof CommitTrackerApiError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: error.status },
+      );
+    }
+
     const message = error instanceof Error ? error.message : "Unknown error";
     return NextResponse.json({ error: message }, { status: 502 });
   }

--- a/docs/project-devkit-commit-tracker.md
+++ b/docs/project-devkit-commit-tracker.md
@@ -136,7 +136,7 @@ Devkit proxy API routes:
 - `POST /api/commit-tracker/report`
 
 Proxy error semantics:
-- `comparison` proxy preserves upstream HTTP status for Commit Tracker RPC failures (for example 400/401/412) instead of collapsing all failures into 502.
+- `series`, `comparison`, and `report` proxies preserve upstream HTTP status for Commit Tracker RPC failures (for example 400/401/412) instead of collapsing all failures into 502.
 
 ## Storage
 Primary backend storage:


### PR DESCRIPTION
## Summary
- propagate `CommitTrackerApiError` HTTP status in commit-tracker `series` and `report` API proxy routes
- keep non-RPC failures mapped to `502`
- add route tests for `400`/`401`/`412` propagation and `502` fallback
- update commit-tracker docs proxy error semantics to include `series`, `comparison`, and `report`

## Testing
- pnpm test (apps/devkit)

Closes #99