### PR TITLE
docs(public-docs): promote cargo-mono as top-level guide

### DIFF
--- a/apps/public-docs/README.md
+++ b/apps/public-docs/README.md
@@ -22,4 +22,5 @@ pnpm --filter public-docs test
 - `documentation-lifecycle.mdx`: Rules for updating internal and public docs together.
 - `devmon.mdx`: Public project guide for `devmon`.
 - `nodeup.mdx`: Public project guide for `nodeup`.
+- `cargo-mono.mdx`: Public project guide for `cargo-mono`.
 - `derun.mdx`: Public project guide for `derun`.

--- a/apps/public-docs/cargo-mono.mdx
+++ b/apps/public-docs/cargo-mono.mdx
@@ -1,0 +1,48 @@
+# cargo-mono
+
+`cargo-mono` is a Cargo external subcommand (`cargo mono`) for monorepo-scale Rust workspace operations.
+
+## Why use cargo-mono
+
+- Discover and scope affected crates with deterministic workspace analysis.
+- Coordinate safe version bumps across internal dependencies.
+- Run release and publish workflows with structured operator-friendly output.
+
+## Core capabilities
+
+- Workspace discovery and reporting: `list`
+- Git-aware impact analysis: `changed`
+- Version orchestration and release tagging: `bump`
+- Dependency-aware publish flow: `publish`
+- Stable output contract: `--output human|json`
+
+## Common workflows
+
+List publishable workspace crates:
+
+```bash
+cargo mono list
+```
+
+Find crates changed from the default base ref:
+
+```bash
+cargo mono changed
+```
+
+Bump changed crates with dependent patch propagation:
+
+```bash
+cargo mono bump --changed --level patch --bump-dependents
+```
+
+Dry-run publish for selected changed crates:
+
+```bash
+cargo mono publish --changed --dry-run
+```
+
+## Related pages
+
+- [Projects Overview](projects-overview)
+- [Getting Started](getting-started)

--- a/apps/public-docs/docs.json
+++ b/apps/public-docs/docs.json
@@ -38,6 +38,15 @@
         ]
       },
       {
+        "tab": "Cargo Mono",
+        "groups": [
+          {
+            "group": "Rust Monorepo Tooling",
+            "pages": ["cargo-mono"]
+          }
+        ]
+      },
+      {
         "tab": "Derun",
         "groups": [
           {

--- a/apps/public-docs/index.mdx
+++ b/apps/public-docs/index.mdx
@@ -9,7 +9,7 @@ This site provides a curated, user-facing layer of documentation that complement
 - Read [Getting Started](getting-started) for local setup and editing workflow.
 - See [Projects Overview](projects-overview) for the current public project catalog.
 - Review [Documentation Lifecycle](documentation-lifecycle) for update rules between `docs/` and `apps/public-docs`.
-- Open [Devmon](devmon), [Nodeup](nodeup), and [Derun](derun) from the top navigation for dedicated project guides.
+- Open [Devmon](devmon), [Nodeup](nodeup), [Cargo Mono](cargo-mono), and [Derun](derun) from the top navigation for dedicated project guides.
 
 ## Scope
 

--- a/apps/public-docs/projects-overview.mdx
+++ b/apps/public-docs/projects-overview.mdx
@@ -4,7 +4,7 @@ This page provides a high-level public catalog of projects in the Delino OSS mon
 
 ## Active Projects
 
-- `cargo-mono`: Cargo subcommand tooling for Rust monorepo workflows.
+- [`cargo-mono`](cargo-mono): Cargo subcommand tooling for Rust monorepo workflows.
 - [`nodeup`](nodeup): Rust-based Node.js runtime manager.
 - [`derun`](derun): Terminal-fidelity run execution and MCP bridge tool.
 - [`devmon`](devmon): Automation daemon with menu bar controls.

--- a/docs/project-public-docs.md
+++ b/docs/project-public-docs.md
@@ -51,6 +51,7 @@ enum PublicDocsPageId {
   DocumentationLifecycle = "documentation-lifecycle",
   Devmon = "devmon",
   Nodeup = "nodeup",
+  CargoMono = "cargo-mono",
   Derun = "derun",
 }
 ```
@@ -61,9 +62,10 @@ Navigation contract:
 - Tab `Home` must include:
 : Group `Get Started` with `index` and `getting-started`.
 : Group `Reference` with `projects-overview` and `documentation-lifecycle`.
-- Tabs `Devmon`, `Nodeup`, and `Derun` must each be present as top-level tabs.
+- Tabs `Devmon`, `Nodeup`, `Cargo Mono`, and `Derun` must each be present as top-level tabs.
 - Tab `Devmon` must include page `devmon`.
 - Tab `Nodeup` must include page `nodeup`.
+- Tab `Cargo Mono` must include page `cargo-mono`.
 - Tab `Derun` must include page `derun`.
 
 Dev preview port contract:


### PR DESCRIPTION
## Summary
- add a dedicated `cargo-mono` public guide page
- promote `cargo-mono` to a top-level Mintlify tab (`Cargo Mono`)
- sync related public docs pages and public-docs contract docs

## Testing
- pnpm test (apps/public-docs)