### PR TITLE
docs(policies): clarify git commit order

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 - If you modified Rust code, run `cargo test` from the root directory before finishing your task.
 - If you modified frontend code, run `pnpm test` from the frontend directory before finishing your task.
 - Commit your work as frequent as possible using git. Do NOT use `--no-verify` flag.
-- After `git add`, run `git commit` without unnecessary delay so staged changes are preserved in history.
+- Run `git commit` only after `git add`; once files are staged, commit without unnecessary delay so staged changes are preserved in history.
 - Committing may require workspace binaries (for example, git hooks). If required binaries are missing, run `pnpm install` at the repository root and retry the commit.
 - After addressing pull request review comments and pushing updates, mark the corresponding review threads as resolved.
 - Do not guess; rather search for the web.

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -153,7 +153,7 @@ Change-scoped execution rules:
 - Every structural repository change must update relevant `docs/project-*.md` files in the same change set.
 - New project creation is blocked until its project document exists.
 - Domain-level `AGENTS.md` files are policy mirrors and must stay aligned with `docs/`.
-- After staging files with `git add`, create a commit with `git commit` without unnecessary delay.
+- Run `git commit` only after `git add`; once files are staged, create the commit without unnecessary delay.
 - Committing may require workspace binaries (for example, git hooks). If required binaries are missing, run `pnpm install` at the repository root and retry the commit.
 - After addressing pull request review comments and pushing updates, resolve the corresponding review threads.
 - If a project splits into multiple deployables, the project doc must include path ownership and integration boundaries.


### PR DESCRIPTION
## Summary
- clarify in `AGENTS.md` that `git commit` must be run only after `git add`
- mirror the same policy wording in `docs/monorepo.md` to keep docs aligned

## Testing
- not run (documentation-only change)