### PR TITLE
fix(skill): quote yaml description in gh-pr-codex-review-loop

### DIFF
--- a/.agents/skills/gh-pr-codex-review-loop/SKILL.md
+++ b/.agents/skills/gh-pr-codex-review-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-pr-codex-review-loop
-description: Repeatedly address GitHub pull request feedback until Codex marks the pull request as accepted with a :+1: reaction. Use when a user asks to iteratively apply PR review comments, run validations, push follow-up commits, and continue until Codex auto review is satisfied.
+description: "Repeatedly address GitHub pull request feedback until Codex marks the pull request as accepted with a :+1: reaction. Use when a user asks to iteratively apply PR review comments, run validations, push follow-up commits, and continue until Codex auto review is satisfied."
 ---
 
 # GitHub PR Codex Review Loop


### PR DESCRIPTION
## Summary
- Quote the description scalar in .agents/skills/gh-pr-codex-review-loop/SKILL.md front matter
- Prevent YAML parse failure caused by the :+1: token sequence
- Keep all non-front-matter content unchanged

## Validation
- Reproduced pre-fix parse failure (mapping values are not allowed in this context)
- Verified post-fix parse success with YAML.safe_load
- Checked all .agents/**/SKILL.md front matters parse successfully