### PR TITLE
chore(nodeup): add local install env patch script

### DIFF
--- a/docs/project-nodeup.md
+++ b/docs/project-nodeup.md
@@ -295,6 +295,13 @@ Required baseline logs:
 - Completion generation target shell and success/failure status (`action=generate`, `outcome=not-implemented` in current phase)
 
 ## Build and Test
+Local development install and shell-session patch:
+- `eval "$(./scripts/setup/nodeup-local.sh)"`
+- Script contract:
+: Installs from `crates/nodeup` using `cargo install --path .`.
+: Uses install root `${NODEUP_LOCAL_INSTALL_ROOT:-<repo>/.local/nodeup}`.
+: Prints shell exports for `PATH` and `NODEUP_SELF_BIN_PATH` so the current shell session can apply them immediately.
+
 Planned commands:
 - Build: `cargo build -p nodeup`
 - Lint: `cargo clippy -p nodeup --all-targets -- -D warnings`

--- a/scripts/setup/nodeup-local.sh
+++ b/scripts/setup/nodeup-local.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env sh
+
+set -eu
+
+if [ "${1:-}" = "--help" ]; then
+  cat >&2 <<'EOF'
+Install nodeup from the local workspace and print shell exports for the current session.
+
+Usage:
+  eval "$(./scripts/setup/nodeup-local.sh)"
+
+Optional environment variables:
+  NODEUP_LOCAL_INSTALL_ROOT  Install root (default: <repo>/.local/nodeup)
+EOF
+  exit 0
+fi
+
+script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+repo_root="$(git -C "$script_dir/../.." rev-parse --show-toplevel)"
+crate_dir="$repo_root/crates/nodeup"
+install_root="${NODEUP_LOCAL_INSTALL_ROOT:-$repo_root/.local/nodeup}"
+install_bin_dir="$install_root/bin"
+
+echo "[nodeup-local] installing with cargo install --path . --root \"$install_root\"" >&2
+(
+  cd "$crate_dir"
+  cargo install --path . --root "$install_root"
+) >&2
+
+echo "[nodeup-local] printing shell exports for current session patch" >&2
+printf '_nodeup_local_bin="%s"\n' "$install_bin_dir"
+printf 'case ":$PATH:" in *":${_nodeup_local_bin}:"*) ;; *) export PATH="${_nodeup_local_bin}:$PATH" ;; esac\n'
+printf 'export NODEUP_SELF_BIN_PATH="%s/nodeup"\n' "$install_bin_dir"
+printf 'hash -r 2>/dev/null || true\n'
+printf 'unset _nodeup_local_bin\n'


### PR DESCRIPTION
## Summary
- add a repository setup script to install nodeup locally with `cargo install --path .`
- print export commands so the current shell session can patch `PATH` and `NODEUP_SELF_BIN_PATH` via `eval "$(./scripts/setup/nodeup-local.sh)"`
- document the local install + shell patch contract in the nodeup project doc

## Validation
- `sh -n scripts/setup/nodeup-local.sh`
- `./scripts/setup/nodeup-local.sh --help`
