### PR TITLE
feat: add with-watch watch-mode CLI scaffold

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@
 - `docs/<domain>-<project-or-component>-<contract>.md`: Canonical domain contract docs (`apps`, `cmds`, `servers`, `crates`, `protos`, `packages`).
 - `docs/project-cargo-mono.md`: Cargo subcommand project index.
 - `docs/project-nodeup.md`: Node.js version manager project index.
+- `docs/project-with-watch.md`: Command rerun watcher CLI project index.
 - `docs/project-derun.md`: Derun CLI project index.
 - `docs/project-ttl.md`: TTL compiler project index.
 - `docs/project-mpapp.md`: Expo mobile app project index.
@@ -57,6 +58,7 @@
 - `docs/project-serde-feather.md`: Serde Feather multi-crate project index.
 - `docs/project-rustia.md`: Rustia multi-crate project index.
 - `docs/project-dexdex.md`: DexDex multi-runtime project index.
+- `docs/crates-with-watch-foundation.md`: with-watch CLI and watcher foundation contract.
 - `docs/crates-rustia-core-foundation.md`: Rustia core runtime LLM data contract.
 - `docs/crates-rustia-llm-foundation.md`: Rustia aisdk tool adapter contract.
 - `docs/crates-rustia-macros-foundation.md`: Rustia macros derive contract.
@@ -85,6 +87,7 @@ Treat project IDs as stable enum-style values:
 enum ProjectId {
   CargoMono = "cargo-mono",
   Nodeup = "nodeup",
+  WithWatch = "with-watch",
   Derun = "derun",
   Ttl = "ttl",
   Mpapp = "mpapp",
@@ -102,6 +105,7 @@ enum ProjectId {
 ### Project Domain Ownership
 
 - `nodeup` -> `crates/nodeup`
+- `with-watch` -> `crates/with-watch`
 - `cargo-mono` -> `crates/cargo-mono`
 - `derun` -> `cmds/derun`
 - `ttl` -> `cmds/ttlc`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -91,7 +91,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -99,6 +99,18 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert-json-diff"
@@ -177,9 +189,29 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "blake3"
+version = "1.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
 
 [[package]]
 name = "block-buffer"
@@ -365,6 +397,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +433,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -536,7 +583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -637,6 +684,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1153,6 +1209,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+dependencies = [
+ "bitflags 2.11.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,6 +1267,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,7 +1320,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
  "redox_syscall 0.7.1",
 ]
@@ -1316,6 +1412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1379,12 +1476,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1414,7 +1538,7 @@ version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1495,6 +1619,49 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1695,7 +1862,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1704,7 +1871,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1885,11 +2052,11 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1938,6 +2105,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scc"
@@ -2000,7 +2176,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2196,7 +2372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2207,7 +2383,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2269,6 +2445,16 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "starbase_args"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f221116b05d4049efc6b36cd530474c07e6719cdc0e92db426deacda7c8b02c6"
+dependencies = [
+ "pest",
+ "pest_derive",
+]
 
 [[package]]
 name = "stringmetrics"
@@ -2335,7 +2521,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -2386,7 +2572,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2680,7 +2866,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -2794,6 +2980,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2877,6 +3069,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -3012,7 +3214,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3053,7 +3255,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3314,7 +3516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",
@@ -3342,6 +3544,25 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "with-watch"
+version = "0.1.0"
+dependencies = [
+ "assert_cmd",
+ "blake3",
+ "clap",
+ "globset",
+ "notify",
+ "predicates",
+ "starbase_args",
+ "swc_malloc",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "tracing-subscriber",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/cargo-mono",
     "crates/nodeup",
+    "crates/with-watch",
     "crates/serde-feather",
     "crates/serde-feather-macros",
     "crates/rustia",

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -9,6 +9,7 @@
 
 - `crates/cargo-mono`: Cargo-based Rust monorepo management CLI.
 - `crates/nodeup`: Rust-based Node.js version manager.
+- `crates/with-watch`: Rust-based filesystem-watching command wrapper.
 - `crates/serde-feather`: Size-first serde runtime-facing core crate.
 - `crates/serde-feather-macros`: Proc-macro companion crate for serde-feather.
 - `crates/rustia`: Serde-based LLM JSON runtime crate.
@@ -38,6 +39,13 @@
 - Keep `publish` delegation aligned with the documented contract: `cargo mono publish` must invoke `cargo publish --no-verify` in both execute and dry-run modes.
 - Ensure release automation (`bump`, `publish`) logs include structured operational context.
 - Keep runtime error output on the fixed `Summary/Context/Hint` three-line contract and include only safe debugging context values.
+
+### with-watch-Specific Rules
+
+- Keep passthrough, shell, and `exec --input` command shapes stable and documented in `docs/project-with-watch.md` and `docs/crates-with-watch-foundation.md`.
+- Keep default rerun filtering content-hash-based, with `--no-hash` as the documented metadata-only override.
+- Keep shell support scoped to command-line expressions and do not silently broaden into shell-script control-flow without updating docs first.
+- Keep logs sufficient to explain inferred inputs, watcher anchors, snapshot counts, and rerun causes.
 
 ### serde-feather-Specific Rules
 

--- a/crates/with-watch/Cargo.toml
+++ b/crates/with-watch/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "with-watch"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Watch command inputs and rerun commands when they change"
+readme = "README.md"
+publish = false
+
+[dependencies]
+blake3 = "1.8.4"
+clap = { version = "4.5.32", features = ["derive"] }
+globset = "0.4.15"
+notify = "8.1.0"
+starbase_args = "0.1.9"
+swc_malloc = "1.2.5"
+thiserror = "2.0.12"
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.19", features = ["fmt", "env-filter"] }
+walkdir = "2.5.0"
+
+[dev-dependencies]
+assert_cmd = "2.0.16"
+predicates = "3.1.3"
+tempfile = "3.18.0"

--- a/crates/with-watch/README.md
+++ b/crates/with-watch/README.md
@@ -1,0 +1,11 @@
+# with-watch
+
+`with-watch` reruns a delegated command when its inferred or explicit filesystem inputs change.
+
+## Examples
+
+```sh
+with-watch cp src.txt dest.txt
+with-watch --shell 'cat src.txt | grep hello'
+with-watch exec --input 'src/**/*.rs' -- cargo test -p with-watch
+```

--- a/crates/with-watch/src/cli.rs
+++ b/crates/with-watch/src/cli.rs
@@ -1,0 +1,150 @@
+use std::ffi::OsString;
+
+use clap::{Args, Parser, Subcommand};
+
+use crate::{
+    error::{Result, WithWatchError},
+    snapshot::ChangeDetectionMode,
+};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "with-watch",
+    version,
+    about = "Run commands again when their inputs change"
+)]
+pub struct Cli {
+    /// Disable content hashing and compare only file metadata.
+    #[arg(long, global = true)]
+    pub no_hash: bool,
+
+    /// Run a quoted shell command line that may contain `&&`, `||`, or `|`.
+    #[arg(long, global = true, value_name = "EXPR")]
+    pub shell: Option<String>,
+
+    #[command(subcommand)]
+    pub command: Option<Command>,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// Run an arbitrary command with explicit watched inputs.
+    Exec(ExecArgs),
+    #[command(external_subcommand)]
+    Passthrough(Vec<OsString>),
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct ExecArgs {
+    /// Watched filesystem inputs expressed as repeatable glob or path values.
+    #[arg(long = "input", value_name = "GLOB", required = true)]
+    pub input: Vec<String>,
+
+    /// Command to execute after `--`.
+    #[arg(required = true, trailing_var_arg = true, allow_hyphen_values = true)]
+    pub command: Vec<OsString>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CommandMode {
+    Passthrough {
+        argv: Vec<OsString>,
+    },
+    Shell {
+        expression: String,
+    },
+    Exec {
+        inputs: Vec<String>,
+        argv: Vec<OsString>,
+    },
+}
+
+impl Cli {
+    pub fn change_detection_mode(&self) -> ChangeDetectionMode {
+        if self.no_hash {
+            ChangeDetectionMode::MtimeOnly
+        } else {
+            ChangeDetectionMode::ContentHash
+        }
+    }
+
+    pub fn command_mode(&self) -> Result<CommandMode> {
+        match (&self.shell, &self.command) {
+            (Some(_), Some(_)) => Err(WithWatchError::ConflictingModes),
+            (Some(expression), None) => {
+                let trimmed = expression.trim();
+                if trimmed.is_empty() {
+                    return Err(WithWatchError::EmptyShellExpression);
+                }
+                Ok(CommandMode::Shell {
+                    expression: trimmed.to_string(),
+                })
+            }
+            (None, Some(Command::Exec(exec))) => {
+                if exec.command.is_empty() {
+                    return Err(WithWatchError::MissingExecCommand);
+                }
+                Ok(CommandMode::Exec {
+                    inputs: exec.input.clone(),
+                    argv: exec.command.clone(),
+                })
+            }
+            (None, Some(Command::Passthrough(argv))) => {
+                if argv.is_empty() {
+                    return Err(WithWatchError::MissingCommand);
+                }
+                Ok(CommandMode::Passthrough { argv: argv.clone() })
+            }
+            (None, None) => Err(WithWatchError::MissingCommand),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::{Cli, CommandMode};
+    use crate::{error::WithWatchError, snapshot::ChangeDetectionMode};
+
+    #[test]
+    fn passthrough_mode_preserves_external_subcommand_arguments() {
+        let cli = Cli::parse_from(["with-watch", "cp", "a", "b"]);
+        let mode = cli.command_mode().expect("command mode");
+
+        match mode {
+            CommandMode::Passthrough { argv } => {
+                assert_eq!(argv.len(), 3);
+                assert_eq!(argv[0].to_string_lossy(), "cp");
+                assert_eq!(argv[1].to_string_lossy(), "a");
+                assert_eq!(argv[2].to_string_lossy(), "b");
+            }
+            other => panic!("unexpected mode: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn shell_mode_is_mutually_exclusive_with_subcommands() {
+        let error = Cli::parse_from(["with-watch", "--shell", "echo hi", "cp", "a", "b"])
+            .command_mode()
+            .expect_err("expected error");
+
+        assert!(matches!(error, WithWatchError::ConflictingModes));
+    }
+
+    #[test]
+    fn exec_mode_uses_mtime_only_when_hashing_is_disabled() {
+        let cli = Cli::parse_from([
+            "with-watch",
+            "--no-hash",
+            "exec",
+            "--input",
+            "src/**/*.rs",
+            "--",
+            "cargo",
+            "test",
+        ]);
+
+        assert_eq!(cli.change_detection_mode(), ChangeDetectionMode::MtimeOnly);
+    }
+}

--- a/crates/with-watch/src/error.rs
+++ b/crates/with-watch/src/error.rs
@@ -1,0 +1,93 @@
+use std::{io, path::PathBuf};
+
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, WithWatchError>;
+
+#[derive(Debug, Error)]
+pub enum WithWatchError {
+    #[error(
+        "Provide a delegated utility, `--shell <expr>`, or `exec --input <glob>... -- <command> \
+         ...`."
+    )]
+    MissingCommand,
+    #[error("`--shell` cannot be combined with delegated argv or the `exec` subcommand.")]
+    ConflictingModes,
+    #[error("`--shell` requires a non-empty shell expression.")]
+    EmptyShellExpression,
+    #[error("`exec` requires a delegated command after `--`.")]
+    MissingExecCommand,
+    #[error(
+        "No watch inputs could be inferred from the delegated command. Use `with-watch exec \
+         --input <glob>... -- <command> [args...]`."
+    )]
+    NoWatchInputs,
+    #[error("Failed to determine the current working directory: {0}")]
+    CurrentDirectory(#[source] io::Error),
+    #[error("Failed to parse shell expression: {message}")]
+    ShellParse { message: String },
+    #[error("Shell control-flow is out of scope for with-watch v1: {construct}")]
+    UnsupportedShellConstruct { construct: String },
+    #[error("Failed to compile glob pattern `{pattern}`: {message}")]
+    InvalidGlob { pattern: String, message: String },
+    #[error("Could not derive a watch anchor for `{path}`.")]
+    MissingWatchAnchor { path: PathBuf },
+    #[error("Failed to read metadata for `{path}`: {source}")]
+    Metadata {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("Failed to read `{path}` while hashing: {source}")]
+    HashRead {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("Failed to create a filesystem watcher: {0}")]
+    WatcherCreate(#[source] notify::Error),
+    #[error("Failed to watch `{path}` recursively: {source}")]
+    WatchPath {
+        path: PathBuf,
+        #[source]
+        source: notify::Error,
+    },
+    #[error("Failed to spawn `{command}`: {source}")]
+    Spawn {
+        command: String,
+        #[source]
+        source: io::Error,
+    },
+    #[error("Failed while waiting for `{command}`: {source}")]
+    Wait {
+        command: String,
+        #[source]
+        source: io::Error,
+    },
+    #[error("`--shell` execution is only supported on Unix-like platforms.")]
+    UnsupportedShellPlatform,
+}
+
+impl WithWatchError {
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            Self::MissingCommand
+            | Self::ConflictingModes
+            | Self::EmptyShellExpression
+            | Self::MissingExecCommand
+            | Self::NoWatchInputs
+            | Self::ShellParse { .. }
+            | Self::UnsupportedShellConstruct { .. }
+            | Self::InvalidGlob { .. }
+            | Self::MissingWatchAnchor { .. }
+            | Self::UnsupportedShellPlatform => 2,
+            Self::CurrentDirectory(_)
+            | Self::Metadata { .. }
+            | Self::HashRead { .. }
+            | Self::WatcherCreate(_)
+            | Self::WatchPath { .. }
+            | Self::Spawn { .. }
+            | Self::Wait { .. } => 1,
+        }
+    }
+}

--- a/crates/with-watch/src/lib.rs
+++ b/crates/with-watch/src/lib.rs
@@ -1,0 +1,195 @@
+pub mod cli;
+pub mod error;
+pub mod logging;
+pub mod parser;
+pub mod runner;
+pub mod snapshot;
+pub mod watch;
+
+use std::path::Path;
+
+use cli::{Cli, CommandMode};
+use error::{Result, WithWatchError};
+use parser::parse_shell_expression;
+use runner::{ExecutionPlan, RunnerOptions};
+use snapshot::{ChangeDetectionMode, WatchInput, WatchInputKind};
+
+pub fn run_cli(cli: Cli, options: RunnerOptions) -> Result<i32> {
+    let mode = cli.command_mode()?;
+    let cwd = std::env::current_dir().map_err(WithWatchError::CurrentDirectory)?;
+    let detection_mode = cli.change_detection_mode();
+    let plan = build_execution_plan(mode, detection_mode, &cwd)?;
+    runner::run(plan, options)
+}
+
+fn build_execution_plan(
+    mode: CommandMode,
+    detection_mode: ChangeDetectionMode,
+    cwd: &Path,
+) -> Result<ExecutionPlan> {
+    match mode {
+        CommandMode::Passthrough { argv } => {
+            let inputs = infer_watch_inputs_from_argv(&argv, cwd)?;
+            Ok(ExecutionPlan::passthrough(argv, inputs, detection_mode))
+        }
+        CommandMode::Shell { expression } => {
+            let parsed = parse_shell_expression(&expression)?;
+            let inputs = infer_watch_inputs_from_values(&parsed.input_candidates, cwd)?;
+            Ok(ExecutionPlan::shell(expression, inputs, detection_mode))
+        }
+        CommandMode::Exec { inputs, argv } => {
+            let planned_inputs = explicit_watch_inputs(&inputs, cwd)?;
+            Ok(ExecutionPlan::exec(argv, planned_inputs, detection_mode))
+        }
+    }
+}
+
+fn infer_watch_inputs_from_argv(
+    argv: &[std::ffi::OsString],
+    cwd: &Path,
+) -> Result<Vec<WatchInput>> {
+    if argv.is_empty() {
+        return Err(WithWatchError::MissingCommand);
+    }
+
+    let mut values = Vec::new();
+    for raw in argv.iter().skip(1) {
+        push_watch_candidates_from_os(raw, &mut values);
+    }
+
+    infer_watch_inputs_from_values(&values, cwd)
+}
+
+fn infer_watch_inputs_from_values(values: &[String], cwd: &Path) -> Result<Vec<WatchInput>> {
+    let mut inputs = Vec::new();
+
+    for value in values {
+        push_watch_input_from_token(value, cwd, &mut inputs)?;
+    }
+
+    if inputs.is_empty() {
+        return Err(WithWatchError::NoWatchInputs);
+    }
+
+    Ok(inputs)
+}
+
+fn explicit_watch_inputs(raw_inputs: &[String], cwd: &Path) -> Result<Vec<WatchInput>> {
+    let mut inputs = Vec::new();
+    for raw in raw_inputs {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let input = if has_glob_magic(trimmed) {
+            WatchInput::glob(trimmed, cwd)?
+        } else {
+            WatchInput::path(trimmed, cwd, WatchInputKind::Explicit)?
+        };
+        push_unique_input(&mut inputs, input);
+    }
+    Ok(inputs)
+}
+
+fn push_watch_candidates_from_os(raw: &std::ffi::OsString, values: &mut Vec<String>) {
+    let text = raw.to_string_lossy();
+    push_watch_candidates_from_text(&text, values);
+}
+
+fn push_watch_candidates_from_text(raw: &str, values: &mut Vec<String>) {
+    if raw.is_empty() {
+        return;
+    }
+
+    if let Some((prefix, value)) = raw.split_once('=') {
+        if prefix.starts_with('-') && !value.is_empty() {
+            values.push(value.to_string());
+            return;
+        }
+    }
+
+    if raw.starts_with('-') {
+        return;
+    }
+
+    values.push(raw.to_string());
+}
+
+fn push_watch_input_from_token(raw: &str, cwd: &Path, inputs: &mut Vec<WatchInput>) -> Result<()> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(());
+    }
+
+    let input = if has_glob_magic(trimmed) {
+        WatchInput::glob(trimmed, cwd)?
+    } else {
+        WatchInput::path(trimmed, cwd, WatchInputKind::Inferred)?
+    };
+
+    push_unique_input(inputs, input);
+    Ok(())
+}
+
+fn push_unique_input(inputs: &mut Vec<WatchInput>, input: WatchInput) {
+    if !inputs.contains(&input) {
+        inputs.push(input);
+    }
+}
+
+fn has_glob_magic(raw: &str) -> bool {
+    raw.contains('*') || raw.contains('?') || raw.contains('[')
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{ffi::OsString, fs, path::Path};
+
+    use super::{
+        explicit_watch_inputs, infer_watch_inputs_from_argv, infer_watch_inputs_from_values,
+    };
+    use crate::snapshot::WatchInputKind;
+
+    #[test]
+    fn infers_existing_and_missing_paths_from_passthrough_argv() {
+        let temp_dir = tempfile::tempdir().expect("create tempdir");
+        let existing = temp_dir.path().join("input.txt");
+        fs::write(&existing, "hello").expect("write input");
+
+        let inputs = infer_watch_inputs_from_argv(
+            &[
+                OsString::from("cp"),
+                existing.as_os_str().to_os_string(),
+                OsString::from("output.txt"),
+            ],
+            temp_dir.path(),
+        )
+        .expect("infer inputs");
+
+        assert_eq!(inputs.len(), 2);
+        assert!(inputs
+            .iter()
+            .any(|input| input.kind() == WatchInputKind::Inferred));
+    }
+
+    #[test]
+    fn inferred_values_require_at_least_one_candidate() {
+        let error =
+            infer_watch_inputs_from_values(&[], Path::new(".")).expect_err("expected error");
+        assert!(error
+            .to_string()
+            .contains("No watch inputs could be inferred"));
+    }
+
+    #[test]
+    fn explicit_inputs_accept_globs_and_paths() {
+        let temp_dir = tempfile::tempdir().expect("create tempdir");
+        let inputs = explicit_watch_inputs(
+            &["src/**/*.rs".to_string(), "README.md".to_string()],
+            temp_dir.path(),
+        )
+        .expect("explicit inputs");
+
+        assert_eq!(inputs.len(), 2);
+    }
+}

--- a/crates/with-watch/src/logging.rs
+++ b/crates/with-watch/src/logging.rs
@@ -1,0 +1,73 @@
+use tracing_subscriber::EnvFilter;
+
+const WITH_WATCH_LOG_COLOR_ENV: &str = "WITH_WATCH_LOG_COLOR";
+const NO_COLOR_ENV: &str = "NO_COLOR";
+
+pub fn init_logging() {
+    let env_filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("with_watch=info"));
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .with_ansi(log_color_enabled())
+        .with_target(false)
+        .with_level(true)
+        .without_time()
+        .try_init();
+}
+
+fn log_color_enabled() -> bool {
+    resolve_log_color_enabled(
+        std::env::var(WITH_WATCH_LOG_COLOR_ENV).ok().as_deref(),
+        std::env::var(NO_COLOR_ENV).ok().as_deref(),
+    )
+}
+
+fn resolve_log_color_enabled(with_watch_log_color: Option<&str>, no_color: Option<&str>) -> bool {
+    match with_watch_log_color.and_then(parse_log_color_mode) {
+        Some(LogColorMode::Always) => return true,
+        Some(LogColorMode::Never) => return false,
+        Some(LogColorMode::Auto) | None => {}
+    }
+
+    if no_color.is_some() {
+        return false;
+    }
+
+    true
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LogColorMode {
+    Auto,
+    Always,
+    Never,
+}
+
+fn parse_log_color_mode(raw: &str) -> Option<LogColorMode> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "always" | "on" | "true" | "1" | "yes" => Some(LogColorMode::Always),
+        "never" | "off" | "false" | "0" | "no" => Some(LogColorMode::Never),
+        "auto" => Some(LogColorMode::Auto),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_log_color_enabled;
+
+    #[test]
+    fn default_enables_colored_logs() {
+        assert!(resolve_log_color_enabled(None, None));
+    }
+
+    #[test]
+    fn override_can_disable_logs() {
+        assert!(!resolve_log_color_enabled(Some("never"), None));
+    }
+
+    #[test]
+    fn no_color_disables_logs_without_override() {
+        assert!(!resolve_log_color_enabled(None, Some("1")));
+    }
+}

--- a/crates/with-watch/src/main.rs
+++ b/crates/with-watch/src/main.rs
@@ -1,0 +1,19 @@
+use clap::Parser;
+use swc_malloc as _;
+use with_watch::{cli::Cli, error::WithWatchError, logging, run_cli, runner::RunnerOptions};
+
+fn main() {
+    logging::init_logging();
+    let cli = Cli::parse();
+    let options = RunnerOptions::from_environment();
+
+    match run_cli(cli, options) {
+        Ok(code) => std::process::exit(code),
+        Err(error) => exit_with_error(error),
+    }
+}
+
+fn exit_with_error(error: WithWatchError) -> ! {
+    eprintln!("with-watch error: {error}");
+    std::process::exit(error.exit_code());
+}

--- a/crates/with-watch/src/parser.rs
+++ b/crates/with-watch/src/parser.rs
@@ -1,0 +1,143 @@
+use crate::error::{Result, WithWatchError};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedShellExpression {
+    pub expression: String,
+    pub input_candidates: Vec<String>,
+}
+
+pub fn parse_shell_expression(expression: &str) -> Result<ParsedShellExpression> {
+    let parsed = starbase_args::parse(expression).map_err(|error| WithWatchError::ShellParse {
+        message: error.to_string(),
+    })?;
+
+    let mut input_candidates = Vec::new();
+    for pipeline in parsed.0 {
+        collect_pipeline_inputs(pipeline, &mut input_candidates)?;
+    }
+
+    Ok(ParsedShellExpression {
+        expression: expression.to_string(),
+        input_candidates,
+    })
+}
+
+fn collect_pipeline_inputs(
+    pipeline: starbase_args::Pipeline,
+    input_candidates: &mut Vec<String>,
+) -> Result<()> {
+    match pipeline {
+        starbase_args::Pipeline::Start(command_list)
+        | starbase_args::Pipeline::StartNegated(command_list)
+        | starbase_args::Pipeline::Pipe(command_list)
+        | starbase_args::Pipeline::PipeAll(command_list)
+        | starbase_args::Pipeline::PipeWith(command_list, _) => {
+            collect_command_list_inputs(command_list, input_candidates)
+        }
+    }
+}
+
+fn collect_command_list_inputs(
+    command_list: starbase_args::CommandList,
+    input_candidates: &mut Vec<String>,
+) -> Result<()> {
+    for sequence in command_list.0 {
+        match sequence {
+            starbase_args::Sequence::Start(command)
+            | starbase_args::Sequence::Then(command)
+            | starbase_args::Sequence::AndThen(command)
+            | starbase_args::Sequence::OrElse(command)
+            | starbase_args::Sequence::Passthrough(command)
+            | starbase_args::Sequence::Redirect(command, _) => {
+                collect_command_inputs(command, input_candidates)?;
+            }
+            starbase_args::Sequence::Stop(_) => {}
+        }
+    }
+
+    Ok(())
+}
+
+fn collect_command_inputs(
+    command: starbase_args::Command,
+    input_candidates: &mut Vec<String>,
+) -> Result<()> {
+    let mut command_name_seen = false;
+
+    for argument in command.0 {
+        match argument {
+            starbase_args::Argument::EnvVar(_, value, _) => {
+                input_candidates.push(value.as_str().to_string());
+            }
+            starbase_args::Argument::Flag(_) | starbase_args::Argument::FlagGroup(_) => {}
+            starbase_args::Argument::Option(_, Some(value)) => {
+                input_candidates.push(value.as_str().to_string());
+            }
+            starbase_args::Argument::Option(_, None) => {}
+            starbase_args::Argument::Value(value) => {
+                if !command_name_seen {
+                    validate_command_name(value.as_str())?;
+                    command_name_seen = true;
+                    continue;
+                }
+
+                input_candidates.push(value.as_str().to_string());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_command_name(command_name: &str) -> Result<()> {
+    let lowered = command_name.trim().to_ascii_lowercase();
+    let unsupported = matches!(
+        lowered.as_str(),
+        "if" | "then"
+            | "else"
+            | "elif"
+            | "fi"
+            | "for"
+            | "while"
+            | "until"
+            | "do"
+            | "done"
+            | "case"
+            | "esac"
+            | "function"
+            | "{"
+            | "}"
+    );
+
+    if unsupported {
+        return Err(WithWatchError::UnsupportedShellConstruct {
+            construct: command_name.to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_shell_expression;
+
+    #[test]
+    fn parses_command_lines_with_and_or_and_pipeline_operators() {
+        let parsed = parse_shell_expression("cp src.txt dest.txt && cat dest.txt | grep hello")
+            .expect("parse shell");
+
+        assert!(parsed.input_candidates.contains(&"src.txt".to_string()));
+        assert!(parsed.input_candidates.contains(&"dest.txt".to_string()));
+        assert!(parsed.input_candidates.contains(&"hello".to_string()));
+    }
+
+    #[test]
+    fn rejects_shell_control_flow_keywords() {
+        let error =
+            parse_shell_expression("if true; then echo hi; fi").expect_err("expected error");
+        assert!(error
+            .to_string()
+            .contains("Shell control-flow is out of scope"));
+    }
+}

--- a/crates/with-watch/src/runner.rs
+++ b/crates/with-watch/src/runner.rs
@@ -1,0 +1,282 @@
+use std::{
+    ffi::OsString,
+    process::{Child, Command, ExitStatus, Stdio},
+    thread,
+    time::Duration,
+};
+
+use tracing::{debug, info, warn};
+
+use crate::{
+    error::{Result, WithWatchError},
+    snapshot::{capture_snapshot, ChangeDetectionMode, CommandSource, SnapshotState, WatchInput},
+    watch::{CollectedEvents, WatchLoop},
+};
+
+const DEFAULT_POLL_TIMEOUT: Duration = Duration::from_millis(50);
+const DEFAULT_DEBOUNCE_WINDOW: Duration = Duration::from_millis(200);
+
+#[derive(Debug, Clone)]
+pub struct ExecutionPlan {
+    pub source: CommandSource,
+    pub detection_mode: ChangeDetectionMode,
+    pub inputs: Vec<WatchInput>,
+    pub delegated_command: DelegatedCommand,
+}
+
+impl ExecutionPlan {
+    pub fn passthrough(
+        argv: Vec<OsString>,
+        inputs: Vec<WatchInput>,
+        detection_mode: ChangeDetectionMode,
+    ) -> Self {
+        Self {
+            source: CommandSource::Argv,
+            detection_mode,
+            inputs,
+            delegated_command: DelegatedCommand::Argv(argv),
+        }
+    }
+
+    pub fn shell(
+        expression: String,
+        inputs: Vec<WatchInput>,
+        detection_mode: ChangeDetectionMode,
+    ) -> Self {
+        Self {
+            source: CommandSource::Shell,
+            detection_mode,
+            inputs,
+            delegated_command: DelegatedCommand::Shell(expression),
+        }
+    }
+
+    pub fn exec(
+        argv: Vec<OsString>,
+        inputs: Vec<WatchInput>,
+        detection_mode: ChangeDetectionMode,
+    ) -> Self {
+        Self {
+            source: CommandSource::Exec,
+            detection_mode,
+            inputs,
+            delegated_command: DelegatedCommand::Argv(argv),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum DelegatedCommand {
+    Argv(Vec<OsString>),
+    Shell(String),
+}
+
+impl DelegatedCommand {
+    fn display_name(&self) -> String {
+        match self {
+            Self::Argv(argv) => argv
+                .iter()
+                .map(|value| value.to_string_lossy().into_owned())
+                .collect::<Vec<_>>()
+                .join(" "),
+            Self::Shell(expression) => expression.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RunnerOptions {
+    pub debounce_window: Duration,
+    pub poll_timeout: Duration,
+    pub max_runs: Option<usize>,
+}
+
+impl Default for RunnerOptions {
+    fn default() -> Self {
+        Self {
+            debounce_window: DEFAULT_DEBOUNCE_WINDOW,
+            poll_timeout: DEFAULT_POLL_TIMEOUT,
+            max_runs: None,
+        }
+    }
+}
+
+impl RunnerOptions {
+    pub fn from_environment() -> Self {
+        let mut options = Self::default();
+
+        // Test-only hooks for deterministic integration coverage. They keep the public
+        // CLI surface stable while allowing `cargo test` to stop the
+        // long-running watch loop and shorten debounce windows. Remove them
+        // when we have a better end-to-end harness.
+        if let Ok(raw_max_runs) = std::env::var("WITH_WATCH_TEST_MAX_RUNS") {
+            if let Ok(parsed) = raw_max_runs.parse::<usize>() {
+                options.max_runs = Some(parsed);
+            }
+        }
+
+        if let Ok(raw_debounce_ms) = std::env::var("WITH_WATCH_TEST_DEBOUNCE_MS") {
+            if let Ok(parsed) = raw_debounce_ms.parse::<u64>() {
+                options.debounce_window = Duration::from_millis(parsed);
+            }
+        }
+
+        options
+    }
+}
+
+pub fn run(plan: ExecutionPlan, options: RunnerOptions) -> Result<i32> {
+    let mut watch_loop = WatchLoop::new(&plan.inputs)?;
+    let mut baseline = capture_snapshot(&plan.inputs, plan.detection_mode)?;
+    let mut child = Some(spawn_command(&plan.delegated_command)?);
+    let mut completed_runs = 0usize;
+    let mut queued_snapshot: Option<SnapshotState> = None;
+
+    info!(
+        command_source = plan.source.as_str(),
+        detection_mode = plan.detection_mode.as_str(),
+        input_count = plan.inputs.len(),
+        "Starting with-watch run loop"
+    );
+
+    loop {
+        if let Some(active_child) = child.as_mut() {
+            match active_child
+                .try_wait()
+                .map_err(|source| WithWatchError::Wait {
+                    command: plan.delegated_command.display_name(),
+                    source,
+                })? {
+                Some(status) => {
+                    completed_runs += 1;
+                    let last_exit_code = exit_code_from_status(status);
+                    info!(
+                        completed_runs,
+                        last_exit_code,
+                        command_source = plan.source.as_str(),
+                        "Delegated command finished"
+                    );
+                    child = None;
+
+                    if options
+                        .max_runs
+                        .is_some_and(|limit| completed_runs >= limit)
+                    {
+                        return Ok(last_exit_code);
+                    }
+
+                    if let Some(next_snapshot) = queued_snapshot.take() {
+                        baseline = next_snapshot;
+                        child = Some(spawn_command(&plan.delegated_command)?);
+                        continue;
+                    }
+                }
+                None => {}
+            }
+        }
+
+        if let Some(events) =
+            watch_loop.collect_events(options.poll_timeout, options.debounce_window)
+        {
+            handle_watch_events(&events);
+
+            let current_snapshot = capture_snapshot(&plan.inputs, plan.detection_mode)?;
+            if current_snapshot.is_meaningfully_different(&baseline, plan.detection_mode) {
+                debug!(
+                    event_count = events.event_count,
+                    path_count = events.path_count,
+                    child_running = child.is_some(),
+                    "Observed meaningful input changes"
+                );
+
+                if child.is_some() {
+                    queued_snapshot = Some(current_snapshot);
+                } else {
+                    baseline = current_snapshot;
+                    child = Some(spawn_command(&plan.delegated_command)?);
+                }
+            } else {
+                queued_snapshot = None;
+            }
+        } else if child.is_none() {
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+}
+
+fn handle_watch_events(events: &CollectedEvents) {
+    if events.error_count > 0 {
+        warn!(
+            error_count = events.error_count,
+            event_count = events.event_count,
+            path_count = events.path_count,
+            "Watcher reported recoverable errors; forcing a rescan"
+        );
+    } else {
+        debug!(
+            event_count = events.event_count,
+            path_count = events.path_count,
+            "Collected filesystem events"
+        );
+    }
+}
+
+fn spawn_command(command: &DelegatedCommand) -> Result<Child> {
+    match command {
+        DelegatedCommand::Argv(argv) => spawn_argv(argv),
+        DelegatedCommand::Shell(expression) => spawn_shell(expression),
+    }
+}
+
+fn spawn_argv(argv: &[OsString]) -> Result<Child> {
+    let program = argv
+        .first()
+        .cloned()
+        .ok_or(WithWatchError::MissingCommand)?;
+    let display_name = argv
+        .iter()
+        .map(|value| value.to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    info!(command = display_name, "Spawning delegated argv command");
+
+    Command::new(&program)
+        .args(argv.iter().skip(1))
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .map_err(|source| WithWatchError::Spawn {
+            command: program.to_string_lossy().into_owned(),
+            source,
+        })
+}
+
+fn spawn_shell(expression: &str) -> Result<Child> {
+    #[cfg(not(unix))]
+    {
+        let _ = expression;
+        Err(WithWatchError::UnsupportedShellPlatform)
+    }
+
+    #[cfg(unix)]
+    {
+        info!(expression, "Spawning delegated shell command");
+        Command::new("/bin/sh")
+            .arg("-c")
+            .arg(expression)
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .map_err(|source| WithWatchError::Spawn {
+                command: expression.to_string(),
+                source,
+            })
+    }
+}
+
+fn exit_code_from_status(status: ExitStatus) -> i32 {
+    status.code().unwrap_or(1)
+}

--- a/crates/with-watch/src/runner.rs
+++ b/crates/with-watch/src/runner.rs
@@ -141,37 +141,36 @@ pub fn run(plan: ExecutionPlan, options: RunnerOptions) -> Result<i32> {
 
     loop {
         if let Some(active_child) = child.as_mut() {
-            match active_child
-                .try_wait()
-                .map_err(|source| WithWatchError::Wait {
-                    command: plan.delegated_command.display_name(),
-                    source,
-                })? {
-                Some(status) => {
-                    completed_runs += 1;
-                    let last_exit_code = exit_code_from_status(status);
-                    info!(
-                        completed_runs,
-                        last_exit_code,
-                        command_source = plan.source.as_str(),
-                        "Delegated command finished"
-                    );
-                    child = None;
+            if let Some(status) =
+                active_child
+                    .try_wait()
+                    .map_err(|source| WithWatchError::Wait {
+                        command: plan.delegated_command.display_name(),
+                        source,
+                    })?
+            {
+                completed_runs += 1;
+                let last_exit_code = exit_code_from_status(status);
+                info!(
+                    completed_runs,
+                    last_exit_code,
+                    command_source = plan.source.as_str(),
+                    "Delegated command finished"
+                );
+                child = None;
 
-                    if options
-                        .max_runs
-                        .is_some_and(|limit| completed_runs >= limit)
-                    {
-                        return Ok(last_exit_code);
-                    }
-
-                    if let Some(next_snapshot) = queued_snapshot.take() {
-                        baseline = next_snapshot;
-                        child = Some(spawn_command(&plan.delegated_command)?);
-                        continue;
-                    }
+                if options
+                    .max_runs
+                    .is_some_and(|limit| completed_runs >= limit)
+                {
+                    return Ok(last_exit_code);
                 }
-                None => {}
+
+                if let Some(next_snapshot) = queued_snapshot.take() {
+                    baseline = next_snapshot;
+                    child = Some(spawn_command(&plan.delegated_command)?);
+                    continue;
+                }
             }
         }
 

--- a/crates/with-watch/src/snapshot.rs
+++ b/crates/with-watch/src/snapshot.rs
@@ -148,6 +148,10 @@ impl SnapshotState {
     pub fn len(&self) -> usize {
         self.entries.len()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -236,7 +240,7 @@ fn capture_path_input(
         for entry in WalkDir::new(path).follow_links(true) {
             let entry = entry.map_err(|error| WithWatchError::Metadata {
                 path: path.to_path_buf(),
-                source: std::io::Error::new(std::io::ErrorKind::Other, error.to_string()),
+                source: std::io::Error::other(error.to_string()),
             })?;
             let entry_path = entry.path().to_path_buf();
             insert_existing_entry(&entry_path, mode, entries)?;
@@ -268,7 +272,7 @@ fn capture_glob_input(
     for entry in WalkDir::new(watch_anchor).follow_links(true) {
         let entry = entry.map_err(|error| WithWatchError::Metadata {
             path: watch_anchor.to_path_buf(),
-            source: std::io::Error::new(std::io::ErrorKind::Other, error.to_string()),
+            source: std::io::Error::other(error.to_string()),
         })?;
         let path = entry.path().to_path_buf();
         let normalized = normalize_path_string(&path);
@@ -434,8 +438,11 @@ mod tests {
         )
         .expect("path input");
 
-        let first = capture_snapshot(&[input.clone()], ChangeDetectionMode::ContentHash)
-            .expect("first snapshot");
+        let first = capture_snapshot(
+            std::slice::from_ref(&input),
+            ChangeDetectionMode::ContentHash,
+        )
+        .expect("first snapshot");
         thread::sleep(Duration::from_millis(20));
         fs::write(&file_path, "hello").expect("rewrite same content");
         let second =
@@ -456,7 +463,7 @@ mod tests {
         )
         .expect("path input");
 
-        let first = capture_snapshot(&[input.clone()], ChangeDetectionMode::MtimeOnly)
+        let first = capture_snapshot(std::slice::from_ref(&input), ChangeDetectionMode::MtimeOnly)
             .expect("first snapshot");
         thread::sleep(Duration::from_millis(20));
         fs::write(&file_path, "hello").expect("rewrite same content");

--- a/crates/with-watch/src/snapshot.rs
+++ b/crates/with-watch/src/snapshot.rs
@@ -1,0 +1,481 @@
+use std::{
+    collections::BTreeMap,
+    fmt,
+    fs::{self, File},
+    io::Read,
+    path::{Path, PathBuf},
+    time::SystemTime,
+};
+
+use globset::Glob;
+use walkdir::WalkDir;
+
+use crate::error::{Result, WithWatchError};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChangeDetectionMode {
+    ContentHash,
+    MtimeOnly,
+}
+
+impl ChangeDetectionMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ContentHash => "content-hash",
+            Self::MtimeOnly => "mtime-only",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandSource {
+    Argv,
+    Shell,
+    Exec,
+}
+
+impl CommandSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Argv => "argv",
+            Self::Shell => "shell",
+            Self::Exec => "exec",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WatchInputKind {
+    Explicit,
+    Inferred,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WatchInput {
+    Path {
+        kind: WatchInputKind,
+        path: PathBuf,
+        watch_anchor: PathBuf,
+    },
+    Glob {
+        kind: WatchInputKind,
+        raw: String,
+        absolute_pattern: String,
+        watch_anchor: PathBuf,
+    },
+}
+
+impl WatchInput {
+    pub fn path(raw: &str, cwd: &Path, kind: WatchInputKind) -> Result<Self> {
+        let absolute_path = absolutize(raw, cwd);
+        let watch_anchor = nearest_existing_parent(&absolute_path).ok_or_else(|| {
+            WithWatchError::MissingWatchAnchor {
+                path: absolute_path.clone(),
+            }
+        })?;
+
+        Ok(Self::Path {
+            kind,
+            path: absolute_path,
+            watch_anchor,
+        })
+    }
+
+    pub fn glob(raw: &str, cwd: &Path) -> Result<Self> {
+        let absolute_pattern_path = absolutize(raw, cwd);
+        let absolute_pattern = normalize_path_string(&absolute_pattern_path);
+        Glob::new(&absolute_pattern).map_err(|error| WithWatchError::InvalidGlob {
+            pattern: raw.to_string(),
+            message: error.to_string(),
+        })?;
+
+        let anchor_candidate = glob_anchor(raw, cwd);
+        let watch_anchor = nearest_existing_parent(&anchor_candidate).ok_or_else(|| {
+            WithWatchError::MissingWatchAnchor {
+                path: anchor_candidate.clone(),
+            }
+        })?;
+
+        Ok(Self::Glob {
+            kind: WatchInputKind::Explicit,
+            raw: raw.to_string(),
+            absolute_pattern,
+            watch_anchor,
+        })
+    }
+
+    pub fn kind(&self) -> WatchInputKind {
+        match self {
+            Self::Path { kind, .. } | Self::Glob { kind, .. } => *kind,
+        }
+    }
+
+    pub fn watch_anchor(&self) -> &Path {
+        match self {
+            Self::Path { watch_anchor, .. } | Self::Glob { watch_anchor, .. } => watch_anchor,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SnapshotState {
+    entries: BTreeMap<PathBuf, SnapshotEntry>,
+}
+
+impl SnapshotState {
+    pub fn is_meaningfully_different(
+        &self,
+        previous: &SnapshotState,
+        mode: ChangeDetectionMode,
+    ) -> bool {
+        if self.entries.len() != previous.entries.len() {
+            return true;
+        }
+
+        for (path, current) in &self.entries {
+            let Some(previous_entry) = previous.entries.get(path) else {
+                return true;
+            };
+
+            if !current.equivalent_to(previous_entry, mode) {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SnapshotEntry {
+    kind: SnapshotEntryKind,
+    modified: Option<SystemTime>,
+    digest: Option<blake3::Hash>,
+}
+
+impl SnapshotEntry {
+    fn equivalent_to(&self, previous: &SnapshotEntry, mode: ChangeDetectionMode) -> bool {
+        if self.kind != previous.kind {
+            return false;
+        }
+
+        match mode {
+            ChangeDetectionMode::ContentHash => match self.kind {
+                SnapshotEntryKind::File => self.digest == previous.digest,
+                SnapshotEntryKind::Directory | SnapshotEntryKind::Missing => true,
+            },
+            ChangeDetectionMode::MtimeOnly => self.modified == previous.modified,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotEntryKind {
+    File,
+    Directory,
+    Missing,
+}
+
+impl fmt::Display for SnapshotEntryKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::File => write!(f, "file"),
+            Self::Directory => write!(f, "directory"),
+            Self::Missing => write!(f, "missing"),
+        }
+    }
+}
+
+pub fn capture_snapshot(inputs: &[WatchInput], mode: ChangeDetectionMode) -> Result<SnapshotState> {
+    let mut entries = BTreeMap::new();
+
+    for input in inputs {
+        match input {
+            WatchInput::Path { path, .. } => {
+                capture_path_input(path, mode, &mut entries)?;
+            }
+            WatchInput::Glob {
+                absolute_pattern,
+                watch_anchor,
+                ..
+            } => {
+                capture_glob_input(absolute_pattern, watch_anchor, mode, &mut entries)?;
+            }
+        }
+    }
+
+    Ok(SnapshotState { entries })
+}
+
+fn capture_path_input(
+    path: &Path,
+    mode: ChangeDetectionMode,
+    entries: &mut BTreeMap<PathBuf, SnapshotEntry>,
+) -> Result<()> {
+    if !path.exists() {
+        entries.insert(
+            path.to_path_buf(),
+            SnapshotEntry {
+                kind: SnapshotEntryKind::Missing,
+                modified: None,
+                digest: None,
+            },
+        );
+        return Ok(());
+    }
+
+    let metadata = fs::metadata(path).map_err(|source| WithWatchError::Metadata {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if metadata.is_dir() {
+        for entry in WalkDir::new(path).follow_links(true) {
+            let entry = entry.map_err(|error| WithWatchError::Metadata {
+                path: path.to_path_buf(),
+                source: std::io::Error::new(std::io::ErrorKind::Other, error.to_string()),
+            })?;
+            let entry_path = entry.path().to_path_buf();
+            insert_existing_entry(&entry_path, mode, entries)?;
+        }
+    } else {
+        insert_existing_entry(path, mode, entries)?;
+    }
+
+    Ok(())
+}
+
+fn capture_glob_input(
+    absolute_pattern: &str,
+    watch_anchor: &Path,
+    mode: ChangeDetectionMode,
+    entries: &mut BTreeMap<PathBuf, SnapshotEntry>,
+) -> Result<()> {
+    let matcher = Glob::new(absolute_pattern)
+        .map_err(|error| WithWatchError::InvalidGlob {
+            pattern: absolute_pattern.to_string(),
+            message: error.to_string(),
+        })?
+        .compile_matcher();
+
+    if !watch_anchor.exists() {
+        return Ok(());
+    }
+
+    for entry in WalkDir::new(watch_anchor).follow_links(true) {
+        let entry = entry.map_err(|error| WithWatchError::Metadata {
+            path: watch_anchor.to_path_buf(),
+            source: std::io::Error::new(std::io::ErrorKind::Other, error.to_string()),
+        })?;
+        let path = entry.path().to_path_buf();
+        let normalized = normalize_path_string(&path);
+        if matcher.is_match(&normalized) {
+            insert_existing_entry(&path, mode, entries)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn insert_existing_entry(
+    path: &Path,
+    mode: ChangeDetectionMode,
+    entries: &mut BTreeMap<PathBuf, SnapshotEntry>,
+) -> Result<()> {
+    let metadata = fs::metadata(path).map_err(|source| WithWatchError::Metadata {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    let kind = if metadata.is_dir() {
+        SnapshotEntryKind::Directory
+    } else {
+        SnapshotEntryKind::File
+    };
+    let modified = metadata.modified().ok();
+    let digest = if mode == ChangeDetectionMode::ContentHash && kind == SnapshotEntryKind::File {
+        Some(hash_file(path)?)
+    } else {
+        None
+    };
+
+    entries.insert(
+        path.to_path_buf(),
+        SnapshotEntry {
+            kind,
+            modified,
+            digest,
+        },
+    );
+
+    Ok(())
+}
+
+fn hash_file(path: &Path) -> Result<blake3::Hash> {
+    let mut file = File::open(path).map_err(|source| WithWatchError::HashRead {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let mut hasher = blake3::Hasher::new();
+    let mut buffer = [0u8; 8192];
+
+    loop {
+        let bytes_read = file
+            .read(&mut buffer)
+            .map_err(|source| WithWatchError::HashRead {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        if bytes_read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..bytes_read]);
+    }
+
+    Ok(hasher.finalize())
+}
+
+fn absolutize(raw: &str, cwd: &Path) -> PathBuf {
+    let expanded = expand_tilde(raw);
+    let path = PathBuf::from(expanded);
+    if path.is_absolute() {
+        path
+    } else {
+        cwd.join(path)
+    }
+}
+
+fn expand_tilde(raw: &str) -> String {
+    if let Some(suffix) = raw.strip_prefix("~/") {
+        if let Ok(home) = std::env::var("HOME") {
+            return format!("{home}/{suffix}");
+        }
+    }
+    raw.to_string()
+}
+
+fn nearest_existing_parent(path: &Path) -> Option<PathBuf> {
+    let mut current = Some(path);
+    while let Some(candidate) = current {
+        if candidate.exists() {
+            return Some(candidate.to_path_buf());
+        }
+        current = candidate.parent();
+    }
+    None
+}
+
+fn glob_anchor(raw: &str, cwd: &Path) -> PathBuf {
+    let expanded = expand_tilde(raw);
+    let original_path = PathBuf::from(&expanded);
+    let is_absolute = original_path.is_absolute();
+    let mut prefix = PathBuf::new();
+
+    for component in expanded.split(['/', '\\']) {
+        if component.is_empty() {
+            continue;
+        }
+        if component.contains('*') || component.contains('?') || component.contains('[') {
+            break;
+        }
+        prefix.push(component);
+    }
+
+    if prefix.as_os_str().is_empty() {
+        if is_absolute {
+            PathBuf::from(std::path::MAIN_SEPARATOR.to_string())
+        } else {
+            cwd.to_path_buf()
+        }
+    } else if is_absolute {
+        PathBuf::from(std::path::MAIN_SEPARATOR.to_string()).join(prefix)
+    } else {
+        cwd.join(prefix)
+    }
+}
+
+fn normalize_path_string(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, thread, time::Duration};
+
+    use super::{
+        capture_snapshot, ChangeDetectionMode, SnapshotEntryKind, WatchInput, WatchInputKind,
+    };
+
+    #[test]
+    fn glob_inputs_anchor_to_existing_parent() {
+        let temp_dir = tempfile::tempdir().expect("create tempdir");
+        let input = WatchInput::glob("src/**/*.rs", temp_dir.path()).expect("glob input");
+
+        match input {
+            WatchInput::Glob { watch_anchor, .. } => {
+                assert_eq!(watch_anchor, temp_dir.path());
+            }
+            other => panic!("unexpected watch input: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hash_mode_ignores_metadata_only_churn() {
+        let temp_dir = tempfile::tempdir().expect("create tempdir");
+        let file_path = temp_dir.path().join("input.txt");
+        fs::write(&file_path, "hello").expect("write file");
+        let input = WatchInput::path(
+            file_path.to_string_lossy().as_ref(),
+            temp_dir.path(),
+            WatchInputKind::Explicit,
+        )
+        .expect("path input");
+
+        let first = capture_snapshot(&[input.clone()], ChangeDetectionMode::ContentHash)
+            .expect("first snapshot");
+        thread::sleep(Duration::from_millis(20));
+        fs::write(&file_path, "hello").expect("rewrite same content");
+        let second =
+            capture_snapshot(&[input], ChangeDetectionMode::ContentHash).expect("second snapshot");
+
+        assert!(!second.is_meaningfully_different(&first, ChangeDetectionMode::ContentHash));
+    }
+
+    #[test]
+    fn mtime_mode_detects_metadata_only_churn() {
+        let temp_dir = tempfile::tempdir().expect("create tempdir");
+        let file_path = temp_dir.path().join("input.txt");
+        fs::write(&file_path, "hello").expect("write file");
+        let input = WatchInput::path(
+            file_path.to_string_lossy().as_ref(),
+            temp_dir.path(),
+            WatchInputKind::Explicit,
+        )
+        .expect("path input");
+
+        let first = capture_snapshot(&[input.clone()], ChangeDetectionMode::MtimeOnly)
+            .expect("first snapshot");
+        thread::sleep(Duration::from_millis(20));
+        fs::write(&file_path, "hello").expect("rewrite same content");
+        let second =
+            capture_snapshot(&[input], ChangeDetectionMode::MtimeOnly).expect("second snapshot");
+
+        assert!(second.is_meaningfully_different(&first, ChangeDetectionMode::MtimeOnly));
+    }
+
+    #[test]
+    fn missing_paths_are_captured_explicitly() {
+        let temp_dir = tempfile::tempdir().expect("create tempdir");
+        let input = WatchInput::path("missing.txt", temp_dir.path(), WatchInputKind::Explicit)
+            .expect("path input");
+        let snapshot =
+            capture_snapshot(&[input], ChangeDetectionMode::ContentHash).expect("capture snapshot");
+
+        assert_eq!(snapshot.len(), 1);
+        let entry = snapshot.entries.values().next().expect("snapshot entry");
+        assert_eq!(entry.kind, SnapshotEntryKind::Missing);
+    }
+}

--- a/crates/with-watch/src/watch.rs
+++ b/crates/with-watch/src/watch.rs
@@ -1,0 +1,81 @@
+use std::{
+    sync::mpsc::{self, Receiver},
+    time::Duration,
+};
+
+use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
+
+use crate::{
+    error::{Result, WithWatchError},
+    snapshot::WatchInput,
+};
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct CollectedEvents {
+    pub event_count: usize,
+    pub path_count: usize,
+    pub error_count: usize,
+}
+
+pub struct WatchLoop {
+    _watcher: RecommendedWatcher,
+    rx: Receiver<notify::Result<Event>>,
+}
+
+impl WatchLoop {
+    pub fn new(inputs: &[WatchInput]) -> Result<Self> {
+        let (tx, rx) = mpsc::channel();
+        let mut watcher = notify::recommended_watcher(move |event| {
+            let _ = tx.send(event);
+        })
+        .map_err(WithWatchError::WatcherCreate)?;
+
+        let mut watched_anchors = Vec::new();
+        for input in inputs {
+            let anchor = input.watch_anchor().to_path_buf();
+            if watched_anchors.contains(&anchor) {
+                continue;
+            }
+            watcher
+                .watch(&anchor, RecursiveMode::Recursive)
+                .map_err(|source| WithWatchError::WatchPath {
+                    path: anchor.clone(),
+                    source,
+                })?;
+            watched_anchors.push(anchor);
+        }
+
+        Ok(Self {
+            _watcher: watcher,
+            rx,
+        })
+    }
+
+    pub fn collect_events(
+        &mut self,
+        timeout: Duration,
+        debounce_window: Duration,
+    ) -> Option<CollectedEvents> {
+        let first = self.rx.recv_timeout(timeout).ok()?;
+        let mut collected = CollectedEvents::default();
+        accumulate_event(first, &mut collected);
+
+        while let Ok(event) = self.rx.recv_timeout(debounce_window) {
+            accumulate_event(event, &mut collected);
+        }
+
+        Some(collected)
+    }
+}
+
+fn accumulate_event(event: notify::Result<Event>, collected: &mut CollectedEvents) {
+    collected.event_count += 1;
+    match event {
+        Ok(event) => {
+            collected.path_count += event.paths.len();
+        }
+        Err(_) => {
+            collected.error_count += 1;
+        }
+    }
+}

--- a/crates/with-watch/tests/cli.rs
+++ b/crates/with-watch/tests/cli.rs
@@ -1,0 +1,147 @@
+use std::{
+    fs,
+    path::Path,
+    process::{Command as ProcessCommand, Stdio},
+    thread,
+    time::Duration,
+};
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn with_watch_command() -> Command {
+    Command::new(assert_cmd::cargo::cargo_bin!("with-watch"))
+}
+
+#[test]
+fn help_lists_shell_and_exec_modes() {
+    with_watch_command()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--shell"))
+        .stdout(predicate::str::contains("exec"))
+        .stdout(predicate::str::contains("--no-hash"));
+}
+
+#[test]
+fn pathless_passthrough_guides_users_to_exec_input() {
+    with_watch_command()
+        .args(["ls", "-l"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "No watch inputs could be inferred from the delegated command",
+        ))
+        .stderr(predicate::str::contains("with-watch exec --input"));
+}
+
+#[test]
+fn shell_and_subcommand_cannot_be_combined() {
+    with_watch_command()
+        .args([
+            "--shell",
+            "echo hi",
+            "exec",
+            "--input",
+            "src/**/*.rs",
+            "--",
+            "echo",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be combined"));
+}
+
+#[cfg(unix)]
+#[test]
+fn passthrough_mode_runs_a_posix_utility_once_with_test_hook() {
+    let temp_dir = tempfile::tempdir().expect("create tempdir");
+    let input_path = temp_dir.path().join("input.txt");
+    fs::write(&input_path, "hello\n").expect("write input");
+
+    with_watch_command()
+        .env("WITH_WATCH_TEST_MAX_RUNS", "1")
+        .arg("cat")
+        .arg(&input_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hello"));
+}
+
+#[cfg(unix)]
+#[test]
+fn shell_mode_supports_operators_and_exits_after_one_run_with_test_hook() {
+    let temp_dir = tempfile::tempdir().expect("create tempdir");
+    let input_path = temp_dir.path().join("input.txt");
+    fs::write(&input_path, "hello\n").expect("write input");
+
+    with_watch_command()
+        .env("WITH_WATCH_TEST_MAX_RUNS", "1")
+        .args([
+            "--shell",
+            &format!("cat '{}' | grep hello", input_path.display()),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hello"));
+}
+
+#[cfg(unix)]
+#[test]
+fn exec_mode_reruns_when_an_explicit_input_changes() {
+    let temp_dir = tempfile::tempdir().expect("create tempdir");
+    let input_path = temp_dir.path().join("input.txt");
+    let output_path = temp_dir.path().join("output.txt");
+    fs::write(&input_path, "alpha\n").expect("write input");
+
+    let mut child = ProcessCommand::new(assert_cmd::cargo::cargo_bin!("with-watch"))
+        .current_dir(temp_dir.path())
+        .env("WITH_WATCH_TEST_MAX_RUNS", "2")
+        .env("WITH_WATCH_TEST_DEBOUNCE_MS", "25")
+        .args([
+            "exec",
+            "--input",
+            input_path.to_string_lossy().as_ref(),
+            "--",
+            "sh",
+            "-c",
+            &format!(
+                "cat '{}' >> '{}'",
+                input_path.display(),
+                output_path.display()
+            ),
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn with-watch");
+
+    wait_for_file_lines(&output_path, 1);
+    thread::sleep(Duration::from_millis(50));
+    fs::write(&input_path, "beta\n").expect("rewrite input");
+
+    let status = child.wait().expect("wait for child");
+    assert!(status.success());
+
+    let output = fs::read_to_string(&output_path).expect("read output");
+    let lines = output.lines().collect::<Vec<_>>();
+    assert_eq!(lines, vec!["alpha", "beta"]);
+}
+
+#[cfg(unix)]
+fn wait_for_file_lines(path: &Path, expected_lines: usize) {
+    for _ in 0..80 {
+        if let Ok(contents) = fs::read_to_string(path) {
+            if contents.lines().count() >= expected_lines {
+                return;
+            }
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+    panic!(
+        "timed out waiting for {expected_lines} lines in {}",
+        path.display()
+    );
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,10 @@ Each project must have one project index document and one or more domain contrac
 - `docs/project-nodeup.md`
 - `docs/crates-nodeup-foundation.md`
 
+### with-watch
+- `docs/project-with-watch.md`
+- `docs/crates-with-watch-foundation.md`
+
 ### derun
 - `docs/project-derun.md`
 - `docs/cmds-derun-foundation.md`

--- a/docs/crates-with-watch-foundation.md
+++ b/docs/crates-with-watch-foundation.md
@@ -1,0 +1,57 @@
+# crates-with-watch-foundation
+
+## Scope
+- Project/component: `with-watch` crate foundation contract
+- Canonical path: `crates/with-watch`
+
+## Runtime and Language
+- Runtime: Rust CLI watcher runtime
+- Primary language: Rust
+
+## Users and Operators
+- Developers who want POSIX/coreutils-style commands to rerun automatically when their inputs change
+- Maintainers validating generic watch planning and rerun behavior across platforms
+
+## Interfaces and Contracts
+- Root passthrough mode must remain `with-watch [--no-hash] <utility> [args...]`.
+- Shell mode must remain `with-watch [--no-hash] --shell '<expr>'`.
+- `exec` mode must remain `with-watch exec [--no-hash] --input <glob>... -- <command> [args...]`.
+- Stable internal enums must remain aligned with the current v1 contract:
+  - `ChangeDetectionMode::{ContentHash, MtimeOnly}`
+  - `CommandSource::{Argv, Shell, Exec}`
+  - `WatchInput::{Path, Glob}`
+  - `SnapshotEntryKind::{File, Directory, Missing}`
+- Shell mode must parse command-line expressions with `&&`, `||`, and `|`, while shell control-flow constructs remain out of scope for v1.
+- Generic watch planning must infer inputs from delegated non-flag argument values and option values, while `exec --input` remains the canonical explicit input contract when inference is insufficient.
+
+## Storage
+- `with-watch` does not persist project state.
+- Snapshot state is in-memory only for the current process.
+
+## Security
+- Delegated commands run with inherited stdio and current-process privileges.
+- `with-watch` must not rewrite delegated argv or inject changed-path placeholders into child processes in v1.
+- Logging must avoid printing secret environment values passed through delegated commands.
+
+## Logging
+- Use structured `tracing` logs for command planning, watcher setup, snapshot capture, debounce decisions, and rerun causes.
+- Logs must include `command_source`, `detection_mode`, input counts, and rerun outcomes.
+
+## Build and Test
+- Local validation: `cargo test -p with-watch`
+- Workspace validation baseline: `cargo test --workspace --all-targets`
+- Tests must cover CLI modes, shell parsing, input planning, snapshot diffing, and representative rerun flows.
+
+## Dependencies and Integrations
+- Uses `clap` for CLI parsing.
+- Uses `starbase_args` for shell command-line parsing.
+- Uses `notify` for filesystem event delivery.
+- Uses `blake3` for content-hash-based rerun filtering.
+
+## Change Triggers
+- Update `docs/project-with-watch.md` with this file when command shape, detection behavior, or ownership changes.
+- Update `docs/README.md`, root `AGENTS.md`, and `crates/AGENTS.md` when project registration or policy changes.
+
+## References
+- `docs/project-with-watch.md`
+- `docs/domain-template.md`

--- a/docs/project-with-watch.md
+++ b/docs/project-with-watch.md
@@ -1,0 +1,29 @@
+# Project: with-watch
+
+## Goal
+Provide a Rust-based CLI wrapper that reruns delegated shell utilities and arbitrary commands when inferred or explicit filesystem inputs change.
+
+## Project ID
+`with-watch`
+
+## Domain Ownership Map
+- `crates/with-watch`
+
+## Domain Contract Documents
+- `docs/crates-with-watch-foundation.md`
+
+## Cross-Domain Invariants
+- Root passthrough mode must remain `with-watch [--no-hash] <utility> [args...]`.
+- Shell mode must remain `with-watch [--no-hash] --shell '<expr>'` and is the supported entrypoint for `&&`, `||`, and `|`.
+- Arbitrary command mode must remain `with-watch exec [--no-hash] --input <glob>... -- <command> [args...]`.
+- Default change detection must prefer content hashing, while `--no-hash` must switch the rerun filter to metadata-only comparison.
+- `exec --input` reruns the delegated command unchanged and must not inject changed paths into argv or environment variables.
+
+## Change Policy
+- Update this index and `docs/crates-with-watch-foundation.md` together when CLI shape, watch inference behavior, or storage/logging contracts change.
+- Keep root `AGENTS.md` and `crates/AGENTS.md` aligned with ownership and project-ID changes.
+
+## References
+- `docs/project-template.md`
+- `docs/domain-template.md`
+- `docs/README.md`


### PR DESCRIPTION
## Summary
- add the new `with-watch` Rust workspace crate with passthrough, `--shell`, and `exec --input` modes
- implement generic watch-input inference, snapshot-based rerun filtering, and a `notify`-driven watch loop
- document and register the new project in `docs/` and `AGENTS.md`

## Testing
- cargo test -p with-watch
- cargo test