### PR TITLE
fix(nodeup): fail show active-runtime for unavailable runtimes

### DIFF
--- a/docs/project-nodeup.md
+++ b/docs/project-nodeup.md
@@ -160,6 +160,7 @@ Subcommand contracts:
 - `nodeup show active-runtime`
 : Output: resolved runtime (`runtime`), selection source (`explicit|override|default`), and canonical selector.
 : Failure: returns deterministic not-found error when neither override nor default selector exists.
+: Failure: returns deterministic not-found error when the resolved runtime is unavailable or missing the delegated `node` executable (for example, when a linked runtime path has been deleted).
 - `nodeup show home`
 : Output: `data_root`, `cache_root`, and `config_root`.
 - `nodeup update [runtime]...`


### PR DESCRIPTION
## Summary
- make `nodeup show active-runtime` fail with deterministic not-found errors when the resolved runtime is unavailable
- add structured availability-failure logs (`command_path=nodeup.show.active-runtime`, `availability=false`, reason fields)
- add regressions for deleted linked runtimes and adjust precedence/log tests to install override runtimes under the new strict availability contract
- update `docs/project-nodeup.md` with the expanded `show active-runtime` failure contract

## Testing
- cargo test -p nodeup
- cargo test

Closes #118