### PR TITLE
feat(cargo-mono): prefetch crates.io sparse index before publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,7 @@ dependencies = [
  "clap",
  "globset",
  "predicates",
+ "reqwest",
  "semver",
  "serde",
  "serde_json",

--- a/crates/cargo-mono/Cargo.toml
+++ b/crates/cargo-mono/Cargo.toml
@@ -12,6 +12,7 @@ globset = "0.4.15"
 semver = { version = "1.0.26", features = ["serde"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
+reqwest = { version = "0.12.14", default-features = false, features = ["blocking", "rustls-tls"] }
 thiserror = "2.0.12"
 toml_edit = "0.22.24"
 tracing = "0.1.41"

--- a/crates/cargo-mono/src/commands/mod.rs
+++ b/crates/cargo-mono/src/commands/mod.rs
@@ -15,6 +15,8 @@ use crate::{
     CargoMonoApp,
 };
 
+const PUBLISH_PREFETCH_CONCURRENCY_ENV: &str = "CARGO_MONO_PUBLISH_PREFETCH_CONCURRENCY";
+
 pub fn execute(cli: Cli, app: &CargoMonoApp) -> Result<i32> {
     match cli.command {
         Command::List => list::execute(cli.output, app),
@@ -128,8 +130,14 @@ fn publish_arg_shape(args: &PublishArgs, output: OutputFormat) -> Value {
         "exclude_path": args.changed.exclude_path,
         "dry_run": args.dry_run,
         "allow_dirty": args.allow_dirty,
-        "registry_provided": args.registry.is_some()
+        "registry_provided": args.registry.is_some(),
+        "prefetch_registry_eligible": publish_prefetch_registry_eligible(args.registry.as_deref()),
+        "prefetch_concurrency_env_set": std::env::var(PUBLISH_PREFETCH_CONCURRENCY_ENV).is_ok()
     })
+}
+
+fn publish_prefetch_registry_eligible(registry: Option<&str>) -> bool {
+    registry.is_none_or(|value| value.eq_ignore_ascii_case("crates-io"))
 }
 
 fn target_selector_key(target: &TargetArgs) -> &'static str {

--- a/crates/cargo-mono/src/commands/publish.rs
+++ b/crates/cargo-mono/src/commands/publish.rs
@@ -1,21 +1,31 @@
 use std::{
+    collections::{BTreeSet, VecDeque},
     process::{Command, Output},
+    sync::{Arc, Mutex},
     thread,
     time::Duration,
 };
 
-use serde::Serialize;
-use tracing::info;
+use reqwest::StatusCode;
+use semver::Version;
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
 
 use crate::{
     cli::PublishArgs,
     commands::{print_output, targeting},
     errors::{CargoMonoError, Result},
     types::{OutputFormat, PublishSkipReason},
+    workspace::Workspace,
     CargoMonoApp,
 };
 
 const MAX_PUBLISH_ATTEMPTS: usize = 3;
+const CRATES_IO_SPARSE_INDEX_BASE_URL: &str = "https://index.crates.io";
+pub(super) const PUBLISH_PREFETCH_CONCURRENCY_ENV: &str = "CARGO_MONO_PUBLISH_PREFETCH_CONCURRENCY";
+const DEFAULT_PREFETCH_CONCURRENCY: usize = 16;
+const MAX_PREFETCH_CONCURRENCY: usize = 64;
+const PREFETCH_HTTP_TIMEOUT: Duration = Duration::from_secs(15);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PublishFailureKind {
@@ -72,6 +82,74 @@ struct PublishResult {
     failed: Vec<FailedPackage>,
 }
 
+#[derive(Debug, Clone)]
+struct PublishPrefetchCandidate {
+    name: String,
+    version: Version,
+}
+
+#[derive(Debug)]
+struct PublishPrefetchResult {
+    confirmed_already_published: BTreeSet<String>,
+    lookup_errors: Vec<PrefetchLookupError>,
+}
+
+#[derive(Debug)]
+struct PrefetchLookupError {
+    package: String,
+    http_status: Option<u16>,
+    error: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PrefetchLookupState {
+    AlreadyPublished,
+    NotPublished,
+    Unknown,
+}
+
+#[derive(Debug)]
+struct PrefetchPackageLookupResult {
+    package: String,
+    state: PrefetchLookupState,
+    http_status: Option<u16>,
+    error: Option<String>,
+}
+
+impl PrefetchPackageLookupResult {
+    fn already_published(package: String) -> Self {
+        Self {
+            package,
+            state: PrefetchLookupState::AlreadyPublished,
+            http_status: None,
+            error: None,
+        }
+    }
+
+    fn not_published(package: String) -> Self {
+        Self {
+            package,
+            state: PrefetchLookupState::NotPublished,
+            http_status: None,
+            error: None,
+        }
+    }
+
+    fn unknown(package: String, http_status: Option<u16>, error: String) -> Self {
+        Self {
+            package,
+            state: PrefetchLookupState::Unknown,
+            http_status,
+            error: Some(error),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SparseIndexEntry {
+    vers: String,
+}
+
 pub fn execute(args: &PublishArgs, output: OutputFormat, app: &CargoMonoApp) -> Result<i32> {
     let resolved = targeting::resolve_targets(&args.target, &args.changed, &app.workspace)?;
 
@@ -97,7 +175,7 @@ pub fn execute(args: &PublishArgs, output: OutputFormat, app: &CargoMonoApp) -> 
                 None
             }
         })
-        .collect::<std::collections::BTreeSet<_>>();
+        .collect::<BTreeSet<_>>();
 
     if publishable_targets.is_empty() {
         let result = PublishResult {
@@ -122,10 +200,33 @@ pub fn execute(args: &PublishArgs, output: OutputFormat, app: &CargoMonoApp) -> 
     }
 
     let order = app.workspace.topological_order(&publishable_targets)?;
+    let prefetch_result =
+        prefetch_published_versions(&app.workspace, &order, args.registry.as_deref());
     let mut published = Vec::<PublishedPackage>::new();
     let mut failed = Vec::<FailedPackage>::new();
 
     for package_name in order {
+        if prefetch_result
+            .confirmed_already_published
+            .contains(&package_name)
+        {
+            skipped.push(SkippedPackage {
+                name: package_name.clone(),
+                reason: PublishSkipReason::AlreadyPublished,
+            });
+            info!(
+                command_path = "cargo-mono.publish",
+                workspace_root = %app.workspace.root.display(),
+                package = %package_name,
+                action = "publish-package",
+                outcome = "already-published",
+                source = "prefetch-sparse-index",
+                retry_attempt = 0usize,
+                "Skipping already-published crate version"
+            );
+            continue;
+        }
+
         let mut attempts = 0usize;
         let mut published_or_skipped = false;
 
@@ -176,6 +277,7 @@ pub fn execute(args: &PublishArgs, output: OutputFormat, app: &CargoMonoApp) -> 
                         action = "publish-package",
                         outcome = "already-published",
                         retry_attempt = attempts,
+                        source = "cargo-publish-output",
                         "Skipping already-published crate version"
                     );
                     break;
@@ -280,6 +382,372 @@ pub fn execute(args: &PublishArgs, output: OutputFormat, app: &CargoMonoApp) -> 
     }
 }
 
+fn prefetch_published_versions(
+    workspace: &Workspace,
+    ordered_packages: &[String],
+    registry: Option<&str>,
+) -> PublishPrefetchResult {
+    if !should_prefetch_published_versions(registry) {
+        info!(
+            command_path = "cargo-mono.publish",
+            workspace_root = %workspace.root.display(),
+            action = "prefetch-published-versions",
+            outcome = "skipped",
+            reason = "unsupported-registry",
+            registry = %registry.unwrap_or(""),
+            "Skipping published version prefetch for unsupported registry"
+        );
+        return PublishPrefetchResult {
+            confirmed_already_published: BTreeSet::new(),
+            lookup_errors: Vec::new(),
+        };
+    }
+
+    let mut candidates = Vec::with_capacity(ordered_packages.len());
+    for package_name in ordered_packages {
+        let Some(package) = workspace.package(package_name) else {
+            warn!(
+                command_path = "cargo-mono.publish",
+                workspace_root = %workspace.root.display(),
+                action = "prefetch-published-versions",
+                outcome = "partial-error",
+                package = %package_name,
+                reason = "missing-workspace-metadata",
+                "Package is missing from workspace metadata during prefetch"
+            );
+            return PublishPrefetchResult {
+                confirmed_already_published: BTreeSet::new(),
+                lookup_errors: vec![PrefetchLookupError {
+                    package: package_name.clone(),
+                    http_status: None,
+                    error: "package missing from workspace metadata".to_string(),
+                }],
+            };
+        };
+
+        candidates.push(PublishPrefetchCandidate {
+            name: package_name.clone(),
+            version: package.version.clone(),
+        });
+    }
+
+    if candidates.is_empty() {
+        info!(
+            command_path = "cargo-mono.publish",
+            workspace_root = %workspace.root.display(),
+            action = "prefetch-published-versions",
+            outcome = "skipped",
+            reason = "no-candidates",
+            "Skipping published version prefetch because there are no candidates"
+        );
+        return PublishPrefetchResult {
+            confirmed_already_published: BTreeSet::new(),
+            lookup_errors: Vec::new(),
+        };
+    }
+
+    let concurrency = resolve_prefetch_concurrency();
+    info!(
+        command_path = "cargo-mono.publish",
+        workspace_root = %workspace.root.display(),
+        action = "prefetch-published-versions",
+        outcome = "started",
+        package_count = candidates.len(),
+        concurrency,
+        "Prefetching published crate versions from crates.io sparse index"
+    );
+
+    let lookup_results = run_parallel_sparse_index_lookup(&candidates, concurrency);
+    let prefetch_result = merge_prefetch_lookup_results(lookup_results);
+
+    for lookup_error in &prefetch_result.lookup_errors {
+        warn!(
+            command_path = "cargo-mono.publish",
+            workspace_root = %workspace.root.display(),
+            package = %lookup_error.package,
+            action = "prefetch-published-versions",
+            outcome = "lookup-error",
+            http_status = lookup_error.http_status,
+            error = %lookup_error.error,
+            "Failed to prefetch published version from sparse index"
+        );
+    }
+
+    info!(
+        command_path = "cargo-mono.publish",
+        workspace_root = %workspace.root.display(),
+        action = "prefetch-published-versions",
+        outcome = if prefetch_result.lookup_errors.is_empty() {
+            "completed"
+        } else {
+            "partial-error"
+        },
+        package_count = candidates.len(),
+        already_published_count = prefetch_result.confirmed_already_published.len(),
+        lookup_error_count = prefetch_result.lookup_errors.len(),
+        "Completed published version prefetch"
+    );
+
+    prefetch_result
+}
+
+fn should_prefetch_published_versions(registry: Option<&str>) -> bool {
+    registry.is_none_or(|value| value.eq_ignore_ascii_case("crates-io"))
+}
+
+fn resolve_prefetch_concurrency() -> usize {
+    let Ok(raw_value) = std::env::var(PUBLISH_PREFETCH_CONCURRENCY_ENV) else {
+        return DEFAULT_PREFETCH_CONCURRENCY;
+    };
+
+    match parse_prefetch_concurrency_value(&raw_value) {
+        Some(concurrency) => concurrency,
+        None => {
+            warn!(
+                command_path = "cargo-mono.publish",
+                action = "prefetch-published-versions",
+                outcome = "invalid-prefetch-concurrency",
+                env_var = PUBLISH_PREFETCH_CONCURRENCY_ENV,
+                env_value = %raw_value,
+                default_concurrency = DEFAULT_PREFETCH_CONCURRENCY,
+                max_concurrency = MAX_PREFETCH_CONCURRENCY,
+                "Invalid prefetch concurrency override; using default"
+            );
+            DEFAULT_PREFETCH_CONCURRENCY
+        }
+    }
+}
+
+fn parse_prefetch_concurrency_value(raw: &str) -> Option<usize> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let parsed = trimmed.parse::<usize>().ok()?;
+    if parsed == 0 {
+        return None;
+    }
+
+    Some(parsed.min(MAX_PREFETCH_CONCURRENCY))
+}
+
+fn run_parallel_sparse_index_lookup(
+    candidates: &[PublishPrefetchCandidate],
+    concurrency: usize,
+) -> Vec<PrefetchPackageLookupResult> {
+    if candidates.is_empty() {
+        return Vec::new();
+    }
+
+    let http_client = match reqwest::blocking::Client::builder()
+        .timeout(PREFETCH_HTTP_TIMEOUT)
+        .build()
+    {
+        Ok(client) => client,
+        Err(error) => {
+            return candidates
+                .iter()
+                .map(|candidate| {
+                    PrefetchPackageLookupResult::unknown(
+                        candidate.name.clone(),
+                        None,
+                        format!("failed to initialize HTTP client: {error}"),
+                    )
+                })
+                .collect();
+        }
+    };
+
+    let worker_count = concurrency
+        .clamp(1, MAX_PREFETCH_CONCURRENCY)
+        .min(candidates.len());
+    let queue = Arc::new(Mutex::new(VecDeque::from(candidates.to_vec())));
+
+    let joined_worker_results = thread::scope(|scope| {
+        let mut handles = Vec::with_capacity(worker_count);
+        for _ in 0..worker_count {
+            let worker_queue = Arc::clone(&queue);
+            let worker_client = http_client.clone();
+            handles.push(scope.spawn(move || prefetch_worker_loop(worker_queue, worker_client)));
+        }
+
+        handles
+            .into_iter()
+            .map(|handle| handle.join())
+            .collect::<Vec<_>>()
+    });
+
+    let mut lookup_results = Vec::with_capacity(candidates.len());
+    for joined_result in joined_worker_results {
+        match joined_result {
+            Ok(worker_results) => lookup_results.extend(worker_results),
+            Err(_) => lookup_results.push(PrefetchPackageLookupResult::unknown(
+                "<worker>".to_string(),
+                None,
+                "prefetch worker thread panicked".to_string(),
+            )),
+        }
+    }
+
+    let seen_packages = lookup_results
+        .iter()
+        .map(|result| result.package.clone())
+        .collect::<BTreeSet<_>>();
+    for candidate in candidates {
+        if !seen_packages.contains(&candidate.name) {
+            lookup_results.push(PrefetchPackageLookupResult::unknown(
+                candidate.name.clone(),
+                None,
+                "prefetch lookup did not complete".to_string(),
+            ));
+        }
+    }
+
+    lookup_results
+}
+
+fn prefetch_worker_loop(
+    queue: Arc<Mutex<VecDeque<PublishPrefetchCandidate>>>,
+    client: reqwest::blocking::Client,
+) -> Vec<PrefetchPackageLookupResult> {
+    let mut results = Vec::new();
+
+    loop {
+        let next_candidate = match queue.lock() {
+            Ok(mut guard) => guard.pop_front(),
+            Err(_) => None,
+        };
+        let Some(candidate) = next_candidate else {
+            break;
+        };
+
+        results.push(lookup_sparse_index_version(&client, &candidate));
+    }
+
+    results
+}
+
+fn lookup_sparse_index_version(
+    client: &reqwest::blocking::Client,
+    candidate: &PublishPrefetchCandidate,
+) -> PrefetchPackageLookupResult {
+    let path = sparse_index_path_for_crate(&candidate.name);
+    let request_url = format!("{CRATES_IO_SPARSE_INDEX_BASE_URL}/{path}");
+
+    let response = match client.get(&request_url).send() {
+        Ok(response) => response,
+        Err(error) => {
+            return PrefetchPackageLookupResult::unknown(
+                candidate.name.clone(),
+                None,
+                format!("sparse index request failed: {error}"),
+            )
+        }
+    };
+
+    let status = response.status();
+    if status == StatusCode::NOT_FOUND {
+        return PrefetchPackageLookupResult::not_published(candidate.name.clone());
+    }
+    if !status.is_success() {
+        return PrefetchPackageLookupResult::unknown(
+            candidate.name.clone(),
+            Some(status.as_u16()),
+            format!("sparse index returned unexpected status {status}"),
+        );
+    }
+
+    let body = match response.text() {
+        Ok(body) => body,
+        Err(error) => {
+            return PrefetchPackageLookupResult::unknown(
+                candidate.name.clone(),
+                None,
+                format!("failed to read sparse index response body: {error}"),
+            )
+        }
+    };
+
+    match sparse_index_has_version(&body, &candidate.version) {
+        Ok(true) => PrefetchPackageLookupResult::already_published(candidate.name.clone()),
+        Ok(false) => PrefetchPackageLookupResult::not_published(candidate.name.clone()),
+        Err(error) => PrefetchPackageLookupResult::unknown(
+            candidate.name.clone(),
+            None,
+            format!("failed to parse sparse index record: {error}"),
+        ),
+    }
+}
+
+fn sparse_index_has_version(
+    index_body: &str,
+    version: &Version,
+) -> std::result::Result<bool, serde_json::Error> {
+    let target_version = version.to_string();
+    for line in index_body.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let entry: SparseIndexEntry = serde_json::from_str(line)?;
+        if entry.vers == target_version {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+fn sparse_index_path_for_crate(crate_name: &str) -> String {
+    let normalized = crate_name.to_ascii_lowercase();
+    let char_count = normalized.chars().count();
+
+    match char_count {
+        1 => format!("1/{normalized}"),
+        2 => format!("2/{normalized}"),
+        3 => format!(
+            "3/{}/{}",
+            normalized.chars().next().unwrap_or('0'),
+            normalized
+        ),
+        _ => {
+            let prefix_a = normalized.chars().take(2).collect::<String>();
+            let prefix_b = normalized.chars().skip(2).take(2).collect::<String>();
+            format!("{prefix_a}/{prefix_b}/{normalized}")
+        }
+    }
+}
+
+fn merge_prefetch_lookup_results(
+    results: Vec<PrefetchPackageLookupResult>,
+) -> PublishPrefetchResult {
+    let mut confirmed_already_published = BTreeSet::new();
+    let mut lookup_errors = Vec::new();
+
+    for result in results {
+        match result.state {
+            PrefetchLookupState::AlreadyPublished => {
+                confirmed_already_published.insert(result.package);
+            }
+            PrefetchLookupState::NotPublished => {}
+            PrefetchLookupState::Unknown => lookup_errors.push(PrefetchLookupError {
+                package: result.package,
+                http_status: result.http_status,
+                error: result
+                    .error
+                    .unwrap_or_else(|| "unknown sparse index lookup error".to_string()),
+            }),
+        }
+    }
+
+    PublishPrefetchResult {
+        confirmed_already_published,
+        lookup_errors,
+    }
+}
+
 fn run_publish_command(package: &str, dry_run: bool, registry: Option<&str>) -> Result<Output> {
     let mut command = Command::new("cargo");
     command.arg("publish").arg("-p").arg(package);
@@ -332,7 +800,7 @@ fn classify_publish_failure(output: &Output) -> PublishFailureKind {
 
 #[cfg(test)]
 mod tests {
-    use std::process::Command;
+    use std::{collections::BTreeSet, process::Command};
 
     use super::*;
 
@@ -375,5 +843,85 @@ mod tests {
             classify_publish_failure(&output),
             PublishFailureKind::Other
         ));
+    }
+
+    #[test]
+    fn sparse_index_path_matches_registry_rules() {
+        assert_eq!(sparse_index_path_for_crate("a"), "1/a");
+        assert_eq!(sparse_index_path_for_crate("ab"), "2/ab");
+        assert_eq!(sparse_index_path_for_crate("abc"), "3/a/abc");
+        assert_eq!(sparse_index_path_for_crate("serde"), "se/rd/serde");
+        assert_eq!(sparse_index_path_for_crate("Serde"), "se/rd/serde");
+    }
+
+    #[test]
+    fn parse_prefetch_concurrency_value_accepts_and_clamps() {
+        assert_eq!(parse_prefetch_concurrency_value("1"), Some(1));
+        assert_eq!(parse_prefetch_concurrency_value("16"), Some(16));
+        assert_eq!(
+            parse_prefetch_concurrency_value("1024"),
+            Some(MAX_PREFETCH_CONCURRENCY)
+        );
+    }
+
+    #[test]
+    fn parse_prefetch_concurrency_value_rejects_invalid_values() {
+        assert_eq!(parse_prefetch_concurrency_value(""), None);
+        assert_eq!(parse_prefetch_concurrency_value("   "), None);
+        assert_eq!(parse_prefetch_concurrency_value("0"), None);
+        assert_eq!(parse_prefetch_concurrency_value("-1"), None);
+        assert_eq!(parse_prefetch_concurrency_value("invalid"), None);
+    }
+
+    #[test]
+    fn should_prefetch_only_for_default_or_crates_io_registry() {
+        assert!(should_prefetch_published_versions(None));
+        assert!(should_prefetch_published_versions(Some("crates-io")));
+        assert!(should_prefetch_published_versions(Some("CRATES-IO")));
+        assert!(!should_prefetch_published_versions(Some("internal")));
+    }
+
+    #[test]
+    fn sparse_index_has_version_finds_requested_version() {
+        let body = r#"
+{"name":"alpha","vers":"0.1.0"}
+{"name":"alpha","vers":"0.2.0"}
+"#;
+        let version = Version::new(0, 2, 0);
+        assert!(sparse_index_has_version(body, &version).unwrap());
+
+        let missing_version = Version::new(0, 3, 0);
+        assert!(!sparse_index_has_version(body, &missing_version).unwrap());
+    }
+
+    #[test]
+    fn sparse_index_has_version_reports_invalid_json_line() {
+        let body = r#"
+{"name":"alpha","vers":"0.1.0"}
+{invalid}
+"#;
+        let version = Version::new(0, 2, 0);
+        assert!(sparse_index_has_version(body, &version).is_err());
+    }
+
+    #[test]
+    fn merge_prefetch_lookup_results_tracks_already_published_and_errors() {
+        let result = merge_prefetch_lookup_results(vec![
+            PrefetchPackageLookupResult::already_published("alpha".to_string()),
+            PrefetchPackageLookupResult::not_published("beta".to_string()),
+            PrefetchPackageLookupResult::unknown(
+                "gamma".to_string(),
+                Some(503),
+                "service unavailable".to_string(),
+            ),
+        ]);
+
+        assert_eq!(
+            result.confirmed_already_published,
+            BTreeSet::from(["alpha".to_string()])
+        );
+        assert_eq!(result.lookup_errors.len(), 1);
+        assert_eq!(result.lookup_errors[0].package, "gamma");
+        assert_eq!(result.lookup_errors[0].http_status, Some(503));
     }
 }

--- a/docs/project-cargo-mono.md
+++ b/docs/project-cargo-mono.md
@@ -81,6 +81,9 @@ CLI entrypoint:
 - Log color override:
 : `CARGO_MONO_LOG_COLOR=always|auto|never` controls ANSI color (`always` default).
 : If `CARGO_MONO_LOG_COLOR` is unset or `auto`, `NO_COLOR` disables color; otherwise color remains enabled.
+- Publish prefetch concurrency override:
+: `CARGO_MONO_PUBLISH_PREFETCH_CONCURRENCY=<positive-int>` controls crates.io sparse index prefetch concurrency.
+: Default is `16`, maximum is `64`; invalid values fall back to default with a warning log.
 
 Target selection contract (`bump`, `publish`):
 - `--all` default when no target selector is provided.
@@ -123,6 +126,10 @@ Target selection contract (`bump`, `publish`):
 - Requires clean working tree unless `--allow-dirty` is provided.
 - Enforces clean-tree policy in preflight before workspace metadata loading to avoid false positives from metadata side effects (for example untracked `Cargo.lock` generation).
 - Default registry is crates.io; `--registry <name>` overrides.
+- For default crates.io (or `--registry crates-io`), the command prefetches selected crate versions from `https://index.crates.io/` before entering the publish loop.
+- Prefetch uses Cargo sparse-index path rules and marks matching `(crate, version)` pairs as already published.
+- Prefetch lookup failures are fail-open: failures are logged and affected crates continue through normal `cargo publish` execution.
+- For non-crates.io registry names, prefetch is skipped and publish behavior falls back to direct `cargo publish` attempts.
 - Skips non-publishable crates and already-published versions with explicit summary output.
 - Publishes in workspace dependency topological order.
 - Retries index-propagation-related failures with bounded backoff.
@@ -157,6 +164,7 @@ Operational expectations:
 - Log package selection decisions and skip reasons.
 - Log bump mutation summary (updated manifests, commit id, tags).
 - Log publish attempt lifecycle including retries and terminal outcome.
+- Log publish prefetch lifecycle (start/completion/lookup error) with package and error context.
 - Use Rust `tracing` for all operational logs.
 - Keep ANSI-colored human logs enabled by default with documented opt-out controls.
 


### PR DESCRIPTION
## Summary
- prefetch crates.io sparse index entries before publish attempts
- skip confirmed already-published crate versions without invoking `cargo publish`
- add fail-open lookup behavior and prefetch lifecycle logs
- add `CARGO_MONO_PUBLISH_PREFETCH_CONCURRENCY` (default 16, max 64)
- update cargo-mono project docs for publish prefetch behavior

## Testing
- cargo fmt --all
- cargo test