### PR TITLE
refactor(derun): split run lifecycle and share mcp output helpers

### DIFF
--- a/cmds/derun/internal/cli/run.go
+++ b/cmds/derun/internal/cli/run.go
@@ -1,20 +1,15 @@
 package cli
 
 import (
-	"context"
 	"errors"
-	"flag"
 	"fmt"
-	"io"
 	"os"
 	"runtime"
 	"strings"
 	"time"
 
-	"github.com/delinoio/oss/cmds/derun/internal/capture"
 	"github.com/delinoio/oss/cmds/derun/internal/contracts"
 	"github.com/delinoio/oss/cmds/derun/internal/logging"
-	"github.com/delinoio/oss/cmds/derun/internal/retention"
 	"github.com/delinoio/oss/cmds/derun/internal/session"
 	"github.com/delinoio/oss/cmds/derun/internal/state"
 	"github.com/delinoio/oss/cmds/derun/internal/transport"
@@ -39,221 +34,32 @@ var (
 )
 
 func ExecuteRun(args []string) int {
-	fs := flag.NewFlagSet("run", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
-
-	var sessionID string
-	retentionDuration := defaultRetention
-	fs.StringVar(&sessionID, "session-id", "", "explicit session id")
-	fs.DurationVar(&retentionDuration, "retention", defaultRetention, "retention duration")
-
-	flagArgs, commandArgs, hasSeparator := splitRunArgs(args)
-	if err := fs.Parse(flagArgs); err != nil {
-		return 2
-	}
-	if !hasSeparator {
-		fmt.Fprintln(os.Stderr, "run command requires '--' separator before target command")
-		return 2
-	}
-	if len(commandArgs) == 0 {
-		fmt.Fprintln(os.Stderr, "run command requires target command")
-		return 2
-	}
-	if err := validateRetentionDuration(retentionDuration); err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		return 2
+	request, exitCode := parseRunRequest(args)
+	if exitCode != 0 {
+		return exitCode
 	}
 
-	stateRoot, err := resolveStateRootForRun()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "resolve state root: %v\n", err)
-		return 1
+	runtimeState, exitCode := initRunRuntime(request)
+	if exitCode != 0 {
+		return exitCode
+	}
+	defer runtimeState.Close()
+
+	preparedSession, exitCode := prepareSession(runtimeState, request)
+	if exitCode != 0 {
+		return exitCode
 	}
 
-	store, err := state.New(stateRoot)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "init state store: %v\n", err)
-		return 1
-	}
-	logger, err := logging.New(stateRoot)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "init logger: %v\n", err)
-		return 1
-	}
-	defer logger.Close()
-
-	cleanupResult, cleanupErr := retention.Sweep(store, retentionDuration, logger)
-	if cleanupErr != nil {
-		logger.Event("cleanup_result", map[string]any{"cleanup_result": "error", "error": cleanupErr.Error()})
-	} else {
-		logger.Event("cleanup_result", map[string]any{"cleanup_result": "ok", "checked": cleanupResult.Checked, "removed": cleanupResult.Removed})
+	execution, exitCode := executeTransport(runtimeState, preparedSession)
+	if exitCode != 0 {
+		return exitCode
 	}
 
-	if sessionID == "" {
-		sessionID, err = generateUniqueSessionID(store, logger)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "generate session id: %v\n", err)
-			return 1
-		}
-	} else {
-		hasMetadata, err := store.HasSessionMetadata(sessionID)
-		if err != nil {
-			if errors.Is(err, state.ErrInvalidSessionID) {
-				logger.Event("session_id_rejected", map[string]any{
-					"session_id": sessionID,
-					"reason":     string(sessionIDRejectionReasonInvalid),
-				})
-				fmt.Fprintf(os.Stderr, "invalid session id: %s\n", sessionID)
-				return 2
-			}
-			fmt.Fprintf(os.Stderr, "check session metadata: %v\n", err)
-			return 1
-		}
-		if hasMetadata {
-			logger.Event("session_id_rejected", map[string]any{
-				"session_id": sessionID,
-				"reason":     string(sessionIDRejectionReasonMetadataExists),
-			})
-			fmt.Fprintf(os.Stderr, "session id already exists: %s\n", sessionID)
-			return 2
-		}
+	if exitCode := persistFinalState(runtimeState, preparedSession, execution); exitCode != 0 {
+		return exitCode
 	}
 
-	if err := store.EnsureSessionDir(sessionID); err != nil {
-		fmt.Fprintf(os.Stderr, "prepare session directory: %v\n", err)
-		return 1
-	}
-
-	workingDir, err := os.Getwd()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "resolve working directory: %v\n", err)
-		return 1
-	}
-
-	ttyAttached := terminalProbe(os.Stdin) && terminalProbe(os.Stdout)
-	transportMode := selectTransportMode(ttyAttached, runtimeGOOS)
-
-	startedAt := time.Now().UTC()
-	meta := session.Meta{
-		SchemaVersion:    "v1alpha1",
-		SessionID:        sessionID,
-		Command:          append([]string(nil), commandArgs...),
-		WorkingDirectory: workingDir,
-		StartedAt:        startedAt,
-		RetentionSeconds: int64(retentionDuration.Seconds()),
-		TransportMode:    transportMode,
-		TTYAttached:      ttyAttached,
-		PID:              0,
-	}
-	if err := store.WriteMeta(meta); err != nil {
-		fmt.Fprintf(os.Stderr, "write metadata: %v\n", err)
-		return 1
-	}
-
-	logger.Event("state_transition", map[string]any{
-		"session_id":       sessionID,
-		"transport_mode":   transportMode,
-		"tty_attached":     ttyAttached,
-		"state_transition": string(contracts.DerunSessionStateStarting) + "->" + string(contracts.DerunSessionStateRunning),
-	})
-
-	ctx := context.Background()
-	onStart := func(pid int) error {
-		if pid <= 0 {
-			return nil
-		}
-		meta.PID = pid
-		if err := store.WriteMeta(meta); err != nil {
-			return fmt.Errorf("write meta file: %w", err)
-		}
-		return nil
-	}
-
-	var runResult transport.RunResult
-	var runErr error
-
-	runPipe := func() {
-		stdoutCapture := capture.NewWriter(store, logger, sessionID, contracts.DerunOutputChannelStdout)
-		stderrCapture := capture.NewWriter(store, logger, sessionID, contracts.DerunOutputChannelStderr)
-		stdoutOutput := io.MultiWriter(os.Stdout, stdoutCapture)
-		stderrOutput := io.MultiWriter(os.Stderr, stderrCapture)
-		runResult, runErr = runPipeTransport(ctx, commandArgs, workingDir, onStart, stdoutOutput, stderrOutput)
-	}
-
-	switch transportMode {
-	case contracts.DerunTransportModePosixPTY:
-		ptyCapture := capture.NewWriter(store, logger, sessionID, contracts.DerunOutputChannelPTY)
-		ptyOutput := io.MultiWriter(os.Stdout, ptyCapture)
-		runResult, runErr = runPosixPTYTransport(ctx, commandArgs, workingDir, onStart, ptyOutput)
-	case contracts.DerunTransportModeWindowsConPTY:
-		ptyCapture := capture.NewWriter(store, logger, sessionID, contracts.DerunOutputChannelPTY)
-		ptyOutput := io.MultiWriter(os.Stdout, ptyCapture)
-		runResult, runErr = runWindowsConPTYTransport(ctx, commandArgs, workingDir, onStart, ptyOutput)
-		if runErr != nil && isConPTYUnavailableError(runErr) {
-			logger.Event("transport_fallback", map[string]any{
-				"session_id":      sessionID,
-				"fallback_from":   contracts.DerunTransportModeWindowsConPTY,
-				"fallback_to":     contracts.DerunTransportModePipe,
-				"fallback_reason": runErr.Error(),
-			})
-			transportMode = contracts.DerunTransportModePipe
-			meta.TransportMode = transportMode
-			if err := store.WriteMeta(meta); err != nil {
-				fmt.Fprintf(os.Stderr, "write fallback metadata: %v\n", err)
-				return 1
-			}
-			runPipe()
-		}
-	default:
-		runPipe()
-	}
-
-	final := session.Final{
-		SchemaVersion: "v1alpha1",
-		SessionID:     sessionID,
-		EndedAt:       time.Now().UTC(),
-	}
-	if runErr != nil {
-		final.State = contracts.DerunSessionStateFailed
-		final.Error = runErr.Error()
-		logger.Event("state_transition", map[string]any{
-			"session_id":       sessionID,
-			"state_transition": string(contracts.DerunSessionStateRunning) + "->" + string(contracts.DerunSessionStateFailed),
-		})
-	} else if runResult.Signal != "" {
-		final.State = contracts.DerunSessionStateSignaled
-		final.Signal = runResult.Signal
-		logger.Event("state_transition", map[string]any{
-			"session_id":       sessionID,
-			"signal":           runResult.Signal,
-			"state_transition": string(contracts.DerunSessionStateRunning) + "->" + string(contracts.DerunSessionStateSignaled),
-		})
-	} else {
-		final.State = contracts.DerunSessionStateExited
-		final.ExitCode = runResult.ExitCode
-		logger.Event("state_transition", map[string]any{
-			"session_id":       sessionID,
-			"exit_code":        derefInt(runResult.ExitCode),
-			"state_transition": string(contracts.DerunSessionStateRunning) + "->" + string(contracts.DerunSessionStateExited),
-		})
-	}
-
-	if err := store.WriteFinal(final); err != nil {
-		fmt.Fprintf(os.Stderr, "write final metadata: %v\n", err)
-		return 1
-	}
-
-	if runErr != nil {
-		fmt.Fprintf(os.Stderr, "run command: %v\n", runErr)
-		return 1
-	}
-	if runResult.SignalNum > 0 {
-		return 128 + runResult.SignalNum
-	}
-	if runResult.ExitCode != nil {
-		return *runResult.ExitCode
-	}
-	return 1
+	return resolveRunExitCode(execution)
 }
 
 func splitRunArgs(args []string) ([]string, []string, bool) {

--- a/cmds/derun/internal/cli/run_flow.go
+++ b/cmds/derun/internal/cli/run_flow.go
@@ -1,0 +1,299 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/delinoio/oss/cmds/derun/internal/capture"
+	"github.com/delinoio/oss/cmds/derun/internal/contracts"
+	"github.com/delinoio/oss/cmds/derun/internal/logging"
+	"github.com/delinoio/oss/cmds/derun/internal/retention"
+	"github.com/delinoio/oss/cmds/derun/internal/session"
+	"github.com/delinoio/oss/cmds/derun/internal/state"
+	"github.com/delinoio/oss/cmds/derun/internal/transport"
+)
+
+type runRequest struct {
+	sessionID         string
+	retentionDuration time.Duration
+	commandArgs       []string
+}
+
+type runRuntime struct {
+	store  *state.Store
+	logger *logging.Logger
+}
+
+type preparedRunSession struct {
+	sessionID     string
+	commandArgs   []string
+	workingDir    string
+	transportMode contracts.DerunTransportMode
+	meta          session.Meta
+}
+
+type runExecutionResult struct {
+	runResult transport.RunResult
+	runErr    error
+}
+
+func (runtimeState *runRuntime) Close() {
+	if runtimeState == nil || runtimeState.logger == nil {
+		return
+	}
+	_ = runtimeState.logger.Close()
+}
+
+func parseRunRequest(args []string) (runRequest, int) {
+	fs := flag.NewFlagSet("run", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	request := runRequest{retentionDuration: defaultRetention}
+	fs.StringVar(&request.sessionID, "session-id", "", "explicit session id")
+	fs.DurationVar(&request.retentionDuration, "retention", defaultRetention, "retention duration")
+
+	flagArgs, commandArgs, hasSeparator := splitRunArgs(args)
+	if err := fs.Parse(flagArgs); err != nil {
+		return runRequest{}, 2
+	}
+	if !hasSeparator {
+		fmt.Fprintln(os.Stderr, "run command requires '--' separator before target command")
+		return runRequest{}, 2
+	}
+	if len(commandArgs) == 0 {
+		fmt.Fprintln(os.Stderr, "run command requires target command")
+		return runRequest{}, 2
+	}
+	if err := validateRetentionDuration(request.retentionDuration); err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		return runRequest{}, 2
+	}
+
+	request.commandArgs = append([]string(nil), commandArgs...)
+	return request, 0
+}
+
+func initRunRuntime(request runRequest) (*runRuntime, int) {
+	stateRoot, err := resolveStateRootForRun()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "resolve state root: %v\n", err)
+		return nil, 1
+	}
+
+	store, err := state.New(stateRoot)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "init state store: %v\n", err)
+		return nil, 1
+	}
+	logger, err := logging.New(stateRoot)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "init logger: %v\n", err)
+		return nil, 1
+	}
+
+	runtimeState := &runRuntime{
+		store:  store,
+		logger: logger,
+	}
+
+	cleanupResult, cleanupErr := retention.Sweep(store, request.retentionDuration, logger)
+	if cleanupErr != nil {
+		logger.Event("cleanup_result", map[string]any{"cleanup_result": "error", "error": cleanupErr.Error()})
+	} else {
+		logger.Event("cleanup_result", map[string]any{"cleanup_result": "ok", "checked": cleanupResult.Checked, "removed": cleanupResult.Removed})
+	}
+
+	return runtimeState, 0
+}
+
+func prepareSession(runtimeState *runRuntime, request runRequest) (*preparedRunSession, int) {
+	sessionID := request.sessionID
+	var err error
+	if sessionID == "" {
+		sessionID, err = generateUniqueSessionID(runtimeState.store, runtimeState.logger)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "generate session id: %v\n", err)
+			return nil, 1
+		}
+	} else {
+		hasMetadata, err := runtimeState.store.HasSessionMetadata(sessionID)
+		if err != nil {
+			if errors.Is(err, state.ErrInvalidSessionID) {
+				runtimeState.logger.Event("session_id_rejected", map[string]any{
+					"session_id": sessionID,
+					"reason":     string(sessionIDRejectionReasonInvalid),
+				})
+				fmt.Fprintf(os.Stderr, "invalid session id: %s\n", sessionID)
+				return nil, 2
+			}
+			fmt.Fprintf(os.Stderr, "check session metadata: %v\n", err)
+			return nil, 1
+		}
+		if hasMetadata {
+			runtimeState.logger.Event("session_id_rejected", map[string]any{
+				"session_id": sessionID,
+				"reason":     string(sessionIDRejectionReasonMetadataExists),
+			})
+			fmt.Fprintf(os.Stderr, "session id already exists: %s\n", sessionID)
+			return nil, 2
+		}
+	}
+
+	if err := runtimeState.store.EnsureSessionDir(sessionID); err != nil {
+		fmt.Fprintf(os.Stderr, "prepare session directory: %v\n", err)
+		return nil, 1
+	}
+
+	workingDir, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "resolve working directory: %v\n", err)
+		return nil, 1
+	}
+
+	ttyAttached := terminalProbe(os.Stdin) && terminalProbe(os.Stdout)
+	transportMode := selectTransportMode(ttyAttached, runtimeGOOS)
+
+	meta := session.Meta{
+		SchemaVersion:    "v1alpha1",
+		SessionID:        sessionID,
+		Command:          append([]string(nil), request.commandArgs...),
+		WorkingDirectory: workingDir,
+		StartedAt:        time.Now().UTC(),
+		RetentionSeconds: int64(request.retentionDuration.Seconds()),
+		TransportMode:    transportMode,
+		TTYAttached:      ttyAttached,
+		PID:              0,
+	}
+	if err := runtimeState.store.WriteMeta(meta); err != nil {
+		fmt.Fprintf(os.Stderr, "write metadata: %v\n", err)
+		return nil, 1
+	}
+
+	runtimeState.logger.Event("state_transition", map[string]any{
+		"session_id":       sessionID,
+		"transport_mode":   transportMode,
+		"tty_attached":     ttyAttached,
+		"state_transition": string(contracts.DerunSessionStateStarting) + "->" + string(contracts.DerunSessionStateRunning),
+	})
+
+	return &preparedRunSession{
+		sessionID:     sessionID,
+		commandArgs:   append([]string(nil), request.commandArgs...),
+		workingDir:    workingDir,
+		transportMode: transportMode,
+		meta:          meta,
+	}, 0
+}
+
+func executeTransport(runtimeState *runRuntime, preparedSession *preparedRunSession) (runExecutionResult, int) {
+	ctx := context.Background()
+	onStart := func(pid int) error {
+		if pid <= 0 {
+			return nil
+		}
+		preparedSession.meta.PID = pid
+		if err := runtimeState.store.WriteMeta(preparedSession.meta); err != nil {
+			return fmt.Errorf("write meta file: %w", err)
+		}
+		return nil
+	}
+
+	runPipe := func() (transport.RunResult, error) {
+		stdoutCapture := capture.NewWriter(runtimeState.store, runtimeState.logger, preparedSession.sessionID, contracts.DerunOutputChannelStdout)
+		stderrCapture := capture.NewWriter(runtimeState.store, runtimeState.logger, preparedSession.sessionID, contracts.DerunOutputChannelStderr)
+		stdoutOutput := io.MultiWriter(os.Stdout, stdoutCapture)
+		stderrOutput := io.MultiWriter(os.Stderr, stderrCapture)
+		return runPipeTransport(ctx, preparedSession.commandArgs, preparedSession.workingDir, onStart, stdoutOutput, stderrOutput)
+	}
+
+	var result transport.RunResult
+	var runErr error
+
+	switch preparedSession.transportMode {
+	case contracts.DerunTransportModePosixPTY:
+		ptyCapture := capture.NewWriter(runtimeState.store, runtimeState.logger, preparedSession.sessionID, contracts.DerunOutputChannelPTY)
+		ptyOutput := io.MultiWriter(os.Stdout, ptyCapture)
+		result, runErr = runPosixPTYTransport(ctx, preparedSession.commandArgs, preparedSession.workingDir, onStart, ptyOutput)
+	case contracts.DerunTransportModeWindowsConPTY:
+		ptyCapture := capture.NewWriter(runtimeState.store, runtimeState.logger, preparedSession.sessionID, contracts.DerunOutputChannelPTY)
+		ptyOutput := io.MultiWriter(os.Stdout, ptyCapture)
+		result, runErr = runWindowsConPTYTransport(ctx, preparedSession.commandArgs, preparedSession.workingDir, onStart, ptyOutput)
+		if runErr != nil && isConPTYUnavailableError(runErr) {
+			runtimeState.logger.Event("transport_fallback", map[string]any{
+				"session_id":      preparedSession.sessionID,
+				"fallback_from":   contracts.DerunTransportModeWindowsConPTY,
+				"fallback_to":     contracts.DerunTransportModePipe,
+				"fallback_reason": runErr.Error(),
+			})
+			preparedSession.transportMode = contracts.DerunTransportModePipe
+			preparedSession.meta.TransportMode = preparedSession.transportMode
+			if err := runtimeState.store.WriteMeta(preparedSession.meta); err != nil {
+				fmt.Fprintf(os.Stderr, "write fallback metadata: %v\n", err)
+				return runExecutionResult{}, 1
+			}
+			result, runErr = runPipe()
+		}
+	default:
+		result, runErr = runPipe()
+	}
+
+	return runExecutionResult{runResult: result, runErr: runErr}, 0
+}
+
+func persistFinalState(runtimeState *runRuntime, preparedSession *preparedRunSession, execution runExecutionResult) int {
+	final := session.Final{
+		SchemaVersion: "v1alpha1",
+		SessionID:     preparedSession.sessionID,
+		EndedAt:       time.Now().UTC(),
+	}
+	if execution.runErr != nil {
+		final.State = contracts.DerunSessionStateFailed
+		final.Error = execution.runErr.Error()
+		runtimeState.logger.Event("state_transition", map[string]any{
+			"session_id":       preparedSession.sessionID,
+			"state_transition": string(contracts.DerunSessionStateRunning) + "->" + string(contracts.DerunSessionStateFailed),
+		})
+	} else if execution.runResult.Signal != "" {
+		final.State = contracts.DerunSessionStateSignaled
+		final.Signal = execution.runResult.Signal
+		runtimeState.logger.Event("state_transition", map[string]any{
+			"session_id":       preparedSession.sessionID,
+			"signal":           execution.runResult.Signal,
+			"state_transition": string(contracts.DerunSessionStateRunning) + "->" + string(contracts.DerunSessionStateSignaled),
+		})
+	} else {
+		final.State = contracts.DerunSessionStateExited
+		final.ExitCode = execution.runResult.ExitCode
+		runtimeState.logger.Event("state_transition", map[string]any{
+			"session_id":       preparedSession.sessionID,
+			"exit_code":        derefInt(execution.runResult.ExitCode),
+			"state_transition": string(contracts.DerunSessionStateRunning) + "->" + string(contracts.DerunSessionStateExited),
+		})
+	}
+
+	if err := runtimeState.store.WriteFinal(final); err != nil {
+		fmt.Fprintf(os.Stderr, "write final metadata: %v\n", err)
+		return 1
+	}
+
+	return 0
+}
+
+func resolveRunExitCode(execution runExecutionResult) int {
+	if execution.runErr != nil {
+		fmt.Fprintf(os.Stderr, "run command: %v\n", execution.runErr)
+		return 1
+	}
+	if execution.runResult.SignalNum > 0 {
+		return 128 + execution.runResult.SignalNum
+	}
+	if execution.runResult.ExitCode != nil {
+		return *execution.runResult.ExitCode
+	}
+	return 1
+}

--- a/cmds/derun/internal/mcp/output_helpers.go
+++ b/cmds/derun/internal/mcp/output_helpers.go
@@ -1,0 +1,93 @@
+package mcp
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/delinoio/oss/cmds/derun/internal/session"
+)
+
+const waitPollInterval = 100 * time.Millisecond
+
+type outputPayloadOptions struct {
+	includeWait bool
+	timedOut    bool
+	waitedMS    int64
+}
+
+func parseRequiredSessionID(args map[string]any) (string, error) {
+	sessionID, ok := args["session_id"].(string)
+	if !ok || sessionID == "" {
+		return "", fmt.Errorf("session_id is required")
+	}
+	return sessionID, nil
+}
+
+func parseCursor(args map[string]any, required bool) (uint64, error) {
+	rawCursor, exists := args["cursor"]
+	if !exists {
+		if required {
+			return 0, fmt.Errorf("cursor is required")
+		}
+		return 0, nil
+	}
+
+	cursorString, ok := rawCursor.(string)
+	if !ok || cursorString == "" {
+		if required {
+			return 0, fmt.Errorf("cursor is required")
+		}
+		return 0, nil
+	}
+
+	cursor, err := strconv.ParseUint(cursorString, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse cursor: %w", err)
+	}
+	return cursor, nil
+}
+
+func parsePositiveIntDefault(args map[string]any, key string, defaultValue int) (int, error) {
+	value := defaultValue
+	raw, ok := args[key]
+	if !ok {
+		return value, nil
+	}
+
+	parsed, err := anyToInt(raw)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s: %w", key, err)
+	}
+	if parsed > 0 {
+		value = parsed
+	}
+	return value, nil
+}
+
+func parseWaitTimeout(args map[string]any) (time.Duration, error) {
+	timeoutMS, err := parsePositiveIntDefault(args, "timeout_ms", int(DefaultWaitTimeout/time.Millisecond))
+	if err != nil {
+		return 0, err
+	}
+	timeout := time.Duration(timeoutMS) * time.Millisecond
+	if timeout > MaxWaitTimeout {
+		timeout = MaxWaitTimeout
+	}
+	return timeout, nil
+}
+
+func buildOutputPayload(sessionID string, chunks []session.OutputChunk, nextCursor uint64, eof bool, options outputPayloadOptions) map[string]any {
+	payload := map[string]any{
+		"schema_version": SchemaVersion,
+		"session_id":     sessionID,
+		"chunks":         chunks,
+		"next_cursor":    strconv.FormatUint(nextCursor, 10),
+		"eof":            eof,
+	}
+	if options.includeWait {
+		payload["timed_out"] = options.timedOut
+		payload["waited_ms"] = options.waitedMS
+	}
+	return payload
+}

--- a/cmds/derun/internal/mcp/output_helpers_test.go
+++ b/cmds/derun/internal/mcp/output_helpers_test.go
@@ -1,0 +1,150 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseRequiredSessionID(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseRequiredSessionID(map[string]any{})
+	if err == nil || !strings.Contains(err.Error(), "session_id is required") {
+		t.Fatalf("expected required session_id error, got=%v", err)
+	}
+
+	sessionID, err := parseRequiredSessionID(map[string]any{"session_id": "01JTEST"})
+	if err != nil {
+		t.Fatalf("parseRequiredSessionID returned error: %v", err)
+	}
+	if sessionID != "01JTEST" {
+		t.Fatalf("unexpected session id: got=%q", sessionID)
+	}
+}
+
+func TestParseCursor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("optional missing", func(t *testing.T) {
+		cursor, err := parseCursor(map[string]any{}, false)
+		if err != nil {
+			t.Fatalf("parseCursor returned error: %v", err)
+		}
+		if cursor != 0 {
+			t.Fatalf("unexpected cursor: got=%d", cursor)
+		}
+	})
+
+	t.Run("optional non string ignored", func(t *testing.T) {
+		cursor, err := parseCursor(map[string]any{"cursor": 12}, false)
+		if err != nil {
+			t.Fatalf("parseCursor returned error: %v", err)
+		}
+		if cursor != 0 {
+			t.Fatalf("unexpected cursor: got=%d", cursor)
+		}
+	})
+
+	t.Run("optional parse error", func(t *testing.T) {
+		_, err := parseCursor(map[string]any{"cursor": "not-a-number"}, false)
+		if err == nil || !strings.Contains(err.Error(), "parse cursor") {
+			t.Fatalf("expected parse cursor error, got=%v", err)
+		}
+	})
+
+	t.Run("required missing", func(t *testing.T) {
+		_, err := parseCursor(map[string]any{}, true)
+		if err == nil || !strings.Contains(err.Error(), "cursor is required") {
+			t.Fatalf("expected cursor required error, got=%v", err)
+		}
+	})
+
+	t.Run("required parse error", func(t *testing.T) {
+		_, err := parseCursor(map[string]any{"cursor": "invalid"}, true)
+		if err == nil || !strings.Contains(err.Error(), "parse cursor") {
+			t.Fatalf("expected parse cursor error, got=%v", err)
+		}
+	})
+}
+
+func TestParsePositiveIntDefault(t *testing.T) {
+	t.Parallel()
+
+	value, err := parsePositiveIntDefault(map[string]any{}, "max_bytes", 64)
+	if err != nil {
+		t.Fatalf("parsePositiveIntDefault returned error: %v", err)
+	}
+	if value != 64 {
+		t.Fatalf("unexpected default value: got=%d", value)
+	}
+
+	value, err = parsePositiveIntDefault(map[string]any{"max_bytes": 128}, "max_bytes", 64)
+	if err != nil {
+		t.Fatalf("parsePositiveIntDefault returned error: %v", err)
+	}
+	if value != 128 {
+		t.Fatalf("unexpected parsed value: got=%d", value)
+	}
+
+	value, err = parsePositiveIntDefault(map[string]any{"max_bytes": -1}, "max_bytes", 64)
+	if err != nil {
+		t.Fatalf("parsePositiveIntDefault returned error: %v", err)
+	}
+	if value != 64 {
+		t.Fatalf("negative input should keep default: got=%d", value)
+	}
+
+	_, err = parsePositiveIntDefault(map[string]any{"max_bytes": 0.5}, "max_bytes", 64)
+	if err == nil || !strings.Contains(err.Error(), "parse max_bytes") {
+		t.Fatalf("expected parse max_bytes error, got=%v", err)
+	}
+}
+
+func TestParseWaitTimeout(t *testing.T) {
+	t.Parallel()
+
+	timeout, err := parseWaitTimeout(map[string]any{})
+	if err != nil {
+		t.Fatalf("parseWaitTimeout returned error: %v", err)
+	}
+	if timeout != DefaultWaitTimeout {
+		t.Fatalf("unexpected default timeout: got=%v want=%v", timeout, DefaultWaitTimeout)
+	}
+
+	timeout, err = parseWaitTimeout(map[string]any{"timeout_ms": int((MaxWaitTimeout + 2*time.Second) / time.Millisecond)})
+	if err != nil {
+		t.Fatalf("parseWaitTimeout returned error: %v", err)
+	}
+	if timeout != MaxWaitTimeout {
+		t.Fatalf("timeout should be capped: got=%v want=%v", timeout, MaxWaitTimeout)
+	}
+
+	_, err = parseWaitTimeout(map[string]any{"timeout_ms": 0.5})
+	if err == nil || !strings.Contains(err.Error(), "parse timeout_ms") {
+		t.Fatalf("expected parse timeout_ms error, got=%v", err)
+	}
+}
+
+func TestBuildOutputPayload(t *testing.T) {
+	t.Parallel()
+
+	withoutWait := buildOutputPayload("session-1", nil, 42, true, outputPayloadOptions{})
+	if withoutWait["next_cursor"] != "42" {
+		t.Fatalf("unexpected next_cursor: %v", withoutWait["next_cursor"])
+	}
+	if _, ok := withoutWait["timed_out"]; ok {
+		t.Fatalf("timed_out should be omitted when includeWait=false")
+	}
+	if _, ok := withoutWait["waited_ms"]; ok {
+		t.Fatalf("waited_ms should be omitted when includeWait=false")
+	}
+
+	withWait := buildOutputPayload("session-2", nil, 7, false, outputPayloadOptions{includeWait: true, timedOut: true, waitedMS: 123})
+	if timedOut, ok := withWait["timed_out"].(bool); !ok || !timedOut {
+		t.Fatalf("expected timed_out=true, got=%v", withWait["timed_out"])
+	}
+	if waitedMS, ok := withWait["waited_ms"].(int64); !ok || waitedMS != 123 {
+		t.Fatalf("unexpected waited_ms: %v", withWait["waited_ms"])
+	}
+}

--- a/cmds/derun/internal/mcp/tools_read_wait.go
+++ b/cmds/derun/internal/mcp/tools_read_wait.go
@@ -3,7 +3,6 @@ package mcp
 import (
 	"errors"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/delinoio/oss/cmds/derun/internal/contracts"
@@ -11,29 +10,19 @@ import (
 )
 
 func handleReadOutput(store *state.Store, args map[string]any) (map[string]any, error) {
-	sessionID, ok := args["session_id"].(string)
-	if !ok || sessionID == "" {
-		return nil, fmt.Errorf("session_id is required")
+	sessionID, err := parseRequiredSessionID(args)
+	if err != nil {
+		return nil, err
 	}
 
-	cursor := uint64(0)
-	if raw, ok := args["cursor"].(string); ok && raw != "" {
-		parsed, err := strconv.ParseUint(raw, 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("parse cursor: %w", err)
-		}
-		cursor = parsed
+	cursor, err := parseCursor(args, false)
+	if err != nil {
+		return nil, err
 	}
 
-	maxBytes := DefaultMaxBytes
-	if raw, ok := args["max_bytes"]; ok {
-		parsed, err := anyToInt(raw)
-		if err != nil {
-			return nil, fmt.Errorf("parse max_bytes: %w", err)
-		}
-		if parsed > 0 {
-			maxBytes = parsed
-		}
+	maxBytes, err := parsePositiveIntDefault(args, "max_bytes", DefaultMaxBytes)
+	if err != nil {
+		return nil, err
 	}
 
 	chunks, nextCursor, eof, err := store.ReadOutput(sessionID, cursor, maxBytes)
@@ -41,53 +30,28 @@ func handleReadOutput(store *state.Store, args map[string]any) (map[string]any, 
 		return nil, wrapReadWaitError("read output", err)
 	}
 
-	return map[string]any{
-		"schema_version": SchemaVersion,
-		"session_id":     sessionID,
-		"chunks":         chunks,
-		"next_cursor":    strconv.FormatUint(nextCursor, 10),
-		"eof":            eof,
-	}, nil
+	return buildOutputPayload(sessionID, chunks, nextCursor, eof, outputPayloadOptions{}), nil
 }
 
 func handleWaitOutput(store *state.Store, args map[string]any) (map[string]any, error) {
-	sessionID, ok := args["session_id"].(string)
-	if !ok || sessionID == "" {
-		return nil, fmt.Errorf("session_id is required")
-	}
-
-	rawCursor, ok := args["cursor"].(string)
-	if !ok || rawCursor == "" {
-		return nil, fmt.Errorf("cursor is required")
-	}
-	cursor, err := strconv.ParseUint(rawCursor, 10, 64)
+	sessionID, err := parseRequiredSessionID(args)
 	if err != nil {
-		return nil, fmt.Errorf("parse cursor: %w", err)
+		return nil, err
 	}
 
-	maxBytes := DefaultMaxBytes
-	if raw, ok := args["max_bytes"]; ok {
-		parsed, err := anyToInt(raw)
-		if err != nil {
-			return nil, fmt.Errorf("parse max_bytes: %w", err)
-		}
-		if parsed > 0 {
-			maxBytes = parsed
-		}
+	cursor, err := parseCursor(args, true)
+	if err != nil {
+		return nil, err
 	}
 
-	timeout := DefaultWaitTimeout
-	if raw, ok := args["timeout_ms"]; ok {
-		parsed, err := anyToInt(raw)
-		if err != nil {
-			return nil, fmt.Errorf("parse timeout_ms: %w", err)
-		}
-		if parsed > 0 {
-			timeout = time.Duration(parsed) * time.Millisecond
-		}
+	maxBytes, err := parsePositiveIntDefault(args, "max_bytes", DefaultMaxBytes)
+	if err != nil {
+		return nil, err
 	}
-	if timeout > MaxWaitTimeout {
-		timeout = MaxWaitTimeout
+
+	timeout, err := parseWaitTimeout(args)
+	if err != nil {
+		return nil, err
 	}
 
 	started := time.Now()
@@ -97,15 +61,11 @@ func handleWaitOutput(store *state.Store, args map[string]any) (map[string]any, 
 			return nil, wrapReadWaitError("wait read output", err)
 		}
 		if len(chunks) > 0 {
-			return map[string]any{
-				"schema_version": SchemaVersion,
-				"session_id":     sessionID,
-				"chunks":         chunks,
-				"next_cursor":    strconv.FormatUint(nextCursor, 10),
-				"eof":            eof,
-				"timed_out":      false,
-				"waited_ms":      time.Since(started).Milliseconds(),
-			}, nil
+			return buildOutputPayload(sessionID, chunks, nextCursor, eof, outputPayloadOptions{
+				includeWait: true,
+				timedOut:    false,
+				waitedMS:    time.Since(started).Milliseconds(),
+			}), nil
 		}
 		if eof {
 			detail, err := store.GetSession(sessionID)
@@ -113,36 +73,28 @@ func handleWaitOutput(store *state.Store, args map[string]any) (map[string]any, 
 				return nil, wrapReadWaitError("get session detail", err)
 			}
 			if !isSessionActive(detail.State) {
-				return map[string]any{
-					"schema_version": SchemaVersion,
-					"session_id":     sessionID,
-					"chunks":         chunks,
-					"next_cursor":    strconv.FormatUint(nextCursor, 10),
-					"eof":            eof,
-					"timed_out":      false,
-					"waited_ms":      time.Since(started).Milliseconds(),
-				}, nil
+				return buildOutputPayload(sessionID, chunks, nextCursor, eof, outputPayloadOptions{
+					includeWait: true,
+					timedOut:    false,
+					waitedMS:    time.Since(started).Milliseconds(),
+				}), nil
 			}
 		}
 		if time.Since(started) >= timeout {
 			break
 		}
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(waitPollInterval)
 	}
 
 	chunks, nextCursor, eof, err := store.ReadOutput(sessionID, cursor, maxBytes)
 	if err != nil {
 		return nil, wrapReadWaitError("read output after timeout", err)
 	}
-	return map[string]any{
-		"schema_version": SchemaVersion,
-		"session_id":     sessionID,
-		"chunks":         chunks,
-		"next_cursor":    strconv.FormatUint(nextCursor, 10),
-		"eof":            eof,
-		"timed_out":      true,
-		"waited_ms":      time.Since(started).Milliseconds(),
-	}, nil
+	return buildOutputPayload(sessionID, chunks, nextCursor, eof, outputPayloadOptions{
+		includeWait: true,
+		timedOut:    true,
+		waitedMS:    time.Since(started).Milliseconds(),
+	}), nil
 }
 
 func isSessionActive(sessionState contracts.DerunSessionState) bool {


### PR DESCRIPTION
## Summary
- split `ExecuteRun` into explicit lifecycle stages (`parse/init/prepare/execute/finalize/exit-code`) while preserving existing CLI behavior
- move run lifecycle internals into `internal/cli/run_flow.go` with typed state structs for request/runtime/session/execution
- add MCP output helper utilities to deduplicate `read/wait` argument parsing and payload assembly
- replace `wait_output` sleep magic number with a named `waitPollInterval` constant
- add focused unit tests for MCP helper parsing and payload composition

## Testing
- go test ./cmds/derun/...
