### PR TITLE
docs(public-docs): document devmon nodeup derun with top-level nav tabs

### DIFF
--- a/apps/public-docs/README.md
+++ b/apps/public-docs/README.md
@@ -20,3 +20,6 @@ pnpm --filter public-docs test
 - `getting-started.mdx`: Local setup and contribution flow.
 - `projects-overview.mdx`: High-level public project catalog.
 - `documentation-lifecycle.mdx`: Rules for updating internal and public docs together.
+- `devmon.mdx`: Public project guide for `devmon`.
+- `nodeup.mdx`: Public project guide for `nodeup`.
+- `derun.mdx`: Public project guide for `derun`.

--- a/apps/public-docs/derun.mdx
+++ b/apps/public-docs/derun.mdx
@@ -1,0 +1,56 @@
+# derun
+
+`derun` is a terminal-faithful command runner with side-channel transcript capture and MCP-based output retrieval for AI workflows.
+
+## Why use derun
+
+- Keep terminal behavior unchanged for human operators.
+- Capture complete command transcripts for later replay and live tail.
+- Expose read-only MCP tools for deterministic session discovery and output access.
+
+## Core capabilities
+
+- Run mode: `derun run -- <command> [args...]`
+- MCP mode: `derun mcp`
+- Cursor-based output APIs over MCP:
+  - `derun_list_sessions`
+  - `derun_get_session`
+  - `derun_read_output`
+  - `derun_wait_output`
+
+## Quick start
+
+Run a command with transcript capture:
+
+```bash
+derun run -- ls -la
+```
+
+Run with an explicit session ID and retention:
+
+```bash
+derun run --session-id local-debug-001 --retention 24h -- go test ./...
+```
+
+Start MCP bridge server for session retrieval:
+
+```bash
+derun mcp
+```
+
+## Terminal fidelity rules
+
+- Child stdout/stderr are forwarded without mutation.
+- PTY transport is used for interactive terminals (POSIX PTY / Windows ConPTY).
+- Process exit code or signal semantics are preserved.
+
+## Retention and storage
+
+- Default retention TTL is 24 hours.
+- Session artifacts are stored under the local state root (`$XDG_STATE_HOME/derun` or fallback path).
+- Per-session artifacts include `meta.json`, `output.bin`, `index.jsonl`, and `final.json`.
+
+## Related pages
+
+- [Projects Overview](projects-overview)
+- [Documentation Lifecycle](documentation-lifecycle)

--- a/apps/public-docs/devmon.mdx
+++ b/apps/public-docs/devmon.mdx
@@ -1,0 +1,60 @@
+# devmon
+
+`devmon` is a local automation daemon for recurring folder jobs, with optional macOS service and menu bar lifecycle control.
+
+## Why use devmon
+
+- Schedule recurring local workflows without building a separate cron setup.
+- Keep execution visibility with structured logs and persisted daemon status.
+- Control lifecycle from both CLI and menu bar on macOS.
+
+## Core capabilities
+
+- Foreground daemon mode: `devmon daemon --config <path>`
+- Config validation mode: `devmon validate --config <path>`
+- Service lifecycle mode (macOS): `devmon service install|uninstall|start|stop|status`
+- Menu bar mode (macOS): `devmon menubar`
+
+## Configuration model
+
+`devmon` uses a TOML config file (`devmon.toml`) with folder and job definitions.
+
+```toml
+version = 1
+
+[daemon]
+max_concurrent_jobs = 2
+startup_run = true
+log_level = "info"
+
+[[folder]]
+id = "workspace"
+path = "/Users/you/projects/oss"
+
+[[folder.job]]
+id = "go-test"
+type = "shell-command"
+enabled = true
+interval = "15m"
+timeout = "10m"
+shell = "/bin/zsh"
+script = "go test ./..."
+```
+
+## Scheduling semantics
+
+- Startup run is executed immediately when enabled.
+- Job overlap is blocked (`skipped-overlap`) when a previous run is still active.
+- Global concurrency limits are enforced (`skipped-capacity`) when all slots are full.
+- Timeouts are enforced per job.
+
+## Observability and state
+
+- Structured logging is implemented with Go `log/slog`.
+- Daemon state is persisted to `~/.local/state/devmon/status.json`.
+- Service mode writes LaunchAgent definitions under `~/Library/LaunchAgents`.
+
+## Related pages
+
+- [Projects Overview](projects-overview)
+- [Documentation Lifecycle](documentation-lifecycle)

--- a/apps/public-docs/docs.json
+++ b/apps/public-docs/docs.json
@@ -5,14 +5,46 @@
     "primary": "#0F766E"
   },
   "navigation": {
-    "groups": [
+    "tabs": [
       {
-        "group": "Get Started",
-        "pages": ["index", "getting-started"]
+        "tab": "Home",
+        "groups": [
+          {
+            "group": "Get Started",
+            "pages": ["index", "getting-started"]
+          },
+          {
+            "group": "Reference",
+            "pages": ["projects-overview", "documentation-lifecycle"]
+          }
+        ]
       },
       {
-        "group": "Reference",
-        "pages": ["projects-overview", "documentation-lifecycle"]
+        "tab": "Devmon",
+        "groups": [
+          {
+            "group": "Automation Daemon",
+            "pages": ["devmon"]
+          }
+        ]
+      },
+      {
+        "tab": "Nodeup",
+        "groups": [
+          {
+            "group": "Node Runtime Manager",
+            "pages": ["nodeup"]
+          }
+        ]
+      },
+      {
+        "tab": "Derun",
+        "groups": [
+          {
+            "group": "Terminal Relay + MCP",
+            "pages": ["derun"]
+          }
+        ]
       }
     ]
   }

--- a/apps/public-docs/index.mdx
+++ b/apps/public-docs/index.mdx
@@ -9,6 +9,7 @@ This site provides a curated, user-facing layer of documentation that complement
 - Read [Getting Started](getting-started) for local setup and editing workflow.
 - See [Projects Overview](projects-overview) for the current public project catalog.
 - Review [Documentation Lifecycle](documentation-lifecycle) for update rules between `docs/` and `apps/public-docs`.
+- Open [Devmon](devmon), [Nodeup](nodeup), and [Derun](derun) from the top navigation for dedicated project guides.
 
 ## Scope
 

--- a/apps/public-docs/nodeup.mdx
+++ b/apps/public-docs/nodeup.mdx
@@ -1,0 +1,54 @@
+# nodeup
+
+`nodeup` is a Rust-based Node.js version manager with rustup-like commands and deterministic runtime selection.
+
+## Why use nodeup
+
+- Manage multiple Node.js runtimes with a single CLI.
+- Resolve runtime precedence consistently across default, override, and explicit execution.
+- Use stable human and JSON output modes for both operators and automation.
+
+## Core capabilities
+
+- Toolchain lifecycle: `toolchain list|install|uninstall|link`
+- Runtime selection: `default`, `override set|unset|list`, `show active-runtime`
+- Runtime-aware execution: `run`, `which`
+- Self-management: `self update|uninstall|upgrade-data`
+
+## Common workflows
+
+Set a global default runtime:
+
+```bash
+nodeup default lts
+```
+
+Install and run with an explicit runtime:
+
+```bash
+nodeup toolchain install 24.0.0
+nodeup run --install 24.0.0 node -v
+```
+
+Use a project directory override:
+
+```bash
+nodeup override set lts --path /path/to/project
+```
+
+## Runtime resolution precedence
+
+1. Explicit runtime selector in command invocation (`run`, `which --runtime`)
+2. Directory override selector (`override set`)
+3. Global default selector (`default`)
+
+## Output and logging behavior
+
+- `--output human|json` is available for management commands.
+- Human mode uses pretty `tracing` logs by default.
+- JSON mode writes machine payloads to stdout and keeps logs off by default unless explicitly enabled.
+
+## Related pages
+
+- [Projects Overview](projects-overview)
+- [Getting Started](getting-started)

--- a/apps/public-docs/projects-overview.mdx
+++ b/apps/public-docs/projects-overview.mdx
@@ -5,9 +5,9 @@ This page provides a high-level public catalog of projects in the Delino OSS mon
 ## Active Projects
 
 - `cargo-mono`: Cargo subcommand tooling for Rust monorepo workflows.
-- `nodeup`: Rust-based Node.js runtime manager.
-- `derun`: Terminal-fidelity run execution and MCP bridge tool.
-- `devmon`: Automation daemon with menu bar controls.
+- [`nodeup`](nodeup): Rust-based Node.js runtime manager.
+- [`derun`](derun): Terminal-fidelity run execution and MCP bridge tool.
+- [`devmon`](devmon): Automation daemon with menu bar controls.
 - `mpapp`: Expo React Native mobile app.
 - `devkit`: Next.js micro-app host platform.
 - `devkit-commit-tracker`: Commit Tracker web/API/collector project.

--- a/docs/project-public-docs.md
+++ b/docs/project-public-docs.md
@@ -27,8 +27,8 @@ It delivers curated onboarding and project overview content while keeping detail
 
 ## Architecture
 - Mintlify app content is authored as MDX pages under `apps/public-docs`.
-- Site navigation and page grouping are defined in `apps/public-docs/docs.json`.
-- `docs.json` must include `colors.primary` and a `navigation` object using the `navigation.groups` array contract.
+- Site navigation, top tabs, and page grouping are defined in `apps/public-docs/docs.json`.
+- `docs.json` must include `colors.primary` and a `navigation` object using the `navigation.tabs` array contract.
 - Public docs summarize stable user-facing information from internal project contracts.
 - Internal contracts remain authoritative and must be updated before or alongside related public docs updates.
 
@@ -49,14 +49,22 @@ enum PublicDocsPageId {
   GettingStarted = "getting-started",
   ProjectsOverview = "projects-overview",
   DocumentationLifecycle = "documentation-lifecycle",
+  Devmon = "devmon",
+  Nodeup = "nodeup",
+  Derun = "derun",
 }
 ```
 
 Navigation contract:
 - `navigation` must be an object, not an array.
-- `navigation.groups` is the canonical group list.
-- Group `Get Started` must include `index` and `getting-started`.
-- Group `Reference` must include `projects-overview` and `documentation-lifecycle`.
+- `navigation.tabs` is the canonical top-level navigation list.
+- Tab `Home` must include:
+: Group `Get Started` with `index` and `getting-started`.
+: Group `Reference` with `projects-overview` and `documentation-lifecycle`.
+- Tabs `Devmon`, `Nodeup`, and `Derun` must each be present as top-level tabs.
+- Tab `Devmon` must include page `devmon`.
+- Tab `Nodeup` must include page `nodeup`.
+- Tab `Derun` must include page `derun`.
 
 Dev preview port contract:
 - `pnpm --filter public-docs dev` runs Mintlify with fixed port `46249`.


### PR DESCRIPTION
## Summary
- add dedicated public docs pages for `devmon`, `nodeup`, and `derun`
- update Mintlify `docs.json` to expose `Devmon`, `Nodeup`, and `Derun` as top-level tabs
- update related public docs links and synchronize `docs/project-public-docs.md` navigation/page-id contract

## Testing
- pnpm --filter public-docs test