### PR TITLE
docs(agents): require gh cli for github.com access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - Write sufficient logs for debugging and operational troubleshooting.
 - Prefer structured logging libraries for business and system logs (Go: `log/slog`, Rust: `tracing`).
 - Prioritize Connect RPC-based communication for business flows over Tauri-specific bindings.
+- When accessing `github.com`, use the GitHub CLI (`gh`) instead of browser-based workflows when possible.
 - When writing shell commands or scripts, treat backticks and command substitution carefully, prefer `$(...)` over legacy backticks, and apply strict escaping for all dynamic values.
 - If an operation is blocked by sandbox restrictions, retry it without sandbox restrictions using the required approval flow.
 


### PR DESCRIPTION
## Summary
- add an AGENTS.md instruction to prefer GitHub CLI (`gh`) when accessing github.com

## Testing
- not run (documentation-only change)