### PR TITLE
chore(dev): route pnpm dev through derun run

### DIFF
--- a/docs/project-derun.md
+++ b/docs/project-derun.md
@@ -120,6 +120,9 @@ Command contracts:
 - `derun mcp`
 : Starts stdio MCP server for AI-driven session/output retrieval.
 
+Workspace integration contract:
+- Root `pnpm dev` must execute `./scripts/dev.sh`, which runs `go -C <repo-root> run ./cmds/derun run -- turbo dev` with repository-local `DERUN_STATE_ROOT`, `GOMODCACHE`, `GOCACHE`, and `GOPATH` exports so local development sessions are discoverable by the configured `derun mcp` server.
+
 MCP I/O contracts:
 - `derun_list_sessions(state?, limit?)`
 : Returns active/recent session metadata with session identifier and lifecycle state.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "prepare": "lefthook install; ./scripts/prepare-apps.sh",
     "predev": "./scripts/generate-go-proto.sh",
-    "dev": "turbo dev",
+    "dev": "./scripts/dev.sh",
     "build": "turbo build",
     "test": "turbo test",
     "lint": "turbo lint",

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+set -eu
+
+repo_root="$(git rev-parse --show-toplevel)"
+
+export DERUN_STATE_ROOT="$repo_root/.derun-state"
+export GOMODCACHE="$repo_root/.gomodcache"
+export GOCACHE="$repo_root/.gocache"
+export GOPATH="$repo_root/.gopath"
+
+if [ "${1-}" = "--" ]; then
+  shift
+fi
+
+exec go -C "$repo_root" run ./cmds/derun run -- turbo dev "$@"


### PR DESCRIPTION
## Summary
- change root `pnpm dev` script to call `./scripts/dev.sh`
- add `scripts/dev.sh` to run `go -C <repo-root> run ./cmds/derun run -- turbo dev` with repo-local derun/go cache env vars
- document the workspace integration contract in `docs/project-derun.md`

## Testing
- `sh -n scripts/dev.sh`
- `pnpm dev -- --help` *(fails in this environment because `node_modules` is not installed, so `turbo` is not found)*