### PR TITLE
chore(dexdex): remove beforeDevCommand from tauri config

### DIFF
--- a/apps/dexdex/src-tauri/tauri.conf.json
+++ b/apps/dexdex/src-tauri/tauri.conf.json
@@ -4,7 +4,6 @@
   "version": "0.1.0",
   "identifier": "io.delino.dexdex",
   "build": {
-    "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",
     "devUrl": "http://localhost:5991",
     "frontendDist": "../dist"


### PR DESCRIPTION
## Summary
- remove `beforeDevCommand` from `apps/dexdex/src-tauri/tauri.conf.json`
- keep `devUrl` as-is so frontend dev server can be run manually

## Testing
- not run (config-only change)