### PR TITLE
docs(ttl): add v1 project and language contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,8 @@
 - `docs/project-cargo-mono.md`: Cargo subcommand for Rust monorepo management.
 - `docs/project-nodeup.md`: Rust-based Node.js version manager.
 - `docs/project-derun.md`: Go CLI for terminal-fidelity run execution and MCP output bridge access for AI.
+- `docs/project-ttl.md`: TTL language/compiler project contracts for incremental task execution on Go runtime foundations.
+- `docs/project-ttl-language.md`: TTL language syntax, type, invalidation, and Go code-generation contracts.
 - `docs/project-mpapp.md`: Expo React Native mobile app.
 - `docs/project-devkit.md`: Next.js 16 web micro-app platform.
 - `docs/project-devkit-commit-tracker.md`: Commit Tracker contracts (Web UI + API server + collector).
@@ -54,6 +56,7 @@ enum ProjectId {
   CargoMono = "cargo-mono",
   Nodeup = "nodeup",
   Derun = "derun",
+  Ttl = "ttl",
   Devmon = "devmon",
   Mpapp = "mpapp",
   Devkit = "devkit",
@@ -69,6 +72,7 @@ enum ProjectId {
 - `nodeup` -> `crates/nodeup`
 - `cargo-mono` -> `crates/cargo-mono`
 - `derun` -> `cmds/derun`
+- `ttl` -> `cmds/ttlc`
 - `devmon` -> `cmds/devmon`
 - `mpapp` -> `apps/mpapp`
 - `devkit` -> `apps/devkit`
@@ -141,6 +145,7 @@ enum ThenvComponent {
 - Reserve a unique `project-id`.
 - Create project path skeleton and add `.gitkeep` if implementation is not started.
 - Add `docs/project-<project-id>.md` using `docs/project-template.md`.
+- Documentation-only phase may mark canonical paths as `planned` before creating path skeletons; create the skeleton in the same change where runtime implementation begins.
 - Update root and domain `AGENTS.md` files when project ownership or contracts change.
 - Ensure path and naming contracts are consistent across docs and AGENTS rules.
 
@@ -208,6 +213,7 @@ Release automation baseline:
 
 - Every structural repository change must update relevant `docs/project-*.md` files in the same change set.
 - New project creation is blocked until its project document exists.
+- Documentation-only project onboarding may use `planned` paths, but runtime implementation must not begin before canonical paths are created and documented.
 - Repository-wide and domain rules must be maintained in the appropriate `AGENTS.md`.
 - When user-facing documentation content changes, update relevant pages in `apps/public-docs` in the same change set as needed.
 - Run `git commit` only after `git add`; once files are staged, create the commit without unnecessary delay.

--- a/cmds/AGENTS.md
+++ b/cmds/AGENTS.md
@@ -11,6 +11,7 @@
 - `cmds/devmon`: Go daemon CLI for recurring folder command automation.
 - `cmds/thenv`: Secure `.env` sharing CLI.
 - `cmds/commit-tracker`: Commit Tracker collector component.
+- `cmds/ttlc`: TTL compiler CLI for `.ttl` parsing/type-checking, Go code generation, and cache-aware task execution contracts.
 
 ### Command Component Contract
 
@@ -36,3 +37,5 @@
 - Update `docs/project-derun.md` whenever command shape or config contracts change.
 - Update `docs/project-thenv.md` whenever thenv CLI operations or trust boundaries change.
 - Update `docs/project-devkit-commit-tracker.md` whenever commit-tracker collector contracts change.
+- Update `docs/project-ttl.md` whenever TTL compiler command shape, cache backend, or runtime boundaries change.
+- Update `docs/project-ttl-language.md` whenever TTL syntax/type/invalidation/code-generation contracts change.

--- a/docs/project-ttl-language.md
+++ b/docs/project-ttl-language.md
@@ -1,0 +1,204 @@
+# Project: ttl-language
+
+## Goal
+This document defines the stable language and compiler contracts for `.ttl` sources.
+The design target is Go-like syntax plus ergonomic TurboTasks-style core types (`Vc`-centric) for incremental, cache-first, parallel task execution.
+
+## Path
+- Language spec document: `docs/project-ttl-language.md`
+- Compiler implementation target: `cmds/ttlc` (planned in v1 documentation phase)
+
+## Runtime and Language
+- Language surface: TTL (`.ttl`)
+- v1 compiler backend: generated Go source
+- v1 execution/caching backend: runtime APIs + SQLite cache
+
+## Users
+- Engineers authoring build/task pipelines in `.ttl`
+- Runtime/compiler maintainers implementing deterministic incremental execution
+
+## In Scope
+- Lexical and syntactic contracts for `.ttl`
+- Typed task declaration and core runtime types
+- Incremental dependency tracking (`read(vc)` contract)
+- Hash-based invalidation model
+- Go code generation contract
+- Runtime/caching schema-level contracts
+
+## Out of Scope
+- Full language grammar for every future feature
+- Alternative backend targets in v1
+- Language server protocol details
+- Remote/distributed scheduler protocol
+
+## Architecture
+Language-to-runtime architecture:
+- Source Layer: `.ttl` modules with Go-like declarations.
+- Semantic Layer: type checking and task graph extraction.
+- Lowering Layer: typed IR lowered to runtime API calls.
+- Runtime Layer: dependency tracking, scheduler, cache lookup/writeback.
+- Persistence Layer: SQLite metadata and optional blob storage.
+
+Compilation flow:
+1. Parse module declarations (`package`, `import`, `type`, `task func`, `func`).
+2. Resolve symbols and validate core type usage.
+3. Build dependency edges from `read(vc)` and task calls.
+4. Derive task/cache fingerprints.
+5. Emit Go source that invokes runtime task APIs.
+
+## Interfaces
+Canonical type and command identifiers:
+
+```ts
+enum TtlCompileTarget {
+  GoSource = "go-source",
+}
+
+enum TtlCacheBackend {
+  SQLite = "sqlite",
+}
+
+enum TtlCommand {
+  Build = "build",
+  Check = "check",
+  Explain = "explain",
+}
+
+enum TtlCoreType {
+  Vc = "vc",
+  ResolvedVc = "resolved-vc",
+  OperationVc = "operation-vc",
+  TransientValue = "transient-value",
+  State = "state",
+}
+```
+
+Core language contracts:
+- File extension is always `.ttl`.
+- Task declaration style is fixed to `task func`.
+- Base syntax intentionally tracks Go style (blocks, signatures, package/import model).
+- Every `task func` must return `Vc[T]`.
+- `read(vc)` establishes dependency tracking from current task to the referenced task/cell.
+
+v1 syntax examples:
+
+```ttl
+package build
+
+type Artifact struct {
+    Path string
+    Digest string
+}
+
+task func Build(target string) Vc[Artifact] {
+    src := read(ResolveSource(target))
+    digest := hash(src.Path, src.Digest)
+    return vc(Artifact{Path: src.Path, Digest: digest})
+}
+
+func Main(target string) {
+    val := read(Build(target))
+    print(val.Path)
+}
+```
+
+Generated Go shape contract (illustrative):
+
+```go
+func Build(target string) runtime.Vc[Artifact] {
+    return runtime.Task("Build", target, func(ctx runtime.TaskContext) (Artifact, error) {
+        src, err := runtime.Read(ctx, ResolveSource(target))
+        if err != nil {
+            return Artifact{}, err
+        }
+        digest := runtime.Hash(src.Path, src.Digest)
+        return Artifact{Path: src.Path, Digest: digest}, nil
+    })
+}
+```
+
+Invalidation contract:
+- Fingerprint inputs are mandatory and ordered:
+1. Input content hash
+2. Parameter hash
+3. Environment snapshot hash
+- Reuse occurs only when full fingerprint matches.
+- Any component mismatch triggers recomputation.
+
+Parallel execution contract:
+- Scheduler may execute tasks concurrently when no unresolved dependency edge exists.
+- Execution order is deterministic with respect to dependency constraints, not submission order.
+
+## Storage
+Cache backend is fixed to SQLite in v1.
+Minimum conceptual schema (field names are stable contract names):
+- `task_key`
+- `input_fingerprint`
+- `output_blob_ref`
+- `deps`
+- `metadata`
+
+Recommended conceptual tables:
+- `task_cache(task_key PRIMARY KEY, input_fingerprint, output_blob_ref, metadata_json, updated_at)`
+- `task_deps(task_key, dep_task_key)`
+- `cache_blobs(blob_ref PRIMARY KEY, codec, bytes, size_bytes)`
+
+## Security
+- Input file resolution must stay within configured workspace roots.
+- Cache metadata and blobs must not expose secret env values.
+- Corrupted cache records must fail closed (no unsafe partial decode).
+
+## Logging
+Compiler and runtime use `log/slog` with structured event records.
+Required fields:
+- `compile_stage`
+- `task_id`
+- `cache_key`
+- `cache_hit`
+- `invalidation_reason`
+- `worker_id`
+- `duration_ms`
+- `error_kind`
+
+Runtime task event baseline:
+- `task_scheduled`
+- `task_started`
+- `task_cache_hit`
+- `task_cache_miss`
+- `task_completed`
+- `task_failed`
+
+## Build and Test
+v1 implementation commands (applies when compiler/runtime code exists):
+- `go build ./cmds/ttlc/...`
+- `go test ./cmds/ttlc/...`
+
+Documentation acceptance checks:
+1. `task func` examples always return `Vc[T]`.
+2. `read(vc)` examples always imply dependency tracking.
+3. Hash invalidation explicitly includes input/parameter/environment components.
+4. Cache backend remains SQLite in all ttl contracts.
+5. Failure modes and observability fields remain explicit and stable.
+
+Failure mode contracts:
+- Circular dependency: fail with cycle diagnostics and no partial success state.
+- Cache corruption: emit `error_kind=cache_corruption`, invalidate row, recompute.
+- Type mismatch: fail during type-check or decode boundary with typed diagnostics.
+- Non-deterministic task warning: emit warning diagnostics when unstable outputs are detected.
+
+## Roadmap
+- Phase 1: Lock syntax + type contracts and ship Go emitter skeleton.
+- Phase 2: Complete scheduler/dependency tracking and SQLite persistence.
+- Phase 3: Improve diagnostics, performance, and cache lifecycle tooling.
+
+## Open Questions
+- Should future syntax include explicit task priority annotations?
+- Should environment snapshots be user-configurable by allowlist rules?
+- Should blob storage remain SQLite-only or move large payloads to file-backed blobs by default?
+
+## References
+- `docs/project-ttl.md`
+- `docs/project-template.md`
+- [turbo-tasks/lib.rs](https://github.com/vercel/next.js/blob/canary/turbopack/crates/turbo-tasks/src/lib.rs)
+- [turbo-tasks/vc/mod.rs](https://github.com/vercel/next.js/blob/canary/turbopack/crates/turbo-tasks/src/vc/mod.rs)
+- [turbo-tasks/value.rs](https://github.com/vercel/next.js/blob/canary/turbopack/crates/turbo-tasks/src/value.rs)

--- a/docs/project-ttl.md
+++ b/docs/project-ttl.md
@@ -1,0 +1,163 @@
+# Project: ttl
+
+## Goal
+`ttl` defines a new task language and toolchain for Go ecosystems inspired by TurboTasks-style execution.
+The project focuses on incremental computing, persistent caching, and parallel task scheduling, while allowing v1 delivery by compiling `.ttl` sources to Go code.
+
+## Path
+- Canonical compiler CLI path: `cmds/ttlc` (planned in v1 documentation phase)
+- Canonical language contract path: `docs/project-ttl-language.md`
+
+## Runtime and Language
+- TTL language (`.ttl`) + Go compiler CLI
+- v1 compile target: Go source (`ttl` -> generated Go)
+- v1 cache backend: SQLite
+
+## Users
+- Build/tooling engineers maintaining CI and developer workflows
+- Monorepo maintainers optimizing repeated build and analysis pipelines
+- Platform engineers building deterministic task graphs with cache reuse
+
+## In Scope
+- `.ttl` parsing and syntax validation
+- Typed task signatures and type checking for v1 core types
+- Go source generation from `.ttl` modules
+- Incremental scheduler contract (dependency graph + invalidation)
+- Persistent cache contract backed by SQLite
+- Parallel task execution contract for independent tasks
+- Structured logging contract for compile/runtime observability
+
+## Out of Scope
+- Distributed cache and remote execution in v1
+- Full IDE language server feature set in v1
+- Multi-target backends beyond Go source in v1
+- Non-deterministic or side-effectful task semantics by default
+
+## Architecture
+Primary boundaries:
+- Frontend: lexer/parser and type checker for `.ttl` sources.
+- Middle: typed IR and dependency graph builder.
+- Backend: Go emitter that lowers typed IR to generated Go source.
+- Runtime: scheduler, cache adapter, invalidation evaluator, and execution workers.
+- CLI: user-facing commands for build/check/explain workflows.
+
+v1 flow:
+1. Parse `.ttl` files and type-check task/module declarations.
+2. Build typed dependency graph and calculate task fingerprints.
+3. Query SQLite cache for reusable task outputs.
+4. Schedule cache misses on parallel workers.
+5. Emit generated Go source and persist fresh task results/metadata.
+
+## Interfaces
+Canonical project and runtime identifiers:
+
+```ts
+enum ProjectId {
+  Ttl = "ttl",
+}
+
+enum TtlCompileTarget {
+  GoSource = "go-source",
+}
+
+enum TtlCacheBackend {
+  SQLite = "sqlite",
+}
+
+enum TtlCommand {
+  Build = "build",
+  Check = "check",
+  Explain = "explain",
+}
+
+enum TtlCoreType {
+  Vc = "vc",
+  ResolvedVc = "resolved-vc",
+  OperationVc = "operation-vc",
+  TransientValue = "transient-value",
+  State = "state",
+}
+```
+
+Canonical CLI command contracts:
+- `ttlc build [--entry <file.ttl>] [--out-dir <dir>]`
+: Compiles `.ttl` to Go source and materializes cache-aware execution outputs.
+- `ttlc check [--entry <file.ttl>]`
+: Parses and type-checks without writing generated runtime artifacts.
+- `ttlc explain [--entry <file.ttl>] [--task <task-name>]`
+: Shows dependency graph, cache-key inputs, and invalidation reasons.
+
+Cache-key contract (v1):
+- `cache_key = hash(input_content_hash + parameter_hash + environment_snapshot_hash)`
+- Cache hit requires exact key equality.
+- Cache mismatch triggers recomputation and cache overwrite.
+
+## Storage
+Canonical local storage layout:
+- `.ttl/cache/cache.sqlite3`: SQLite database for task metadata and cache indices.
+- `.ttl/cache/blobs/`: optional output blob payload storage referenced by DB rows.
+- `.ttl/gen/`: generated Go source artifacts.
+
+Minimum persisted records:
+- `task_key`
+- `input_fingerprint`
+- `output_blob_ref`
+- `deps`
+- `metadata`
+
+Retention and persistence expectations:
+- Cache is persistent across process restarts.
+- Cache invalidation is key-based, not timestamp-only.
+- Schema migrations must be explicit and versioned.
+
+## Security
+- Restrict cache directory permissions to current user (POSIX target: `0700` directory, `0600` files).
+- Reject path traversal and symlink escape when resolving `.ttl` workspace paths.
+- Never log secret material or raw sensitive environment variables.
+- Keep generated code output paths under explicit workspace-controlled directories.
+
+## Logging
+Required `log/slog` structured fields:
+- `compile_stage`
+- `task_id`
+- `cache_key`
+- `cache_hit`
+- `invalidation_reason`
+- `worker_id`
+- `duration_ms`
+- `error_kind`
+
+Logging baseline:
+- Compiler stages emit start/end events with duration.
+- Scheduler emits queue/dequeue/complete events.
+- Cache layer emits read/write hit/miss/corruption events.
+
+## Build and Test
+v1 implementation validation commands (to apply once `cmds/ttlc` is implemented):
+- Build: `go build ./cmds/ttlc/...`
+- Test: `go test ./cmds/ttlc/...`
+- Workspace sanity: `go test ./...`
+
+Documentation acceptance scenarios:
+1. `docs/project-ttl.md` keeps required template section order and content.
+2. `AGENTS.md` project IDs and ownership mappings remain consistent with this contract.
+3. `docs/project-ttl-language.md` syntax/type contracts remain compatible with this project contract.
+4. Go compile target and SQLite cache backend remain identical across all ttl documents.
+
+## Roadmap
+- Phase 1: Documentation finalization and compiler scaffold (`cmds/ttlc`).
+- Phase 2: Incremental scheduler, hash invalidation engine, and SQLite cache integration.
+- Phase 3: Performance tuning, advanced observability, and richer cache lifecycle controls.
+
+## Open Questions
+- Should v2 include distributed cache protocol compatibility?
+- Should remote execution be introduced before multi-target backend support?
+- Which garbage-collection policy should prune stale cache blobs safely?
+
+## References
+- `AGENTS.md`
+- `cmds/AGENTS.md`
+- `docs/project-template.md`
+- [turbo-tasks/lib.rs](https://github.com/vercel/next.js/blob/canary/turbopack/crates/turbo-tasks/src/lib.rs)
+- [turbo-tasks/vc/mod.rs](https://github.com/vercel/next.js/blob/canary/turbopack/crates/turbo-tasks/src/vc/mod.rs)
+- [turbo-tasks/value.rs](https://github.com/vercel/next.js/blob/canary/turbopack/crates/turbo-tasks/src/value.rs)


### PR DESCRIPTION
## Summary
- add docs/project-ttl.md as the v1 project contract for TTL
- add docs/project-ttl-language.md as the TTL language/compiler contract
- register ttl in root AGENTS.md (ProjectId, ownership, canonical doc map)
- update cmds/AGENTS.md scope and TTL doc-sync rules

## Validation
- documentation-only change
- confirmed required section order in both new docs/project-*.md files