### PR TITLE
fix(nodeup): keep default introspection available offline

### DIFF
--- a/crates/nodeup/src/commands/default_cmd.rs
+++ b/crates/nodeup/src/commands/default_cmd.rs
@@ -1,15 +1,35 @@
 use serde::Serialize;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::{
-    cli::OutputFormat, commands::print_output, errors::Result, resolver::ResolvedRuntimeTarget,
-    types::RuntimeSelectorSource, NodeupApp,
+    cli::OutputFormat,
+    commands::print_output,
+    errors::{ErrorKind, NodeupError, Result},
+    resolver::ResolvedRuntimeTarget,
+    types::RuntimeSelectorSource,
+    NodeupApp,
 };
+
+#[derive(Debug, Serialize)]
+struct DefaultResolutionError {
+    kind: ErrorKind,
+    message: String,
+}
 
 #[derive(Debug, Serialize)]
 struct DefaultResponse {
     default_selector: Option<String>,
     resolved_runtime: Option<String>,
+    resolution_error: Option<DefaultResolutionError>,
+}
+
+impl From<NodeupError> for DefaultResolutionError {
+    fn from(value: NodeupError) -> Self {
+        Self {
+            kind: value.kind,
+            message: value.message,
+        }
+    }
 }
 
 pub fn execute(runtime: Option<&str>, output: OutputFormat, app: &NodeupApp) -> Result<i32> {
@@ -37,6 +57,7 @@ pub fn execute(runtime: Option<&str>, output: OutputFormat, app: &NodeupApp) -> 
         let response = DefaultResponse {
             default_selector: Some(runtime_selector.to_string()),
             resolved_runtime: Some(resolved.runtime_id()),
+            resolution_error: None,
         };
         let human = format!(
             "Default runtime set to {}",
@@ -47,22 +68,41 @@ pub fn execute(runtime: Option<&str>, output: OutputFormat, app: &NodeupApp) -> 
     }
 
     let settings = app.store.load_settings()?;
-    let resolved_runtime = if let Some(selector) = settings.default_selector.as_ref() {
-        Some(
-            app.resolver
-                .resolve_selector_with_source(selector, RuntimeSelectorSource::Default)?
-                .runtime_id(),
-        )
-    } else {
-        None
-    };
+    let (resolved_runtime, resolution_error) =
+        if let Some(selector) = settings.default_selector.as_ref() {
+            match app
+                .resolver
+                .resolve_selector_with_source(selector, RuntimeSelectorSource::Default)
+            {
+                Ok(resolved) => (Some(resolved.runtime_id()), None),
+                Err(error) => {
+                    warn!(
+                        command_path = "nodeup.default",
+                        selector = %selector,
+                        error_kind = error_kind_key(error.kind),
+                        error = %error.message,
+                        outcome = "unresolved",
+                        "Default selector resolution failed during introspection"
+                    );
+                    (None, Some(DefaultResolutionError::from(error)))
+                }
+            }
+        } else {
+            (None, None)
+        };
 
+    let default_selector = settings.default_selector;
     let response = DefaultResponse {
-        default_selector: settings.default_selector,
+        default_selector: default_selector.clone(),
         resolved_runtime,
+        resolution_error,
     };
-    let human = if let Some(default_selector) = response.default_selector.as_ref() {
-        format!("Default runtime: {default_selector}")
+    let human = if let Some(selector) = default_selector.as_ref() {
+        if response.resolution_error.is_some() {
+            format!("Default runtime: {selector} (resolution unavailable)")
+        } else {
+            format!("Default runtime: {selector}")
+        }
     } else {
         "Default runtime is not set".to_string()
     };
@@ -70,4 +110,16 @@ pub fn execute(runtime: Option<&str>, output: OutputFormat, app: &NodeupApp) -> 
     print_output(output, &human, &response)?;
 
     Ok(0)
+}
+
+fn error_kind_key(kind: ErrorKind) -> &'static str {
+    match kind {
+        ErrorKind::Internal => "internal",
+        ErrorKind::InvalidInput => "invalid-input",
+        ErrorKind::UnsupportedPlatform => "unsupported-platform",
+        ErrorKind::Network => "network",
+        ErrorKind::NotFound => "not-found",
+        ErrorKind::Conflict => "conflict",
+        ErrorKind::NotImplemented => "not-implemented",
+    }
 }

--- a/crates/nodeup/tests/cli.rs
+++ b/crates/nodeup/tests/cli.rs
@@ -929,6 +929,119 @@ fn default_override_show_precedence() {
 
 #[test]
 #[serial]
+fn default_json_returns_selector_when_channel_resolution_is_offline() {
+    let env = TestEnv::new();
+    let settings_file = env.config_root.join("settings.toml");
+    fs::write(
+        &settings_file,
+        r#"schema_version = 1
+default_selector = "lts"
+tracked_selectors = ["lts"]
+
+[linked_runtimes]
+"#,
+    )
+    .unwrap();
+
+    let output = env
+        .command()
+        .env("NODEUP_INDEX_URL", "http://127.0.0.1:9/index.json")
+        .args(["--output", "json", "default"])
+        .output()
+        .expect("default --output json with offline channel selector");
+
+    assert!(output.status.success());
+    let payload: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(payload["default_selector"], "lts");
+    assert!(payload["resolved_runtime"].is_null());
+    assert_eq!(payload["resolution_error"]["kind"], "network");
+}
+
+#[test]
+#[serial]
+fn default_json_returns_selector_when_default_selector_is_invalid() {
+    let env = TestEnv::new();
+    let settings_file = env.config_root.join("settings.toml");
+    fs::write(
+        &settings_file,
+        r#"schema_version = 1
+default_selector = "invalid selector"
+tracked_selectors = ["invalid selector"]
+
+[linked_runtimes]
+"#,
+    )
+    .unwrap();
+
+    let output = env
+        .command()
+        .args(["--output", "json", "default"])
+        .output()
+        .expect("default --output json with invalid selector");
+
+    assert!(output.status.success());
+    let payload: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(payload["default_selector"], "invalid selector");
+    assert!(payload["resolved_runtime"].is_null());
+    assert_eq!(payload["resolution_error"]["kind"], "invalid-input");
+}
+
+#[test]
+#[serial]
+fn default_json_resolved_path_keeps_resolution_error_null() {
+    let env = TestEnv::new();
+    let settings_file = env.config_root.join("settings.toml");
+    fs::write(
+        &settings_file,
+        r#"schema_version = 1
+default_selector = "22.1.0"
+tracked_selectors = ["22.1.0"]
+
+[linked_runtimes]
+"#,
+    )
+    .unwrap();
+
+    let output = env
+        .command()
+        .args(["--output", "json", "default"])
+        .output()
+        .expect("default --output json with resolvable selector");
+
+    assert!(output.status.success());
+    let payload: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(payload["default_selector"], "22.1.0");
+    assert_eq!(payload["resolved_runtime"], "v22.1.0");
+    assert!(payload["resolution_error"].is_null());
+}
+
+#[test]
+#[serial]
+fn default_human_unresolved_still_prints_selector() {
+    let env = TestEnv::new();
+    let settings_file = env.config_root.join("settings.toml");
+    fs::write(
+        &settings_file,
+        r#"schema_version = 1
+default_selector = "lts"
+tracked_selectors = ["lts"]
+
+[linked_runtimes]
+"#,
+    )
+    .unwrap();
+
+    env.command()
+        .env("NODEUP_INDEX_URL", "http://127.0.0.1:9/index.json")
+        .arg("default")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Default runtime: lts"))
+        .stdout(predicates::str::contains("resolution unavailable"));
+}
+
+#[test]
+#[serial]
 fn show_active_runtime_fails_when_linked_runtime_path_is_deleted() {
     let env = TestEnv::new();
     let runtime_dir = env.root.join("linked-runtime-deleted");

--- a/docs/project-nodeup.md
+++ b/docs/project-nodeup.md
@@ -175,7 +175,11 @@ Subcommand contracts:
 : Status field (`--output json`): `linked`.
 - `nodeup default [runtime]`
 : With `runtime`: resolves selector, installs if it resolves to a version and is missing, saves selector as global default, and tracks selector.
-: Without `runtime`: returns current default selector and resolved runtime (if configured).
+: Without `runtime`: returns current default selector and resolved runtime when resolution succeeds.
+: Without `runtime`: when selector resolution fails, command still succeeds and returns persisted selector state with `resolved_runtime: null`.
+: JSON output includes `resolution_error`:
+: `null` when resolution succeeds or no default selector is configured.
+: object with `kind` and `message` when resolution fails during introspection.
 - `nodeup show active-runtime`
 : Output: resolved runtime (`runtime`), selection source (`explicit|override|default`), and canonical selector.
 : Failure: returns deterministic not-found error when neither override nor default selector exists.


### PR DESCRIPTION
## Summary
- keep `nodeup default` introspection successful even when selector resolution fails
- add `resolution_error` to default introspection JSON output for deterministic machine parsing
- add regression tests for offline channel resolution, invalid selector fallback, resolved path, and human output hint
- update `docs/project-nodeup.md` contract for the new behavior

## Validation
- cargo test -p nodeup --test cli default_
- cargo test

Fixes #84