### PR TITLE
feat(with-watch): add public release automation

### DIFF
--- a/.github/workflows/release-with-watch.yml
+++ b/.github/workflows/release-with-watch.yml
@@ -1,0 +1,247 @@
+name: Release with-watch
+
+on:
+  push:
+    tags:
+      - "with-watch@v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Semver without v prefix (for example: 0.2.0)"
+        required: true
+      dry_run:
+        description: "If true, skip release publication and Homebrew tap push"
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: release-with-watch-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Prepare metadata
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.meta.outputs.tag }}
+      version: ${{ steps.meta.outputs.version }}
+      dry_run: ${{ steps.meta.outputs.dry_run }}
+    steps:
+      - name: Resolve release metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            tag="with-watch@v${{ github.event.inputs.version }}"
+            dry_run="${{ github.event.inputs.dry_run }}"
+          else
+            tag="${GITHUB_REF_NAME}"
+            dry_run="false"
+          fi
+
+          version="${tag#with-watch@v}"
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "dry_run=$dry_run" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build (${{ matrix.asset_os }}-${{ matrix.asset_arch }})
+    runs-on: ${{ matrix.os }}
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            asset_os: linux
+            asset_arch: amd64
+            archive_ext: tar.gz
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+            asset_os: darwin
+            asset_arch: amd64
+            archive_ext: tar.gz
+          - os: macos-14
+            target: aarch64-apple-darwin
+            asset_os: darwin
+            asset_arch: arm64
+            archive_ext: tar.gz
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            asset_os: windows
+            asset_arch: amd64
+            archive_ext: zip
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: nightly-2026-01-01
+          target: ${{ matrix.target }}
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build with-watch
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build -p with-watch --release --target "${{ matrix.target }}"
+
+      - name: Package artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p dist
+          artifact_name="with-watch-${{ matrix.asset_os }}-${{ matrix.asset_arch }}.${{ matrix.archive_ext }}"
+          binary_name="with-watch-${{ matrix.asset_os }}-${{ matrix.asset_arch }}"
+          source_binary="target/${{ matrix.target }}/release/with-watch"
+
+          if [ "${{ matrix.asset_os }}" = "windows" ]; then
+            binary_name="${binary_name}.exe"
+            source_binary="${source_binary}.exe"
+          fi
+
+          cp "$source_binary" "dist/${binary_name}"
+
+          if [ "${{ matrix.asset_os }}" = "windows" ]; then
+            cp "$source_binary" "dist/with-watch.exe"
+            pwsh -NoLogo -NoProfile -Command "Compress-Archive -Path dist/with-watch.exe -DestinationPath dist/${artifact_name}"
+            rm -f "dist/with-watch.exe"
+          else
+            cp "$source_binary" "dist/with-watch"
+            tar -C dist -czf "dist/${artifact_name}" with-watch
+            rm -f "dist/with-watch"
+          fi
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: with-watch-${{ matrix.asset_os }}-${{ matrix.asset_arch }}
+          path: dist/*
+
+  publish:
+    name: Publish release
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
+      - build
+    env:
+      RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+      RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+      DRY_RUN: ${{ needs.prepare.outputs.dry_run }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: dist
+
+      - name: Flatten artifact directory
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p release-dist
+          find dist -maxdepth 2 -type f -exec cp "{}" "release-dist/" \;
+          rm -rf dist
+          mv release-dist dist
+          find dist -maxdepth 1 -type f | sed 's#^#artifact: #' >&2
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.1.1
+
+      - name: Generate checksums and signatures
+        shell: bash
+        run: |
+          set -euo pipefail
+          chmod +x ./scripts/release/generate-checksums.sh
+          ./scripts/release/generate-checksums.sh --artifacts-dir dist
+
+      - name: Create GitHub release
+        if: env.DRY_RUN != 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          files: dist/*
+          generate_release_notes: true
+
+      - name: Render Homebrew update
+        if: env.DRY_RUN == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          chmod +x ./scripts/release/update-homebrew.sh
+
+          darwin_amd64_asset="with-watch-darwin-amd64.tar.gz"
+          darwin_amd64_sha="$(grep " ${darwin_amd64_asset}$" dist/SHA256SUMS | awk '{print $1}')"
+          darwin_amd64_url="https://github.com/delinoio/oss/releases/download/${RELEASE_TAG}/${darwin_amd64_asset}"
+
+          darwin_arm64_asset="with-watch-darwin-arm64.tar.gz"
+          darwin_arm64_sha="$(grep " ${darwin_arm64_asset}$" dist/SHA256SUMS | awk '{print $1}')"
+          darwin_arm64_url="https://github.com/delinoio/oss/releases/download/${RELEASE_TAG}/${darwin_arm64_asset}"
+
+          linux_amd64_asset="with-watch-linux-amd64.tar.gz"
+          linux_amd64_sha="$(grep " ${linux_amd64_asset}$" dist/SHA256SUMS | awk '{print $1}')"
+          linux_amd64_url="https://github.com/delinoio/oss/releases/download/${RELEASE_TAG}/${linux_amd64_asset}"
+
+          ./scripts/release/update-homebrew.sh \
+            --project with-watch \
+            --version "$RELEASE_VERSION" \
+            --darwin-amd64-url "$darwin_amd64_url" \
+            --darwin-amd64-sha256 "$darwin_amd64_sha" \
+            --darwin-arm64-url "$darwin_arm64_url" \
+            --darwin-arm64-sha256 "$darwin_arm64_sha" \
+            --linux-amd64-url "$linux_amd64_url" \
+            --linux-amd64-sha256 "$linux_amd64_sha" \
+            --dry-run >/dev/null
+
+      - name: Submit Homebrew update
+        if: env.DRY_RUN != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          chmod +x ./scripts/release/update-homebrew.sh
+
+          darwin_amd64_asset="with-watch-darwin-amd64.tar.gz"
+          darwin_amd64_sha="$(grep " ${darwin_amd64_asset}$" dist/SHA256SUMS | awk '{print $1}')"
+          darwin_amd64_url="https://github.com/delinoio/oss/releases/download/${RELEASE_TAG}/${darwin_amd64_asset}"
+
+          darwin_arm64_asset="with-watch-darwin-arm64.tar.gz"
+          darwin_arm64_sha="$(grep " ${darwin_arm64_asset}$" dist/SHA256SUMS | awk '{print $1}')"
+          darwin_arm64_url="https://github.com/delinoio/oss/releases/download/${RELEASE_TAG}/${darwin_arm64_asset}"
+
+          linux_amd64_asset="with-watch-linux-amd64.tar.gz"
+          linux_amd64_sha="$(grep " ${linux_amd64_asset}$" dist/SHA256SUMS | awk '{print $1}')"
+          linux_amd64_url="https://github.com/delinoio/oss/releases/download/${RELEASE_TAG}/${linux_amd64_asset}"
+
+          ./scripts/release/update-homebrew.sh \
+            --project with-watch \
+            --version "$RELEASE_VERSION" \
+            --darwin-amd64-url "$darwin_amd64_url" \
+            --darwin-amd64-sha256 "$darwin_amd64_sha" \
+            --darwin-arm64-url "$darwin_arm64_url" \
+            --darwin-arm64-sha256 "$darwin_arm64_sha" \
+            --linux-amd64-url "$linux_amd64_url" \
+            --linux-amd64-sha256 "$linux_amd64_sha"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,6 +343,9 @@ Release automation baseline:
 - `release-derun` is defined in `.github/workflows/release-derun.yml`.
 - Trigger contract: runs on tag push `derun@v*` and supports `workflow_dispatch` (`version`, `dry_run`).
 - Distribution contract: publishes signed multi-OS derun release artifacts and updates Homebrew (`derun`) from GitHub release prebuilt archives (`darwin-amd64`, `darwin-arm64`, `linux-amd64`).
+- `release-with-watch` is defined in `.github/workflows/release-with-watch.yml`.
+- Trigger contract: runs on tag push `with-watch@v*` and supports `workflow_dispatch` (`version`, `dry_run`).
+- Distribution contract: publishes signed multi-OS with-watch release artifacts, including standalone prebuilt binaries (`with-watch-<os>-<arch>[.exe]`) and archive assets (`with-watch-<os>-<arch>.tar.gz|zip`), then updates Homebrew (`with-watch`) from GitHub release prebuilt archives (`darwin-amd64`, `darwin-arm64`, `linux-amd64`).
 - `release-dexdex` is defined in `.github/workflows/release-dexdex.yml`.
 - Trigger contract: runs on tag push `dexdex@v*` and supports `workflow_dispatch` (`version`, `dry_run`).
 - Distribution contract: publishes signed DexDex desktop + main/worker server artifacts and applies desktop signing/notarization secrets, then updates Homebrew (`dexdex`, `dexdex-main-server`, `dexdex-worker-server`) where DexDex server formulas consume prebuilt release artifacts for `darwin/amd64`, `darwin/arm64`, and `linux/amd64`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.metadata.cargo-mono.publish.tag]
-packages = ["nodeup", "cargo-mono", "rustia-rs", "rustia-macros", "rustia-llm"]
+packages = ["nodeup", "with-watch", "cargo-mono", "rustia-rs", "rustia-macros", "rustia-llm"]
 
 # Release profile optimizations
 [profile.release]

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -46,6 +46,7 @@
 - Keep default rerun filtering content-hash-based, with `--no-hash` as the documented metadata-only override.
 - Keep shell support scoped to command-line expressions and do not silently broaden into shell-script control-flow without updating docs first.
 - Keep logs sufficient to explain inferred inputs, watcher anchors, snapshot counts, and rerun causes.
+- Keep public release contracts aligned across root publish-tag allowlist, `.github/workflows/release-with-watch.yml`, and Homebrew packaging assets.
 
 ### serde-feather-Specific Rules
 

--- a/crates/with-watch/Cargo.toml
+++ b/crates/with-watch/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 license = "MIT"
 description = "Watch command inputs and rerun commands when they change"
 readme = "README.md"
-publish = false
 
 [dependencies]
 blake3 = "1.8.4"

--- a/crates/with-watch/Cargo.toml
+++ b/crates/with-watch/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 license = "MIT"
 description = "Watch command inputs and rerun commands when they change"
 readme = "README.md"
+repository = "https://github.com/delinoio/oss"
 
 [dependencies]
 blake3 = "1.8.4"

--- a/crates/with-watch/README.md
+++ b/crates/with-watch/README.md
@@ -2,6 +2,13 @@
 
 `with-watch` reruns a delegated command when its inferred or explicit filesystem inputs change.
 
+## Install
+
+```sh
+cargo install with-watch
+brew install delinoio/tap/with-watch
+```
+
 ## Examples
 
 ```sh

--- a/docs/crates-with-watch-foundation.md
+++ b/docs/crates-with-watch-foundation.md
@@ -11,11 +11,14 @@
 ## Users and Operators
 - Developers who want POSIX/coreutils-style commands to rerun automatically when their inputs change
 - Maintainers validating generic watch planning and rerun behavior across platforms
+- Release engineers operating crate publication and binary distribution workflows
 
 ## Interfaces and Contracts
 - Root passthrough mode must remain `with-watch [--no-hash] <utility> [args...]`.
 - Shell mode must remain `with-watch [--no-hash] --shell '<expr>'`.
 - `exec` mode must remain `with-watch exec [--no-hash] --input <glob>... -- <command> [args...]`.
+- Public crate installation must remain `cargo install with-watch`.
+- Publish tag naming must remain `with-watch@v<version>`.
 - Stable internal enums must remain aligned with the current v1 contract:
   - `ChangeDetectionMode::{ContentHash, MtimeOnly}`
   - `CommandSource::{Argv, Shell, Exec}`
@@ -23,6 +26,7 @@
   - `SnapshotEntryKind::{File, Directory, Missing}`
 - Shell mode must parse command-line expressions with `&&`, `||`, and `|`, while shell control-flow constructs remain out of scope for v1.
 - Generic watch planning must infer inputs from delegated non-flag argument values and option values, while `exec --input` remains the canonical explicit input contract when inference is insufficient.
+- Homebrew installation must consume prebuilt GitHub release archives for `darwin/amd64`, `darwin/arm64`, and `linux/amd64`.
 
 ## Storage
 - `with-watch` does not persist project state.
@@ -32,6 +36,7 @@
 - Delegated commands run with inherited stdio and current-process privileges.
 - `with-watch` must not rewrite delegated argv or inject changed-path placeholders into child processes in v1.
 - Logging must avoid printing secret environment values passed through delegated commands.
+- Release automation must publish checksum manifests and Sigstore bundle sidecars without exposing registry or tap-write credentials.
 
 ## Logging
 - Use structured `tracing` logs for command planning, watcher setup, snapshot capture, debounce decisions, and rerun causes.
@@ -40,6 +45,10 @@
 ## Build and Test
 - Local validation: `cargo test -p with-watch`
 - Workspace validation baseline: `cargo test --workspace --all-targets`
+- Publishability validation: `cargo publish -p with-watch --dry-run`
+- Release contract checks should align with `.github/workflows/release-with-watch.yml`.
+- Release assets must include standalone binaries (`with-watch-<os>-<arch>[.exe]`) and compressed archives (`with-watch-<os>-<arch>.tar.gz|zip`) for the supported release matrix.
+- Release signing outputs must include `SHA256SUMS.sigstore.json` and `<artifact>.sigstore.json` sidecars.
 - Tests must cover CLI modes, shell parsing, input planning, snapshot diffing, and representative rerun flows.
 
 ## Dependencies and Integrations
@@ -47,9 +56,11 @@
 - Uses `starbase_args` for shell command-line parsing.
 - Uses `notify` for filesystem event delivery.
 - Uses `blake3` for content-hash-based rerun filtering.
+- Integrates with root `auto-publish` tag publication and `.github/workflows/release-with-watch.yml`.
+- Integrates with Homebrew tap automation through `scripts/release/update-homebrew.sh` and `packaging/homebrew/templates/with-watch.rb.tmpl`.
 
 ## Change Triggers
-- Update `docs/project-with-watch.md` with this file when command shape, detection behavior, or ownership changes.
+- Update `docs/project-with-watch.md` with this file when command shape, detection behavior, release distribution, or ownership changes.
 - Update `docs/README.md`, root `AGENTS.md`, and `crates/AGENTS.md` when project registration or policy changes.
 
 ## References

--- a/docs/project-with-watch.md
+++ b/docs/project-with-watch.md
@@ -18,9 +18,14 @@ Provide a Rust-based CLI wrapper that reruns delegated shell utilities and arbit
 - Arbitrary command mode must remain `with-watch exec [--no-hash] --input <glob>... -- <command> [args...]`.
 - Default change detection must prefer content hashing, while `--no-hash` must switch the rerun filter to metadata-only comparison.
 - `exec --input` reruns the delegated command unchanged and must not inject changed paths into argv or environment variables.
+- Public crate distribution must remain `cargo install with-watch`.
+- Publish tag eligibility must remain enabled through root `[workspace.metadata.cargo-mono.publish.tag].packages`, and release tag naming must remain `with-watch@v<version>`.
+- Release automation must publish signed GitHub Release assets for `linux/amd64`, `darwin/amd64`, `darwin/arm64`, and `windows/amd64`, including standalone binaries (`with-watch-<os>-<arch>[.exe]`) and archives (`with-watch-<os>-<arch>.tar.gz|zip`).
+- Homebrew installation must consume prebuilt `with-watch` release archives for `darwin/amd64`, `darwin/arm64`, and `linux/amd64`.
 
 ## Change Policy
-- Update this index and `docs/crates-with-watch-foundation.md` together when CLI shape, watch inference behavior, or storage/logging contracts change.
+- Update this index and `docs/crates-with-watch-foundation.md` together when CLI shape, watch inference behavior, release automation, or storage/logging contracts change.
+- Update root `Cargo.toml`, `.github/workflows/release-with-watch.yml`, `scripts/release/update-homebrew.sh`, and `packaging/homebrew/templates/with-watch.rb.tmpl` in the same change when with-watch release tags, artifact names, or package-manager distribution contracts change.
 - Keep root `AGENTS.md` and `crates/AGENTS.md` aligned with ownership and project-ID changes.
 
 ## References

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -5,6 +5,7 @@ This directory contains Homebrew formula/cask templates rendered by `scripts/rel
 Supported package identifiers:
 
 - `nodeup` (prebuilt formula: `darwin/amd64`, `darwin/arm64`, `linux/amd64`)
+- `with-watch` (prebuilt formula: `darwin/amd64`, `darwin/arm64`, `linux/amd64`)
 - `derun`
 - `dexdex-main-server` (prebuilt formula: `darwin/amd64`, `darwin/arm64`, `linux/amd64`)
 - `dexdex-worker-server` (prebuilt formula: `darwin/amd64`, `darwin/arm64`, `linux/amd64`)

--- a/packaging/homebrew/templates/with-watch.rb.tmpl
+++ b/packaging/homebrew/templates/with-watch.rb.tmpl
@@ -1,0 +1,33 @@
+class WithWatch < Formula
+  desc "Watch command inputs and rerun commands when they change"
+  homepage "https://github.com/delinoio/oss"
+  version "__VERSION__"
+  license "MIT"
+
+  on_macos do
+    if Hardware::CPU.intel?
+      url "__DARWIN_AMD64_URL__"
+      sha256 "__DARWIN_AMD64_SHA256__"
+    else
+      url "__DARWIN_ARM64_URL__"
+      sha256 "__DARWIN_ARM64_SHA256__"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.intel?
+      url "__LINUX_AMD64_URL__"
+      sha256 "__LINUX_AMD64_SHA256__"
+    else
+      odie "with-watch prebuilt distribution currently supports Linux amd64 only"
+    end
+  end
+
+  def install
+    bin.install "with-watch"
+  end
+
+  test do
+    assert_predicate bin/"with-watch", :exist?
+  end
+end

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -1,11 +1,12 @@
 # Release Automation Scripts
 
 - `generate-checksums.sh`: produces `SHA256SUMS` and Sigstore bundle sidecars (`*.sigstore.json`) for each published artifact.
-- `update-homebrew.sh`: renders and optionally pushes Homebrew formula/cask updates to the tap repository `main` branch (DexDex server formulas and nodeup consume prebuilt multi-OS release artifacts). In non-dry-run mode, it expects `HOMEBREW_TAP_GH_TOKEN` (or `GH_TOKEN`) with write access to the tap repository and sets a fixed local commit identity (`github-actions[bot] <github-actions@users.noreply.github.com>`) before creating the tap commit.
+- `update-homebrew.sh`: renders and optionally pushes Homebrew formula/cask updates to the tap repository `main` branch (DexDex server formulas, nodeup, and with-watch consume prebuilt multi-OS release artifacts). In non-dry-run mode, it expects `HOMEBREW_TAP_GH_TOKEN` (or `GH_TOKEN`) with write access to the tap repository and sets a fixed local commit identity (`github-actions[bot] <github-actions@users.noreply.github.com>`) before creating the tap commit.
 
 These scripts are designed for use by release workflows:
 
 - `.github/workflows/release-cargo-mono.yml`
 - `.github/workflows/release-nodeup.yml`
 - `.github/workflows/release-derun.yml`
+- `.github/workflows/release-with-watch.yml`
 - `.github/workflows/release-dexdex.yml`

--- a/scripts/release/update-homebrew.sh
+++ b/scripts/release/update-homebrew.sh
@@ -8,7 +8,7 @@ Render and optionally push Homebrew formula/cask updates.
 
 Usage:
   ./scripts/release/update-homebrew.sh \
-    --project <nodeup|derun|dexdex-main-server|dexdex-worker-server|dexdex> \
+    --project <nodeup|with-watch|derun|dexdex-main-server|dexdex-worker-server|dexdex> \
     --version <semver> \
     [--darwin-amd64-url <url>] [--darwin-amd64-sha256 <sha>] \
     [--darwin-arm64-url <url>] [--darwin-arm64-sha256 <sha>] \
@@ -20,17 +20,17 @@ Options:
   --project <id>         Package identifier.
   --version <semver>     Release version without v-prefix.
   --darwin-amd64-url <url>
-                         Darwin amd64 prebuilt artifact URL (nodeup, derun, and DexDex server formulas).
+                         Darwin amd64 prebuilt artifact URL (nodeup, with-watch, derun, and DexDex server formulas).
   --darwin-amd64-sha256 <sha>
-                         Darwin amd64 prebuilt artifact SHA256 (nodeup, derun, and DexDex server formulas).
+                         Darwin amd64 prebuilt artifact SHA256 (nodeup, with-watch, derun, and DexDex server formulas).
   --darwin-arm64-url <url>
-                         Darwin arm64 prebuilt artifact URL (nodeup, derun, and DexDex server formulas).
+                         Darwin arm64 prebuilt artifact URL (nodeup, with-watch, derun, and DexDex server formulas).
   --darwin-arm64-sha256 <sha>
-                         Darwin arm64 prebuilt artifact SHA256 (nodeup, derun, and DexDex server formulas).
+                         Darwin arm64 prebuilt artifact SHA256 (nodeup, with-watch, derun, and DexDex server formulas).
   --linux-amd64-url <url>
-                         Linux amd64 prebuilt artifact URL (nodeup, derun, and DexDex server formulas).
+                         Linux amd64 prebuilt artifact URL (nodeup, with-watch, derun, and DexDex server formulas).
   --linux-amd64-sha256 <sha>
-                         Linux amd64 prebuilt artifact SHA256 (nodeup, derun, and DexDex server formulas).
+                         Linux amd64 prebuilt artifact SHA256 (nodeup, with-watch, derun, and DexDex server formulas).
   --desktop-url <url>    Desktop installer URL (dexdex cask).
   --desktop-sha256 <sha> Desktop installer SHA256 (dexdex cask).
   --tap-repo <repo>      Homebrew tap repository (default: delinoio/homebrew-tap).
@@ -129,7 +129,7 @@ rendered_file=""
 destination_path=""
 
 case "$project" in
-  nodeup|derun|dexdex-main-server|dexdex-worker-server)
+  nodeup|with-watch|derun|dexdex-main-server|dexdex-worker-server)
     if [ -z "$darwin_amd64_url" ] || [ -z "$darwin_amd64_sha256" ] || [ -z "$darwin_arm64_url" ] || [ -z "$darwin_arm64_sha256" ] || [ -z "$linux_amd64_url" ] || [ -z "$linux_amd64_sha256" ]; then
       log "$project requires --darwin-amd64-url, --darwin-amd64-sha256, --darwin-arm64-url, --darwin-arm64-sha256, --linux-amd64-url, and --linux-amd64-sha256"
       exit 1


### PR DESCRIPTION
## Summary
- promote `with-watch` to a public release target by enabling crate publication and adding it to the `cargo-mono` publish-tag allowlist
- add a dedicated `release-with-watch` GitHub Actions workflow for signed multi-platform GitHub Releases and Homebrew tap updates
- document the new release contracts across AGENTS/docs and add a Homebrew formula template for `with-watch`

## Testing
- `cargo test -p with-watch`
- `cargo test --workspace --all-targets`
- `cargo publish -p with-watch --dry-run`
- `cargo mono publish --dry-run`
- `./scripts/release/update-homebrew.sh --project with-watch --version 0.1.0 --darwin-amd64-url https://example.com/with-watch-darwin-amd64.tar.gz --darwin-amd64-sha256 1111111111111111111111111111111111111111111111111111111111111111 --darwin-arm64-url https://example.com/with-watch-darwin-arm64.tar.gz --darwin-arm64-sha256 2222222222222222222222222222222222222222222222222222222222222222 --linux-amd64-url https://example.com/with-watch-linux-amd64.tar.gz --linux-amd64-sha256 3333333333333333333333333333333333333333333333333333333333333333 --dry-run`
