### PR TITLE
feat(nodeup): add local managed-alias shim setup

### DIFF
--- a/docs/project-nodeup.md
+++ b/docs/project-nodeup.md
@@ -249,6 +249,8 @@ Dispatch contract:
 Symlink contract:
 - Shims point to one nodeup binary.
 - Runtime behavior branches by `argv[0]`.
+- Local setup script `scripts/setup/nodeup-local.sh` must create or refresh `node`, `npm`, and
+  `npx` symlinks in the local install `bin/` directory with `ln -sfn` so reruns are idempotent.
 
 ## Storage
 - Install root: managed Node.js runtimes per version (`data/toolchains/<version>`).
@@ -304,8 +306,13 @@ Local development install and shell-session patch:
 - `eval "$(./scripts/setup/nodeup-local.sh)"`
 - Script contract:
 : Installs from `crates/nodeup` using `cargo install --path .`.
+: Verifies installed `nodeup` binary exists at `<install-root>/bin/nodeup` and is executable.
+: Creates managed alias shims `node`, `npm`, and `npx` in `<install-root>/bin`, each pointing to
+  the `nodeup` binary via symlink.
 : Uses install root `${NODEUP_LOCAL_INSTALL_ROOT:-<repo>/.local/nodeup}`.
 : Prints shell exports for `PATH` and `NODEUP_SELF_BIN_PATH` so the current shell session can apply them immediately.
+: Does not auto-select a default runtime; operators bootstrap runtime explicitly after install:
+  `nodeup default lts`, then verify with `node --version` and `npm --version`.
 
 Planned commands:
 - Build: `cargo build -p nodeup`

--- a/scripts/setup/nodeup-local.sh
+++ b/scripts/setup/nodeup-local.sh
@@ -4,10 +4,16 @@ set -eu
 
 if [ "${1:-}" = "--help" ]; then
   cat >&2 <<'EOF'
-Install nodeup from the local workspace and print shell exports for the current session.
+Install nodeup from the local workspace, create managed alias shims, and print shell
+exports for the current session.
 
 Usage:
   eval "$(./scripts/setup/nodeup-local.sh)"
+
+Post-install bootstrap:
+  nodeup default lts
+  node --version
+  npm --version
 
 Optional environment variables:
   NODEUP_LOCAL_INSTALL_ROOT  Install root (default: <repo>/.local/nodeup)
@@ -27,6 +33,19 @@ echo "[nodeup-local] installing with cargo install --path . --root \"$install_ro
   cargo install --path . --root "$install_root"
 ) >&2
 
+nodeup_binary="$install_bin_dir/nodeup"
+if [ ! -x "$nodeup_binary" ]; then
+  echo "[nodeup-local] expected installed binary at \"$nodeup_binary\" but it is missing or not executable" >&2
+  exit 1
+fi
+
+echo "[nodeup-local] ensuring managed alias shims in \"$install_bin_dir\"" >&2
+for alias in node npm npx; do
+  ln -sfn nodeup "$install_bin_dir/$alias"
+  echo "[nodeup-local] shim ready: $alias -> nodeup" >&2
+done
+
+echo "[nodeup-local] installation complete; bootstrap runtime with: nodeup default lts" >&2
 echo "[nodeup-local] printing shell exports for current session patch" >&2
 printf '_nodeup_local_bin="%s"\n' "$install_bin_dir"
 printf 'case ":$PATH:" in *":${_nodeup_local_bin}:"*) ;; *) export PATH="${_nodeup_local_bin}:$PATH" ;; esac\n'


### PR DESCRIPTION
## Summary
- extend `scripts/setup/nodeup-local.sh` to create idempotent `node`/`npm`/`npx` shims after local install
- validate installed `nodeup` binary exists/executable before emitting shell exports
- document updated local installer and symlink contract in `docs/project-nodeup.md`

## Validation
- `./scripts/setup/nodeup-local.sh --help`
- `NODEUP_LOCAL_INSTALL_ROOT=/tmp/nodeup-local-test ./scripts/setup/nodeup-local.sh > /tmp/nodeup-local-eval.sh`
- verified `/tmp/nodeup-local-test/bin/{nodeup,node,npm,npx}` and symlink targets
- `eval "$(cat /tmp/nodeup-local-eval.sh)"` then verified `command -v nodeup node npm npx`
- verified deterministic not-found when no default runtime is set
- verified delegated execution via linked runtime for `node`, `npm`, and `npx`
