### PR TITLE
fix(nodeup): include cache/config roots in show home human output

### DIFF
--- a/crates/nodeup/src/commands/show.rs
+++ b/crates/nodeup/src/commands/show.rs
@@ -87,7 +87,10 @@ fn show_home(output: OutputFormat, app: &NodeupApp) -> Result<i32> {
         cache_root: app.paths.cache_root.to_string_lossy().to_string(),
         config_root: app.paths.config_root.to_string_lossy().to_string(),
     };
-    let human = format!("nodeup home: {}", response.data_root);
+    let human = format!(
+        "nodeup home:\ndata_root: {}\ncache_root: {}\nconfig_root: {}",
+        response.data_root, response.cache_root, response.config_root
+    );
 
     print_output(output, &human, &response)?;
     Ok(0)

--- a/crates/nodeup/tests/cli.rs
+++ b/crates/nodeup/tests/cli.rs
@@ -1090,6 +1090,29 @@ fn management_human_default_logging_emits_info_logs_without_rust_log_env() {
 
 #[test]
 #[serial]
+fn show_home_human_output_includes_all_roots() {
+    let env = TestEnv::new();
+
+    let output = env
+        .command()
+        .args(["show", "home"])
+        .output()
+        .expect("show home");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("nodeup home:"));
+    assert!(stdout.contains(&format!("data_root: {}", env.data_root.to_string_lossy())));
+    assert!(stdout.contains(&format!("cache_root: {}", env.cache_root.to_string_lossy())));
+    assert!(stdout.contains(&format!(
+        "config_root: {}",
+        env.config_root.to_string_lossy()
+    )));
+}
+
+#[test]
+#[serial]
 fn json_show_active_runtime_failure_emits_stderr_error_envelope() {
     let env = TestEnv::new();
 


### PR DESCRIPTION
## Summary
- update `nodeup show home` human output to include `data_root`, `cache_root`, and `config_root`
- keep JSON output unchanged
- add a regression test to verify human output includes all three root paths

## Testing
- cargo test -p nodeup show_home_human_output_includes_all_roots
- cargo test -p nodeup json_show_home_remains_parseable_without_rust_log_env
- cargo test -p nodeup management_human_default_logging_emits_info_logs_without_rust_log_env
- cargo test

Closes #119