### PR TITLE
ci(release): add auto-publish workflow

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -44,4 +44,4 @@ jobs:
       - name: Publish workspace crates
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo run -p cargo-mono -- publish --no-verify
+        run: cargo run -p cargo-mono -- publish

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,7 +201,7 @@ Release automation baseline:
 - `auto-publish` is defined in `.github/workflows/auto-publish.yml`.
 - Trigger contract: runs on `push` to `main` and supports `workflow_dispatch`.
 - Branch guard contract: publish job runs only when `github.ref == 'refs/heads/main'`.
-- Publish command contract: `cargo run -p cargo-mono -- publish --no-verify`.
+- Publish command contract: `cargo run -p cargo-mono -- publish`.
 - Required secret contract: `CARGO_REGISTRY_TOKEN`.
 
 ### Documentation Lifecycle Rules

--- a/docs/project-cargo-mono.md
+++ b/docs/project-cargo-mono.md
@@ -138,7 +138,7 @@ Target selection contract (`bump`, `publish`):
 - GitHub Actions auto-publish integration is defined in `.github/workflows/auto-publish.yml`.
 - Auto-publish triggers on `push` to `main` and `workflow_dispatch`, and enforces a `main` branch guard at job runtime.
 - Auto-publish requires `CARGO_REGISTRY_TOKEN` and maps it to Cargo registry authentication.
-- Auto-publish executes `cargo run -p cargo-mono -- publish --no-verify` for workspace-wide publish orchestration.
+- Auto-publish executes `cargo run -p cargo-mono -- publish` for workspace-wide publish orchestration.
 
 ## Storage
 - No project-owned persistent storage.

--- a/docs/project-nodeup.md
+++ b/docs/project-nodeup.md
@@ -314,7 +314,7 @@ Planned commands:
 - Workspace validation: `cargo test`
 
 Release automation integration:
-- `.github/workflows/auto-publish.yml` runs workspace publish orchestration through `cargo run -p cargo-mono -- publish --no-verify`.
+- `.github/workflows/auto-publish.yml` runs workspace publish orchestration through `cargo run -p cargo-mono -- publish`.
 - The workflow triggers on `push` to `main` and `workflow_dispatch`, with a `main`-branch runtime guard.
 - Nodeup is included automatically when selected by `cargo-mono publish` as a publishable crate version.
 


### PR DESCRIPTION
## Summary
- add a new `Auto Publish` workflow at `.github/workflows/auto-publish.yml`
- trigger on `push` to `main` and `workflow_dispatch` with a `main` branch runtime guard
- publish workspace crates using `cargo run -p cargo-mono -- publish --no-verify` with required `CARGO_REGISTRY_TOKEN`
- update `AGENTS.md`, `docs/project-cargo-mono.md`, and `docs/project-nodeup.md` to document the release automation contract

## Validation
- workflow and docs changes only
- no Rust/frontend runtime code changed, so no additional local test runs were required