### PR TITLE
chore(devkit): pin dev server port to 5990

### DIFF
--- a/apps/devkit/package.json
+++ b/apps/devkit/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "prepare:app": "echo \"devkit prepared\"",
-    "dev": "next dev",
+    "dev": "next dev --port 5990",
     "build": "next build",
     "start": "next start",
     "test": "vitest run",

--- a/docs/project-devkit.md
+++ b/docs/project-devkit.md
@@ -105,6 +105,7 @@ Required baseline logs:
 
 ## Build and Test
 Current commands:
+- Dev: `pnpm --filter devkit... dev` (fixed port `5990`)
 - Build: `pnpm --filter devkit... build`
 - Test: `pnpm --filter devkit... test`
 - Test runner: Vitest (`apps/devkit/vitest.config.ts`)


### PR DESCRIPTION
## Summary
- pin the devkit Next.js dev server port to `5990`
- document the fixed dev command and port in `docs/project-devkit.md`

## Testing
- pnpm test (apps/devkit)