### PR TITLE
chore(cargo-mono): bump crate version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-mono"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "assert_cmd",
  "cargo_metadata",

--- a/crates/cargo-mono/Cargo.toml
+++ b/crates/cargo-mono/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-mono"
-version = "0.1.0"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 description = "Cargo subcommand for Rust monorepo management"


### PR DESCRIPTION
## Summary
- bump `cargo-mono` crate version to `0.5.0` (minor +1 over the currently published `0.4.1`)
- sync the `cargo-mono` package entry in `Cargo.lock` to `0.5.0`

## Testing
- cargo test -p cargo-mono