### PR TITLE
chore(thenv): generate protobuf before dev server startup

### DIFF
--- a/docs/project-thenv.md
+++ b/docs/project-thenv.md
@@ -233,6 +233,7 @@ Devkit environment variables (optional):
 ## Build and Test
 Current commands:
 - Proto generation prerequisite: `./scripts/generate-go-proto.sh`
+- Server local dev (auto proto generation): `cd servers/thenv && pnpm dev` (`predev` runs `./scripts/generate-go-proto.sh` before `air`)
 - CLI build/test: `go build ./cmds/thenv/...` and `go test ./cmds/thenv/...`
 - Server build/test: `go build ./servers/thenv/...` and `go test ./servers/thenv/...`
 - Web console tests: `cd apps/devkit && pnpm test`

--- a/servers/thenv/package.json
+++ b/servers/thenv/package.json
@@ -2,6 +2,7 @@
     "name": "@servers/thenv",
     "private": true,
     "scripts": {
+        "predev": "cd ../.. && ./scripts/generate-go-proto.sh",
         "dev": "air"
     }
 }


### PR DESCRIPTION
## Summary
- add a predev script to servers/thenv/package.json so pnpm dev regenerates Go protobuf stubs before starting air
- document the new local dev behavior in docs/project-thenv.md

## Testing
- pnpm --filter @servers/thenv run predev