### PR TITLE
chore(nodeup): bump patch version to 0.1.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,7 +1339,7 @@ dependencies = [
 
 [[package]]
 name = "nodeup"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/crates/nodeup/Cargo.toml
+++ b/crates/nodeup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nodeup"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 license = "MIT"
 description = "Rustup-like Node.js version manager"


### PR DESCRIPTION
## Summary
- bump the `nodeup` crate version from `0.1.10` to `0.1.11`
- refresh the workspace lockfile package entry to match the new crate version

## Testing
- cargo test