### PR TITLE
feat(nodeup): reduce default managed-alias logging noise

### DIFF
--- a/crates/nodeup/src/logging.rs
+++ b/crates/nodeup/src/logging.rs
@@ -3,14 +3,26 @@ use tracing_subscriber::EnvFilter;
 const NODEUP_LOG_COLOR_ENV: &str = "NODEUP_LOG_COLOR";
 const NO_COLOR_ENV: &str = "NO_COLOR";
 
-pub fn init_logging(json_error_output_requested: bool) {
-    let default_filter = if json_error_output_requested {
-        "nodeup=off"
-    } else {
-        "nodeup=info"
-    };
-    let env_filter =
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_filter));
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoggingContext {
+    ManagedAlias,
+    ManagementHuman,
+    ManagementJson,
+}
+
+impl LoggingContext {
+    fn default_filter(self) -> &'static str {
+        match self {
+            Self::ManagedAlias => "nodeup=warn",
+            Self::ManagementHuman => "nodeup=info",
+            Self::ManagementJson => "nodeup=off",
+        }
+    }
+}
+
+pub fn init_logging(context: LoggingContext) {
+    let env_filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(context.default_filter()));
     let _ = tracing_subscriber::fmt()
         .pretty()
         .with_env_filter(env_filter)
@@ -60,7 +72,28 @@ fn parse_log_color_mode(raw: &str) -> Option<LogColorMode> {
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_log_color_enabled;
+    use super::{resolve_log_color_enabled, LoggingContext};
+
+    #[test]
+    fn managed_alias_default_filter_is_warn() {
+        assert_eq!(LoggingContext::ManagedAlias.default_filter(), "nodeup=warn");
+    }
+
+    #[test]
+    fn management_human_default_filter_is_info() {
+        assert_eq!(
+            LoggingContext::ManagementHuman.default_filter(),
+            "nodeup=info"
+        );
+    }
+
+    #[test]
+    fn management_json_default_filter_is_off() {
+        assert_eq!(
+            LoggingContext::ManagementJson.default_filter(),
+            "nodeup=off"
+        );
+    }
 
     #[test]
     fn default_enables_colored_logs() {

--- a/crates/nodeup/src/main.rs
+++ b/crates/nodeup/src/main.rs
@@ -6,8 +6,9 @@ use nodeup::{
 };
 
 fn main() {
-    let json_error_output_requested = json_error_output_requested();
-    logging::init_logging(json_error_output_requested);
+    let logging_context = logging_context();
+    let json_error_output_requested = logging_context == logging::LoggingContext::ManagementJson;
+    logging::init_logging(logging_context);
 
     match run() {
         Ok(code) => std::process::exit(code),
@@ -40,23 +41,43 @@ fn run() -> Result<i32, NodeupError> {
     commands::execute(cli, &app)
 }
 
-fn json_error_output_requested() -> bool {
-    json_error_output_requested_from_args(std::env::args_os())
+fn logging_context() -> logging::LoggingContext {
+    logging_context_from_args(std::env::args_os())
 }
 
-fn json_error_output_requested_from_args<I>(args: I) -> bool
+fn logging_context_from_args<I>(args: I) -> logging::LoggingContext
 where
     I: IntoIterator<Item = OsString>,
 {
     let mut args = args.into_iter();
     let Some(argv0) = args.next() else {
-        return false;
+        return logging::LoggingContext::ManagementHuman;
     };
 
     if ManagedAlias::from_argv0(argv0.as_os_str()).is_some() {
-        return false;
+        return logging::LoggingContext::ManagedAlias;
     }
 
+    if json_error_output_requested_from_management_args(args) {
+        logging::LoggingContext::ManagementJson
+    } else {
+        logging::LoggingContext::ManagementHuman
+    }
+}
+
+#[cfg(test)]
+fn json_error_output_requested_from_args<I>(args: I) -> bool
+where
+    I: IntoIterator<Item = OsString>,
+{
+    logging_context_from_args(args) == logging::LoggingContext::ManagementJson
+}
+
+fn json_error_output_requested_from_management_args<I>(args: I) -> bool
+where
+    I: IntoIterator<Item = OsString>,
+{
+    let mut args = args.into_iter();
     let mut json_output_requested = false;
     let mut command_scan_state = CommandScanState::BeforeSubcommand;
     let mut output_value_expected = false;
@@ -137,7 +158,9 @@ enum CommandScanState {
 
 #[cfg(test)]
 mod tests {
-    use super::json_error_output_requested_from_args;
+    use nodeup::logging::LoggingContext;
+
+    use super::{json_error_output_requested_from_args, logging_context_from_args};
 
     fn os_args(args: &[&str]) -> Vec<std::ffi::OsString> {
         args.iter()
@@ -167,6 +190,14 @@ mod tests {
         assert!(!json_error_output_requested_from_args(os_args(&[
             "node", "--output", "json",
         ])));
+    }
+
+    #[test]
+    fn managed_alias_invocation_selects_managed_alias_logging_context() {
+        assert_eq!(
+            logging_context_from_args(os_args(&["node"])),
+            LoggingContext::ManagedAlias
+        );
     }
 
     #[test]
@@ -211,5 +242,13 @@ mod tests {
             "--output",
             "json",
         ])));
+    }
+
+    #[test]
+    fn human_management_defaults_to_human_logging_context() {
+        assert_eq!(
+            logging_context_from_args(os_args(&["nodeup", "show", "home"])),
+            LoggingContext::ManagementHuman
+        );
     }
 }

--- a/crates/nodeup/tests/cli.rs
+++ b/crates/nodeup/tests/cli.rs
@@ -1072,6 +1072,24 @@ fn override_resolution_logs_miss_without_default_selector() {
 
 #[test]
 #[serial]
+fn management_human_default_logging_emits_info_logs_without_rust_log_env() {
+    let env = TestEnv::new();
+
+    let output = env
+        .command()
+        .env_remove("RUST_LOG")
+        .args(["show", "home"])
+        .output()
+        .expect("show home without rust log env");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("command_path: \"nodeup.show.home\""));
+}
+
+#[test]
+#[serial]
 fn json_show_active_runtime_failure_emits_stderr_error_envelope() {
     let env = TestEnv::new();
 
@@ -1111,6 +1129,31 @@ fn json_show_active_runtime_failure_remains_parseable_without_rust_log_env() {
     let payload: Value = serde_json::from_slice(&output.stderr).unwrap();
     assert_eq!(payload["kind"], "not-found");
     assert_eq!(payload["exit_code"], 5);
+}
+
+#[test]
+#[serial]
+fn json_show_home_remains_parseable_without_rust_log_env() {
+    let env = TestEnv::new();
+
+    let output = env
+        .command()
+        .env_remove("RUST_LOG")
+        .args(["--output", "json", "show", "home"])
+        .output()
+        .expect("show home --output json without rust log env");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!stdout.contains("command_path:"));
+    assert!(!stderr.contains("command_path:"));
+
+    let payload: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(payload["data_root"].as_str().is_some());
+    assert!(payload["cache_root"].as_str().is_some());
+    assert!(payload["config_root"].as_str().is_some());
 }
 
 #[test]
@@ -1585,6 +1628,42 @@ fn shim_dispatch_uses_argv0_alias() {
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("shim-ok"));
+}
+
+#[test]
+#[serial]
+fn shim_dispatch_default_logging_suppresses_info_logs_without_rust_log_env() {
+    let env = TestEnv::new();
+    env.register_index(&[("22.1.0", Some("Jod"))]);
+    env.register_release(
+        "22.1.0",
+        make_archive(
+            "22.1.0",
+            "linux-x64",
+            &[("node", "#!/bin/sh\necho shim-ok\n")],
+        ),
+        None,
+    );
+
+    env.command().args(["default", "22.1.0"]).assert().success();
+
+    let real_bin = assert_cmd::cargo::cargo_bin!("nodeup");
+    let shim_path = env.root.join("node");
+    std::os::unix::fs::symlink(real_bin, &shim_path).unwrap();
+
+    let output = env
+        .command_with_program(&shim_path)
+        .env_remove("RUST_LOG")
+        .output()
+        .expect("run shim binary without rust log env");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stdout.contains("shim-ok"));
+    assert!(!stdout.contains("command_path:"));
+    assert!(!stderr.contains("command_path:"));
 }
 
 #[cfg(unix)]

--- a/docs/project-nodeup.md
+++ b/docs/project-nodeup.md
@@ -117,7 +117,8 @@ CLI entrypoints:
 
 Global option contract:
 - `--output <human|json>` is available for all management commands and defaults to `human`.
-- In `--output human`, default logging uses `tracing` pretty formatting (`level=on`, `target=off`, `time=off`, `ansi=on`).
+- In `--output human` for management commands, default logging uses `tracing` pretty formatting (`level=on`, `target=off`, `time=off`, `ansi=on`) with `nodeup=info`.
+- In managed-alias dispatch mode (`node`, `npm`, `npx`), default logging uses the same `tracing` format but with `nodeup=warn` to keep normal delegated command execution quiet.
 - Log color override:
 : `NODEUP_LOG_COLOR=always|auto|never` controls ANSI color (`always` default).
 : If `NODEUP_LOG_COLOR` is unset or `auto`, `NO_COLOR` disables color; otherwise color remains enabled.
@@ -268,10 +269,12 @@ Symlink contract:
 - Log provenance metadata for each installed version.
 
 ## Logging
-Default human-mode logging uses `tracing` pretty formatting with `level=on`, `target=off`, `time=off`, and `ansi=off`.
+Default management-command human logging uses `tracing` pretty formatting with `level=on`, `target=off`, `time=off`, and `ansi=on` and a default filter of `nodeup=info`.
+Default managed-alias dispatch logging uses the same formatting and a default filter of `nodeup=warn`.
 In `--output json`, default logging remains disabled (`nodeup=off`) unless `RUST_LOG` is explicitly set.
 
 Required baseline logs:
+- Baseline structured events are emitted at `info` level and are guaranteed when `RUST_LOG` includes `nodeup=info` (or a more verbose level); alias default mode intentionally suppresses those `info` events unless explicitly enabled.
 - Command path (`nodeup.<group>.<subcommand>` or `nodeup.<command>`) and `arg_shape` JSON payload (single structured field, sanitized)
 - Runtime selector source (`explicit`, `override`, `default`) and resolved runtime
 - Override lookup result (`path`, `matched`, `fallback_reason`) with stable fallback codes:


### PR DESCRIPTION
## Summary
- add logging context modes for nodeup startup (`ManagedAlias`, `ManagementHuman`, `ManagementJson`)
- set managed alias default logging to `nodeup=warn` while keeping management human mode at `nodeup=info`
- detect execution context before logging initialization and keep JSON error envelope behavior unchanged
- add CLI tests for alias default log suppression, management human default info logging, and JSON parseability without `RUST_LOG`
- update `docs/project-nodeup.md` logging contract to document alias default logging behavior

## Testing
- cargo fmt --all --check
- cargo test -p nodeup
- cargo test