### PR TITLE
chore(serde-lite-derive): add docs and initial crate scaffolding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@
 - `docs/project-thenv.md`: Secure `.env` sharing system (CLI + Server + Web).
 - `docs/project-devmon.md`: Go automation daemon with macOS menu bar-managed lifecycle controls.
 - `docs/project-public-docs.md`: Mintlify-based public documentation app.
+- `docs/project-serde-lite-derive.md`: Size-first serde derive scaffolding contracts (core + proc-macro split).
 - `.agents/skills/gh-pr-codex-review-loop`: Skill for iteratively applying PR feedback until Codex leaves a `:+1:` reaction, with Node.js helpers for approval checks and feedback aggregation (default actor set includes `chatgpt-codex-connector[bot]`).
 
 ### Project Identifier Contract
@@ -60,6 +61,7 @@ enum ProjectId {
   DevkitCommitTracker = "devkit-commit-tracker",
   DevkitRemoteFilePicker = "devkit-remote-file-picker",
   Thenv = "thenv",
+  SerdeLiteDerive = "serde-lite-derive",
   PublicDocs = "public-docs",
 }
 ```
@@ -75,6 +77,7 @@ enum ProjectId {
 - `devkit-commit-tracker` -> `apps/devkit/src/apps/commit-tracker`, `servers/commit-tracker`, `cmds/commit-tracker`
 - `devkit-remote-file-picker` -> `apps/devkit/src/apps/remote-file-picker`
 - `thenv` -> `cmds/thenv`, `servers/thenv`, `apps/devkit/src/apps/thenv`
+- `serde-lite-derive` -> `crates/serde-lite-derive`, `crates/serde-lite-derive-macros`
 - `public-docs` -> `apps/public-docs`
 
 ### Devkit Mini-App Identifier Contract
@@ -128,6 +131,20 @@ enum ThenvComponent {
 - `Cli` -> `cmds/thenv`
 - `Server` -> `servers/thenv`
 - `WebConsole` -> `apps/devkit/src/apps/thenv`
+
+### Serde Lite Derive Component Contract
+
+`serde-lite-derive` is a two-component project with fixed mapping:
+
+```ts
+enum SerdeLiteDeriveComponent {
+  Core = "core",
+  Macros = "macros",
+}
+```
+
+- `Core` -> `crates/serde-lite-derive`
+- `Macros` -> `crates/serde-lite-derive-macros`
 
 ### Documentation-First Policy
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1560,6 +1560,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-lite-derive"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde-lite-derive-macros",
+]
+
+[[package]]
+name = "serde-lite-derive-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ resolver = "2"
 members = [
     "crates/cargo-mono",
     "crates/nodeup",
+    "crates/serde-lite-derive",
+    "crates/serde-lite-derive-macros",
 ]
 
 # Release profile optimizations

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -9,12 +9,17 @@
 
 - `crates/cargo-mono`: Cargo-based Rust monorepo management CLI.
 - `crates/nodeup`: Rust-based Node.js version manager.
+- `crates/serde-lite-derive`: Size-first serde runtime-facing core crate.
+- `crates/serde-lite-derive-macros`: Proc-macro companion crate for serde-lite-derive.
 
 ### Rust Workspace Rules
 
 - Add new crates as explicit workspace members in root `Cargo.toml`.
 - Keep crate naming aligned with project IDs when possible.
 - Document CLI behavior contracts in `docs/project-<id>.md` before large implementation changes.
+- For new package scaffolding, default `publish = false` until publish contracts are explicitly approved.
+- Prefer minimal default features and keep optional capabilities opt-in for size-sensitive crates.
+- Keep proc-macro crates and runtime crates separated by explicit crate boundaries.
 
 ### nodeup-Specific Rules
 
@@ -27,6 +32,12 @@
 - Keep command identifiers stable and documented in `docs/project-cargo-mono.md`.
 - Preserve `cargo mono` subcommand compatibility (`cargo-mono` binary naming contract).
 - Ensure release automation (`bump`, `publish`) logs include structured operational context.
+
+### serde-lite-derive-Specific Rules
+
+- Keep `serde-lite-derive` as the runtime-facing crate and `serde-lite-derive-macros` as the proc-macro crate.
+- Keep binary-size-first defaults: minimal default features and no convenience dependencies by default.
+- Do not stabilize public derive macro identifiers before they are documented in `docs/project-serde-lite-derive.md`.
 
 ### Testing and Validation
 

--- a/crates/serde-lite-derive-macros/Cargo.toml
+++ b/crates/serde-lite-derive-macros/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "serde-lite-derive-macros"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Proc-macro scaffold crate for serde-lite-derive"
+publish = false
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.94"
+quote = "1.0.39"
+syn = { version = "2.0.100", features = ["full"] }

--- a/crates/serde-lite-derive-macros/src/lib.rs
+++ b/crates/serde-lite-derive-macros/src/lib.rs
@@ -1,0 +1,4 @@
+#![forbid(unsafe_code)]
+
+//! Proc-macro scaffolding crate for `serde-lite-derive`.
+//! Public derive macro identifiers are intentionally not stabilized yet.

--- a/crates/serde-lite-derive/Cargo.toml
+++ b/crates/serde-lite-derive/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "serde-lite-derive"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Size-first serde integration scaffold with optional derive support"
+publish = false
+
+[features]
+default = ["std"]
+std = ["serde/std"]
+derive = ["dep:serde-lite-derive-macros"]
+
+[dependencies]
+serde = { version = "1.0.219", default-features = false }
+serde-lite-derive-macros = { version = "0.1.0", path = "../serde-lite-derive-macros", optional = true }

--- a/crates/serde-lite-derive/src/lib.rs
+++ b/crates/serde-lite-derive/src/lib.rs
@@ -1,0 +1,7 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![forbid(unsafe_code)]
+
+//! Size-first scaffolding crate for future serde derive integration.
+//! Public derive macro identifiers are intentionally not stabilized yet.
+
+pub use serde;

--- a/docs/project-serde-lite-derive.md
+++ b/docs/project-serde-lite-derive.md
@@ -1,0 +1,103 @@
+# Project: serde-lite-derive
+
+## Goal
+`serde-lite-derive` provides a size-first serde integration scaffold split into runtime and proc-macro crates.
+The initial goal is to reduce final binary size even when it means giving up runtime performance optimizations.
+
+## Path
+- `crates/serde-lite-derive`
+- `crates/serde-lite-derive-macros`
+
+## Runtime and Language
+- Rust library crate (`serde-lite-derive`)
+- Rust proc-macro crate (`serde-lite-derive-macros`)
+
+## Users
+- Rust library maintainers who prioritize binary-size footprint
+- Application developers who want opt-in derive support with minimal default surface area
+- Release operators preparing a future publishable serde-lite derive stack
+
+## In Scope
+- Two-crate project skeleton with explicit runtime/proc-macro boundaries.
+- Workspace membership and package metadata contracts.
+- Feature contracts for `std` and optional derive integration.
+- Documentation contracts for future derive API stabilization.
+
+## Out of Scope
+- Actual serde derive implementation logic.
+- Runtime performance tuning and benchmark optimization.
+- Stable public derive macro identifiers in this phase.
+- crates.io publication in this phase (`publish = false` baseline).
+
+## Architecture
+- `serde-lite-derive` is the runtime-facing crate.
+: It exposes a minimal serde-compatible dependency surface with `serde` default features disabled.
+: It keeps default features minimal (`std`) and reserves `derive` as opt-in.
+- `serde-lite-derive-macros` is the proc-macro crate.
+: It is isolated from runtime code and prepared for future derive expansion.
+: It exists as scaffolding only in the current phase and intentionally avoids stabilized macro contracts.
+- Cross-crate contract:
+: `serde-lite-derive` references `serde-lite-derive-macros` as an optional dependency through feature wiring.
+: Runtime and proc-macro concerns remain separated to preserve package boundaries.
+
+## Interfaces
+Canonical component identifiers:
+
+```ts
+enum SerdeLiteDeriveComponent {
+  Core = "core",
+  Macros = "macros",
+}
+```
+
+Canonical feature identifiers:
+
+```ts
+enum SerdeLiteDeriveFeature {
+  Std = "std",
+  Derive = "derive",
+}
+```
+
+Package and feature contract:
+- `serde-lite-derive` default features: `["std"]`.
+- `serde-lite-derive` feature `std` maps to `serde/std`.
+- `serde-lite-derive` feature `derive` maps to optional dependency `serde-lite-derive-macros`.
+- `serde-lite-derive-macros` is configured as `proc-macro = true`.
+- Public derive macro identifiers are intentionally not stabilized in this phase.
+
+## Storage
+- No project-owned persistent storage.
+- Uses standard Cargo workspace metadata and lockfile management.
+
+## Security
+- Keep proc-macro expansion boundaries explicit and isolated from runtime crate contracts.
+- Avoid introducing network access, secret handling, or implicit code generation side effects in scaffolding phase.
+- Keep publish disabled until API and release contracts are documented and reviewed.
+
+## Logging
+- This phase introduces no runtime logging surface because no runtime behavior is implemented.
+- Future operational logging requirements for build tooling or commands must use structured logging (`tracing`) and be documented before implementation.
+
+## Build and Test
+Planned validation commands for the scaffolding phase:
+- `cargo metadata`
+- `cargo check -p serde-lite-derive`
+- `cargo check -p serde-lite-derive-macros`
+- `cargo test`
+
+## Roadmap
+- Phase 1: Document-first skeleton with workspace wiring and minimal feature contracts.
+- Phase 2: Introduce derive macro design and stabilization plan.
+- Phase 3: Implement derive behavior and compatibility tests.
+- Phase 4: Evaluate publish readiness and lift `publish = false` when contracts are stable.
+
+## Open Questions
+- Which public derive macro identifiers should be stabilized first.
+- Whether no-std + alloc support should be introduced after std-first baseline.
+- Which generated-code policies best balance binary size and developer ergonomics.
+
+## References
+- `docs/project-template.md`
+- `AGENTS.md`
+- `crates/AGENTS.md`


### PR DESCRIPTION
## Summary
- add docs/project-serde-lite-derive.md with the initial project contracts
- update root and crates AGENTS policies for the new size-first serde-lite-derive project
- add workspace members and scaffold serde-lite-derive + serde-lite-derive-macros crates with publish = false

## Validation
- cargo metadata --no-deps
- cargo check -p serde-lite-derive
- cargo check -p serde-lite-derive-macros
- cargo test