### PR TITLE
feat: complete with-watch command inference

### DIFF
--- a/crates/with-watch/README.md
+++ b/crates/with-watch/README.md
@@ -6,6 +6,15 @@
 
 ```sh
 with-watch cp src.txt dest.txt
+with-watch ls -l
 with-watch --shell 'cat src.txt | grep hello'
+with-watch sed -i.bak -e 's/old/new/' config.txt
 with-watch exec --input 'src/**/*.rs' -- cargo test -p with-watch
 ```
+
+## Inference Model
+
+- Passthrough and shell modes use built-in command adapters before falling back to conservative path heuristics.
+- Known outputs, inline scripts, patterns, and shell output redirects are filtered out of the watch set.
+- Pathless defaults are intentionally narrow: only `ls`, `dir`, `vdir`, `du`, and `find` implicitly watch the current directory.
+- `exec --input` remains the explicit escape hatch when a delegated command has no meaningful filesystem inputs or when fallback inference would be ambiguous.

--- a/crates/with-watch/src/analysis.rs
+++ b/crates/with-watch/src/analysis.rs
@@ -1,0 +1,2311 @@
+use std::{ffi::OsString, path::Path};
+
+use crate::{
+    error::Result,
+    parser::{ParsedShellExpression, ShellRedirect, ShellRedirectOperator},
+    snapshot::{WatchInput, WatchInputKind},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandAdapterId {
+    WrapperEnv,
+    WrapperNice,
+    WrapperNohup,
+    WrapperStdbuf,
+    WrapperTimeout,
+    CopyLike,
+    MoveLike,
+    Install,
+    LinkLike,
+    RemoveLike,
+    ReadPaths,
+    DefaultCurrentDir,
+    Grep,
+    Sed,
+    Awk,
+    Find,
+    Xargs,
+    Tar,
+    Sort,
+    Uniq,
+    Split,
+    Csplit,
+    Tee,
+    Touch,
+    Truncate,
+    ChangeAttributes,
+    Dd,
+    NonWatchable,
+    Fallback,
+}
+
+impl CommandAdapterId {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::WrapperEnv => "wrapper-env",
+            Self::WrapperNice => "wrapper-nice",
+            Self::WrapperNohup => "wrapper-nohup",
+            Self::WrapperStdbuf => "wrapper-stdbuf",
+            Self::WrapperTimeout => "wrapper-timeout",
+            Self::CopyLike => "copy-like",
+            Self::MoveLike => "move-like",
+            Self::Install => "install",
+            Self::LinkLike => "link-like",
+            Self::RemoveLike => "remove-like",
+            Self::ReadPaths => "read-paths",
+            Self::DefaultCurrentDir => "default-current-dir",
+            Self::Grep => "grep",
+            Self::Sed => "sed",
+            Self::Awk => "awk",
+            Self::Find => "find",
+            Self::Xargs => "xargs",
+            Self::Tar => "tar",
+            Self::Sort => "sort",
+            Self::Uniq => "uniq",
+            Self::Split => "split",
+            Self::Csplit => "csplit",
+            Self::Tee => "tee",
+            Self::Touch => "touch",
+            Self::Truncate => "truncate",
+            Self::ChangeAttributes => "change-attributes",
+            Self::Dd => "dd",
+            Self::NonWatchable => "non-watchable",
+            Self::Fallback => "fallback",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SideEffectProfile {
+    ReadOnly,
+    WritesExcludedOutputs,
+    WritesWatchedInputs,
+}
+
+impl SideEffectProfile {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ReadOnly => "read-only",
+            Self::WritesExcludedOutputs => "writes-excluded-outputs",
+            Self::WritesWatchedInputs => "writes-watched-inputs",
+        }
+    }
+
+    fn merge(self, other: Self) -> Self {
+        self.max(other)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandAnalysisStatus {
+    Resolved,
+    NoInputs,
+    AmbiguousFallback,
+}
+
+impl CommandAnalysisStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Resolved => "resolved",
+            Self::NoInputs => "no-inputs",
+            Self::AmbiguousFallback => "ambiguous-fallback",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CommandAnalysis {
+    pub inputs: Vec<WatchInput>,
+    pub adapter_ids: Vec<CommandAdapterId>,
+    pub fallback_used: bool,
+    pub default_watch_root_used: bool,
+    pub filtered_output_count: usize,
+    pub side_effect_profile: SideEffectProfile,
+    pub status: CommandAnalysisStatus,
+}
+
+impl CommandAnalysis {
+    pub fn adapter_field(&self) -> String {
+        self.adapter_ids
+            .iter()
+            .map(|adapter| adapter.as_str())
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SingleCommandAnalysis {
+    inputs: Vec<WatchInput>,
+    adapter_ids: Vec<CommandAdapterId>,
+    fallback_used: bool,
+    default_watch_root_used: bool,
+    filtered_output_count: usize,
+    side_effect_profile: SideEffectProfile,
+    status: CommandAnalysisStatus,
+}
+
+impl SingleCommandAnalysis {
+    fn empty(adapter_id: CommandAdapterId) -> Self {
+        Self {
+            inputs: Vec::new(),
+            adapter_ids: vec![adapter_id],
+            fallback_used: adapter_id == CommandAdapterId::Fallback,
+            default_watch_root_used: false,
+            filtered_output_count: 0,
+            side_effect_profile: SideEffectProfile::ReadOnly,
+            status: CommandAnalysisStatus::NoInputs,
+        }
+    }
+
+    fn finalize(mut self) -> Self {
+        if self.status != CommandAnalysisStatus::AmbiguousFallback {
+            self.status = if self.inputs.is_empty() {
+                CommandAnalysisStatus::NoInputs
+            } else {
+                CommandAnalysisStatus::Resolved
+            };
+        }
+        self
+    }
+}
+
+pub fn analyze_argv(argv: &[OsString], cwd: &Path) -> Result<CommandAnalysis> {
+    let argv = argv
+        .iter()
+        .map(|value| value.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+
+    let analysis = if argv.is_empty() {
+        SingleCommandAnalysis::empty(CommandAdapterId::NonWatchable)
+    } else {
+        analyze_command_tokens(&argv, &[], cwd)?
+    };
+
+    Ok(aggregate_analyses([analysis]))
+}
+
+pub fn analyze_shell_expression(
+    expression: &ParsedShellExpression,
+    cwd: &Path,
+) -> Result<CommandAnalysis> {
+    let mut analyses = Vec::new();
+
+    for command in &expression.commands {
+        analyses.push(analyze_command_tokens(
+            &command.argv,
+            &command.redirects,
+            cwd,
+        )?);
+    }
+
+    Ok(aggregate_analyses(analyses))
+}
+
+fn aggregate_analyses<I>(analyses: I) -> CommandAnalysis
+where
+    I: IntoIterator<Item = SingleCommandAnalysis>,
+{
+    let mut inputs = Vec::new();
+    let mut adapter_ids = Vec::new();
+    let mut fallback_used = false;
+    let mut default_watch_root_used = false;
+    let mut filtered_output_count = 0usize;
+    let mut side_effect_profile = SideEffectProfile::ReadOnly;
+    let mut status = CommandAnalysisStatus::NoInputs;
+
+    for analysis in analyses {
+        for input in analysis.inputs {
+            if !inputs.contains(&input) {
+                inputs.push(input);
+            }
+        }
+        for adapter_id in analysis.adapter_ids {
+            if !adapter_ids.contains(&adapter_id) {
+                adapter_ids.push(adapter_id);
+            }
+        }
+        fallback_used |= analysis.fallback_used;
+        default_watch_root_used |= analysis.default_watch_root_used;
+        filtered_output_count += analysis.filtered_output_count;
+        side_effect_profile = side_effect_profile.merge(analysis.side_effect_profile);
+        if analysis.status == CommandAnalysisStatus::AmbiguousFallback {
+            status = CommandAnalysisStatus::AmbiguousFallback;
+        } else if analysis.status == CommandAnalysisStatus::Resolved
+            && status != CommandAnalysisStatus::AmbiguousFallback
+        {
+            status = CommandAnalysisStatus::Resolved;
+        }
+    }
+
+    if status != CommandAnalysisStatus::AmbiguousFallback && inputs.is_empty() {
+        status = CommandAnalysisStatus::NoInputs;
+    }
+
+    CommandAnalysis {
+        inputs,
+        adapter_ids,
+        fallback_used,
+        default_watch_root_used,
+        filtered_output_count,
+        side_effect_profile,
+        status,
+    }
+}
+
+fn analyze_command_tokens(
+    argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    if argv.is_empty() {
+        return Ok(SingleCommandAnalysis::empty(CommandAdapterId::NonWatchable));
+    }
+
+    let command_name = command_name(argv[0].as_str());
+    let mut analysis = match command_name.as_str() {
+        "env" => analyze_env_wrapper(argv, redirects, cwd)?,
+        "nice" => analyze_nice_wrapper(argv, redirects, cwd)?,
+        "nohup" => analyze_nohup_wrapper(argv, redirects, cwd)?,
+        "stdbuf" => analyze_stdbuf_wrapper(argv, redirects, cwd)?,
+        "timeout" => analyze_timeout_wrapper(argv, redirects, cwd)?,
+        "cp" => analyze_copy_like(
+            argv,
+            CommandAdapterId::CopyLike,
+            SideEffectProfile::WritesExcludedOutputs,
+            redirects,
+            cwd,
+        )?,
+        "mv" => analyze_copy_like(
+            argv,
+            CommandAdapterId::MoveLike,
+            SideEffectProfile::WritesWatchedInputs,
+            redirects,
+            cwd,
+        )?,
+        "install" => analyze_install(argv, redirects, cwd)?,
+        "ln" | "link" => analyze_link_like(argv, redirects, cwd)?,
+        "rm" | "unlink" | "rmdir" | "shred" => analyze_remove_like(argv, redirects, cwd)?,
+        "sort" => analyze_sort(argv, redirects, cwd)?,
+        "uniq" => analyze_uniq(argv, redirects, cwd)?,
+        "split" => analyze_split(argv, redirects, cwd)?,
+        "csplit" => analyze_csplit(argv, redirects, cwd)?,
+        "tee" => analyze_tee(argv, redirects, cwd)?,
+        "grep" | "egrep" | "fgrep" => analyze_grep(argv, redirects, cwd)?,
+        "sed" => analyze_sed(argv, redirects, cwd)?,
+        "awk" | "gawk" | "mawk" | "nawk" => analyze_awk(argv, redirects, cwd)?,
+        "find" => analyze_find(argv, redirects, cwd)?,
+        "xargs" => analyze_xargs(argv, redirects, cwd)?,
+        "tar" => analyze_tar(argv, redirects, cwd)?,
+        "touch" => analyze_touch_like(argv, CommandAdapterId::Touch, redirects, cwd)?,
+        "truncate" => analyze_touch_like(argv, CommandAdapterId::Truncate, redirects, cwd)?,
+        "chmod" | "chown" | "chgrp" => analyze_change_attributes(argv, redirects, cwd)?,
+        "dd" => analyze_dd(argv, redirects, cwd)?,
+        name if DEFAULT_CURRENT_DIR_COMMANDS.contains(&name) => {
+            analyze_default_current_dir_reader(argv, redirects, cwd)?
+        }
+        name if NONWATCHABLE_COMMANDS.contains(&name) => {
+            analyze_non_watchable(argv, redirects, cwd)?
+        }
+        name if GENERIC_READ_PATH_COMMANDS.contains(&name) => {
+            analyze_generic_read_paths(argv, redirects, cwd)?
+        }
+        _ => analyze_fallback(argv, redirects, cwd)?,
+    };
+
+    if analysis.adapter_ids.is_empty() {
+        analysis.adapter_ids.push(CommandAdapterId::Fallback);
+    }
+
+    Ok(analysis.finalize())
+}
+
+const DEFAULT_CURRENT_DIR_COMMANDS: &[&str] = &["ls", "dir", "vdir", "du"];
+const NONWATCHABLE_COMMANDS: &[&str] = &[
+    "echo", "printf", "seq", "yes", "sleep", "date", "uname", "pwd", "true", "false", "basename",
+    "dirname", "nproc", "printenv", "whoami", "logname", "users", "hostid", "numfmt", "mktemp",
+    "mkdir", "mkfifo", "mknod",
+];
+const GENERIC_READ_PATH_COMMANDS: &[&str] = &[
+    "cat",
+    "tac",
+    "head",
+    "tail",
+    "wc",
+    "nl",
+    "od",
+    "cut",
+    "fmt",
+    "fold",
+    "paste",
+    "pr",
+    "tr",
+    "expand",
+    "unexpand",
+    "stat",
+    "readlink",
+    "realpath",
+    "md5sum",
+    "b2sum",
+    "cksum",
+    "sum",
+    "sha1sum",
+    "sha224sum",
+    "sha256sum",
+    "sha384sum",
+    "sha512sum",
+    "sha512_224sum",
+    "sha512_256sum",
+    "base32",
+    "base64",
+    "basenc",
+    "comm",
+    "join",
+    "cmp",
+    "tsort",
+    "shuf",
+];
+
+fn command_name(program: &str) -> String {
+    Path::new(program)
+        .file_name()
+        .unwrap_or_else(|| program.as_ref())
+        .to_string_lossy()
+        .to_ascii_lowercase()
+}
+
+fn analyze_env_wrapper(
+    argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut index = 1usize;
+
+    while index < argv.len() {
+        let token = argv[index].as_str();
+        if token == "--" || token == "-" {
+            index += 1;
+            break;
+        }
+        if token == "-u" || token == "--unset" || token == "-C" || token == "--chdir" {
+            index += 2;
+            continue;
+        }
+        if token == "-S"
+            || token == "--split-string"
+            || token.starts_with("--unset=")
+            || token.starts_with("--chdir=")
+            || token.starts_with("--split-string=")
+            || token == "-i"
+            || token == "--ignore-environment"
+        {
+            index += 1;
+            continue;
+        }
+        if token.contains('=') && !token.starts_with('=') {
+            index += 1;
+            continue;
+        }
+        break;
+    }
+
+    wrap_analysis(CommandAdapterId::WrapperEnv, &argv[index..], redirects, cwd)
+}
+
+fn analyze_nice_wrapper(
+    argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut index = 1usize;
+
+    while index < argv.len() {
+        let token = argv[index].as_str();
+        if token == "--" {
+            index += 1;
+            break;
+        }
+        if token == "-n" || token == "--adjustment" {
+            index += 2;
+            continue;
+        }
+        if token.starts_with("--adjustment=")
+            || token == "--help"
+            || token == "--version"
+            || is_signed_integer(token)
+        {
+            index += 1;
+            continue;
+        }
+        break;
+    }
+
+    wrap_analysis(
+        CommandAdapterId::WrapperNice,
+        &argv[index..],
+        redirects,
+        cwd,
+    )
+}
+
+fn analyze_nohup_wrapper(
+    argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut index = 1usize;
+    if index < argv.len() && argv[index] == "--" {
+        index += 1;
+    }
+    wrap_analysis(
+        CommandAdapterId::WrapperNohup,
+        &argv[index..],
+        redirects,
+        cwd,
+    )
+}
+
+fn analyze_stdbuf_wrapper(
+    argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut index = 1usize;
+
+    while index < argv.len() {
+        let token = argv[index].as_str();
+        if token == "--" {
+            index += 1;
+            break;
+        }
+        if token == "-i" || token == "-o" || token == "-e" {
+            index += 2;
+            continue;
+        }
+        if token.starts_with("--input=")
+            || token.starts_with("--output=")
+            || token.starts_with("--error=")
+        {
+            index += 1;
+            continue;
+        }
+        if token == "--input" || token == "--output" || token == "--error" {
+            index += 2;
+            continue;
+        }
+        break;
+    }
+
+    wrap_analysis(
+        CommandAdapterId::WrapperStdbuf,
+        &argv[index..],
+        redirects,
+        cwd,
+    )
+}
+
+fn analyze_timeout_wrapper(
+    argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut index = 1usize;
+
+    while index < argv.len() {
+        let token = argv[index].as_str();
+        if token == "--" {
+            index += 1;
+            break;
+        }
+        if token == "-s" || token == "--signal" || token == "-k" || token == "--kill-after" {
+            index += 2;
+            continue;
+        }
+        if token.starts_with("--signal=")
+            || token.starts_with("--kill-after=")
+            || token == "--foreground"
+            || token == "--preserve-status"
+            || token == "--verbose"
+        {
+            index += 1;
+            continue;
+        }
+        break;
+    }
+
+    if index < argv.len() {
+        index += 1;
+    }
+
+    wrap_analysis(
+        CommandAdapterId::WrapperTimeout,
+        &argv[index..],
+        redirects,
+        cwd,
+    )
+}
+
+fn wrap_analysis(
+    wrapper_id: CommandAdapterId,
+    inner_argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut analysis = if inner_argv.is_empty() {
+        SingleCommandAnalysis::empty(wrapper_id)
+    } else {
+        analyze_command_tokens(inner_argv, redirects, cwd)?
+    };
+
+    if !analysis.adapter_ids.contains(&wrapper_id) {
+        analysis.adapter_ids.insert(0, wrapper_id);
+    }
+    Ok(analysis)
+}
+
+fn analyze_copy_like(
+    argv: &[String],
+    adapter_id: CommandAdapterId,
+    side_effect_profile: SideEffectProfile,
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut inputs = Vec::new();
+    let mut filtered_output_count = 0usize;
+    let mut target_directory = None::<String>;
+    let mut operands = Vec::new();
+    let mut positional_only = false;
+    let mut index = 1usize;
+
+    while index < argv.len() {
+        let token = argv[index].as_str();
+        if !positional_only && token == "--" {
+            positional_only = true;
+            index += 1;
+            continue;
+        }
+
+        if !positional_only {
+            if token == "-t" || token == "--target-directory" {
+                if let Some(value) = argv.get(index + 1) {
+                    target_directory = Some(value.clone());
+                }
+                index += 2;
+                continue;
+            }
+            if let Some(value) = token.strip_prefix("--target-directory=") {
+                target_directory = Some(value.to_string());
+                index += 1;
+                continue;
+            }
+            if token.starts_with('-') {
+                index += 1;
+                continue;
+            }
+        }
+
+        operands.push(argv[index].clone());
+        index += 1;
+    }
+
+    if target_directory.is_some() {
+        filtered_output_count += 1;
+        for operand in operands {
+            push_inferred_input(&mut inputs, operand.as_str(), cwd)?;
+        }
+        let mut analysis = SingleCommandAnalysis {
+            inputs,
+            adapter_ids: vec![adapter_id],
+            fallback_used: false,
+            default_watch_root_used: false,
+            filtered_output_count,
+            side_effect_profile,
+            status: CommandAnalysisStatus::NoInputs,
+        };
+        apply_redirects(&mut analysis, redirects, cwd)?;
+        return Ok(analysis);
+    }
+
+    let split_index = operands.len().saturating_sub(1);
+    for operand in &operands[..split_index] {
+        push_inferred_input(&mut inputs, operand.as_str(), cwd)?;
+    }
+    if operands.len() >= 2 {
+        filtered_output_count += 1;
+    } else if let Some(operand) = operands.first() {
+        push_inferred_input(&mut inputs, operand.as_str(), cwd)?;
+    }
+
+    let mut analysis = SingleCommandAnalysis {
+        inputs,
+        adapter_ids: vec![adapter_id],
+        fallback_used: false,
+        default_watch_root_used: false,
+        filtered_output_count,
+        side_effect_profile,
+        status: CommandAnalysisStatus::NoInputs,
+    };
+    apply_redirects(&mut analysis, redirects, cwd)?;
+    Ok(analysis)
+}
+
+fn analyze_install(
+    argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut inputs = Vec::new();
+    let mut filtered_output_count = 0usize;
+    let mut target_directory = None::<String>;
+    let mut compare_reference = None::<String>;
+    let mut operands = Vec::new();
+    let mut positional_only = false;
+    let mut index = 1usize;
+
+    while index < argv.len() {
+        let token = argv[index].as_str();
+        if !positional_only && token == "--" {
+            positional_only = true;
+            index += 1;
+            continue;
+        }
+
+        if !positional_only {
+            if token == "-t" || token == "--target-directory" {
+                if let Some(value) = argv.get(index + 1) {
+                    target_directory = Some(value.clone());
+                }
+                index += 2;
+                continue;
+            }
+            if token == "-C" || token == "--compare" {
+                index += 1;
+                continue;
+            }
+            if token == "--compare-with" {
+                if let Some(value) = argv.get(index + 1) {
+                    compare_reference = Some(value.clone());
+                }
+                index += 2;
+                continue;
+            }
+            if let Some(value) = token.strip_prefix("--target-directory=") {
+                target_directory = Some(value.to_string());
+                index += 1;
+                continue;
+            }
+            if let Some(value) = token.strip_prefix("--compare-with=") {
+                compare_reference = Some(value.to_string());
+                index += 1;
+                continue;
+            }
+            if token.starts_with('-') {
+                index += 1;
+                continue;
+            }
+        }
+
+        operands.push(argv[index].clone());
+        index += 1;
+    }
+
+    if let Some(compare_reference) = compare_reference {
+        push_inferred_input(&mut inputs, compare_reference.as_str(), cwd)?;
+    }
+
+    if let Some(_target_directory) = target_directory {
+        filtered_output_count += 1;
+        for operand in operands {
+            push_inferred_input(&mut inputs, operand.as_str(), cwd)?;
+        }
+    } else {
+        let split_index = operands.len().saturating_sub(1);
+        for operand in &operands[..split_index] {
+            push_inferred_input(&mut inputs, operand.as_str(), cwd)?;
+        }
+        if operands.len() >= 2 {
+            filtered_output_count += 1;
+        } else if let Some(operand) = operands.first() {
+            push_inferred_input(&mut inputs, operand.as_str(), cwd)?;
+        }
+    }
+
+    let mut analysis = SingleCommandAnalysis {
+        inputs,
+        adapter_ids: vec![CommandAdapterId::Install],
+        fallback_used: false,
+        default_watch_root_used: false,
+        filtered_output_count,
+        side_effect_profile: SideEffectProfile::WritesExcludedOutputs,
+        status: CommandAnalysisStatus::NoInputs,
+    };
+    apply_redirects(&mut analysis, redirects, cwd)?;
+    Ok(analysis)
+}
+
+fn analyze_link_like(
+    argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    analyze_copy_like(
+        argv,
+        CommandAdapterId::LinkLike,
+        SideEffectProfile::WritesExcludedOutputs,
+        redirects,
+        cwd,
+    )
+}
+
+fn analyze_remove_like(
+    argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut inputs = Vec::new();
+    let mut positional_only = false;
+    let mut index = 1usize;
+
+    while index < argv.len() {
+        let token = argv[index].as_str();
+        if !positional_only && token == "--" {
+            positional_only = true;
+            index += 1;
+            continue;
+        }
+        if !positional_only && token.starts_with('-') {
+            index += 1;
+            continue;
+        }
+        push_inferred_input(&mut inputs, token, cwd)?;
+        index += 1;
+    }
+
+    let mut analysis = SingleCommandAnalysis {
+        inputs,
+        adapter_ids: vec![CommandAdapterId::RemoveLike],
+        fallback_used: false,
+        default_watch_root_used: false,
+        filtered_output_count: 0,
+        side_effect_profile: SideEffectProfile::WritesWatchedInputs,
+        status: CommandAnalysisStatus::NoInputs,
+    };
+    apply_redirects(&mut analysis, redirects, cwd)?;
+    Ok(analysis)
+}
+
+fn analyze_sort(
+    argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut inputs = Vec::new();
+    let mut filtered_output_count = 0usize;
+    let mut operands = Vec::new();
+    let mut positional_only = false;
+    let mut index = 1usize;
+
+    while index < argv.len() {
+        let token = argv[index].as_str();
+        if !positional_only && token == "--" {
+            positional_only = true;
+            index += 1;
+            continue;
+        }
+        if !positional_only {
+            if token == "-o" || token == "--output" {
+                if argv.get(index + 1).is_some() {
+                    filtered_output_count += 1;
+                }
+                index += 2;
+                continue;
+            }
+            if token == "--files0-from" {
+                if let Some(value) = argv.get(index + 1) {
+                    push_inferred_input(&mut inputs, value.as_str(), cwd)?;
+                }
+                index += 2;
+                continue;
+            }
+            if token.starts_with("-o") && token.len() > 2 {
+                filtered_output_count += 1;
+                index += 1;
+                continue;
+            }
+            if let Some(value) = token.strip_prefix("--output=") {
+                if !value.is_empty() {
+                    filtered_output_count += 1;
+                }
+                index += 1;
+                continue;
+            }
+            if let Some(value) = token.strip_prefix("--files0-from=") {
+                push_inferred_input(&mut inputs, value, cwd)?;
+                index += 1;
+                continue;
+            }
+            if token.starts_with('-') {
+                index += 1;
+                continue;
+            }
+        }
+
+        operands.push(argv[index].clone());
+        index += 1;
+    }
+
+    for operand in operands {
+        if operand != "-" {
+            push_inferred_input(&mut inputs, operand.as_str(), cwd)?;
+        }
+    }
+
+    let mut analysis = SingleCommandAnalysis {
+        inputs,
+        adapter_ids: vec![CommandAdapterId::Sort],
+        fallback_used: false,
+        default_watch_root_used: false,
+        filtered_output_count,
+        side_effect_profile: if filtered_output_count > 0 {
+            SideEffectProfile::WritesExcludedOutputs
+        } else {
+            SideEffectProfile::ReadOnly
+        },
+        status: CommandAnalysisStatus::NoInputs,
+    };
+    apply_redirects(&mut analysis, redirects, cwd)?;
+    Ok(analysis)
+}
+
+fn analyze_uniq(
+    argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut inputs = Vec::new();
+    let mut filtered_output_count = 0usize;
+    let mut operands = Vec::new();
+    let mut positional_only = false;
+    let mut index = 1usize;
+
+    while index < argv.len() {
+        let token = argv[index].as_str();
+        if !positional_only && token == "--" {
+            positional_only = true;
+            index += 1;
+            continue;
+        }
+        if !positional_only && token.starts_with('-') {
+            index += 1;
+            continue;
+        }
+        operands.push(argv[index].clone());
+        index += 1;
+    }
+
+    if let Some(input) = operands.first() {
+        if input != "-" {
+            push_inferred_input(&mut inputs, input.as_str(), cwd)?;
+        }
+    }
+    if operands.len() >= 2 {
+        filtered_output_count += 1;
+    }
+
+    let mut analysis = SingleCommandAnalysis {
+        inputs,
+        adapter_ids: vec![CommandAdapterId::Uniq],
+        fallback_used: false,
+        default_watch_root_used: false,
+        filtered_output_count,
+        side_effect_profile: if filtered_output_count > 0 {
+            SideEffectProfile::WritesExcludedOutputs
+        } else {
+            SideEffectProfile::ReadOnly
+        },
+        status: CommandAnalysisStatus::NoInputs,
+    };
+    apply_redirects(&mut analysis, redirects, cwd)?;
+    Ok(analysis)
+}
+
+fn analyze_split(
+    argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut inputs = Vec::new();
+    let mut filtered_output_count = 0usize;
+    let mut operands = Vec::new();
+    let mut positional_only = false;
+    let mut index = 1usize;
+
+    while index < argv.len() {
+        let token = argv[index].as_str();
+        if !positional_only && token == "--" {
+            positional_only = true;
+            index += 1;
+            continue;
+        }
+        if !positional_only {
+            if token == "--filter"
+                || token == "--separator"
+                || token == "--additional-suffix"
+                || token == "--number"
+            {
+                index += 2;
+                continue;
+            }
+            if token == "-n"
+                || token == "-a"
+                || token == "-b"
+                || token == "-C"
+                || token == "-l"
+                || token == "-t"
+            {
+                index += 2;
+                continue;
+            }
+            if token.starts_with("--filter=")
+                || token.starts_with("--separator=")
+                || token.starts_with("--additional-suffix=")
+                || token.starts_with("--number=")
+                || token.starts_with("-n")
+                || token.starts_with("-a")
+                || token.starts_with("-b")
+                || token.starts_with("-C")
+                || token.starts_with("-l")
+                || token.starts_with("-t")
+            {
+                index += 1;
+                continue;
+            }
+            if token.starts_with('-') {
+                index += 1;
+                continue;
+            }
+        }
+
+        operands.push(argv[index].clone());
+        index += 1;
+    }
+
+    if let Some(input) = operands.first() {
+        if input != "-" {
+            push_inferred_input(&mut inputs, input.as_str(), cwd)?;
+        }
+    }
+    if operands.len() >= 2 {
+        filtered_output_count += 1;
+    }
+
+    let mut analysis = SingleCommandAnalysis {
+        inputs,
+        adapter_ids: vec![CommandAdapterId::Split],
+        fallback_used: false,
+        default_watch_root_used: false,
+        filtered_output_count,
+        side_effect_profile: SideEffectProfile::WritesExcludedOutputs,
+        status: CommandAnalysisStatus::NoInputs,
+    };
+    apply_redirects(&mut analysis, redirects, cwd)?;
+    Ok(analysis)
+}
+
+fn analyze_csplit(
+    argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut inputs = Vec::new();
+    let mut filtered_output_count = 0usize;
+    let mut first_operand = None::<String>;
+    let mut positional_only = false;
+    let mut index = 1usize;
+
+    while index < argv.len() {
+        let token = argv[index].as_str();
+        if !positional_only && token == "--" {
+            positional_only = true;
+            index += 1;
+            continue;
+        }
+        if !positional_only {
+            if token == "-f" || token == "--prefix" || token == "-b" || token == "--suffix-format" {
+                if token == "-f" || token == "--prefix" {
+                    filtered_output_count += 1;
+                }
+                index += 2;
+                continue;
+            }
+            if token.starts_with("--prefix=") {
+                filtered_output_count += 1;
+                index += 1;
+                continue;
+            }
+            if token.starts_with("--suffix-format=") || token.starts_with('-') {
+                index += 1;
+                continue;
+            }
+        }
+
+        if first_operand.is_none() {
+            first_operand = Some(argv[index].clone());
+        }
+        index += 1;
+    }
+
+    if let Some(input) = first_operand {
+        if input != "-" {
+            push_inferred_input(&mut inputs, input.as_str(), cwd)?;
+        }
+    }
+
+    let mut analysis = SingleCommandAnalysis {
+        inputs,
+        adapter_ids: vec![CommandAdapterId::Csplit],
+        fallback_used: false,
+        default_watch_root_used: false,
+        filtered_output_count,
+        side_effect_profile: SideEffectProfile::WritesExcludedOutputs,
+        status: CommandAnalysisStatus::NoInputs,
+    };
+    apply_redirects(&mut analysis, redirects, cwd)?;
+    Ok(analysis)
+}
+
+fn analyze_tee(
+    _argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut analysis = SingleCommandAnalysis::empty(CommandAdapterId::Tee);
+    analysis.side_effect_profile = SideEffectProfile::WritesExcludedOutputs;
+    analysis.filtered_output_count = 1;
+    apply_redirects(&mut analysis, redirects, cwd)?;
+    Ok(analysis)
+}
+
+fn analyze_grep(
+    argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut inputs = Vec::new();
+    let mut explicit_pattern = false;
+    let mut consumed_pattern = false;
+    let mut positional_only = false;
+    let mut index = 1usize;
+
+    while index < argv.len() {
+        let token = argv[index].as_str();
+        if !positional_only && token == "--" {
+            positional_only = true;
+            index += 1;
+            continue;
+        }
+
+        if !positional_only {
+            if token == "-e" || token == "--regexp" {
+                explicit_pattern = true;
+                index += 2;
+                continue;
+            }
+            if token == "-f" || token == "--file" {
+                explicit_pattern = true;
+                if let Some(value) = argv.get(index + 1) {
+                    push_inferred_input(&mut inputs, value.as_str(), cwd)?;
+                }
+                index += 2;
+                continue;
+            }
+            if let Some(value) = token.strip_prefix("--regexp=") {
+                explicit_pattern = true;
+                let _ = value;
+                index += 1;
+                continue;
+            }
+            if let Some(value) = token.strip_prefix("--file=") {
+                explicit_pattern = true;
+                push_inferred_input(&mut inputs, value, cwd)?;
+                index += 1;
+                continue;
+            }
+            if let Some(value) = token.strip_prefix("-e") {
+                if !value.is_empty() {
+                    explicit_pattern = true;
+                    index += 1;
+                    continue;
+                }
+            }
+            if let Some(value) = token.strip_prefix("-f") {
+                if !value.is_empty() {
+                    explicit_pattern = true;
+                    push_inferred_input(&mut inputs, value, cwd)?;
+                    index += 1;
+                    continue;
+                }
+            }
+            if token.starts_with('-') {
+                index += 1;
+                continue;
+            }
+        }
+
+        if !explicit_pattern && !consumed_pattern {
+            consumed_pattern = true;
+        } else if token != "-" {
+            push_inferred_input(&mut inputs, token, cwd)?;
+        }
+        index += 1;
+    }
+
+    let mut analysis = SingleCommandAnalysis {
+        inputs,
+        adapter_ids: vec![CommandAdapterId::Grep],
+        fallback_used: false,
+        default_watch_root_used: false,
+        filtered_output_count: 0,
+        side_effect_profile: SideEffectProfile::ReadOnly,
+        status: CommandAnalysisStatus::NoInputs,
+    };
+    apply_redirects(&mut analysis, redirects, cwd)?;
+    Ok(analysis)
+}
+
+fn analyze_sed(
+    argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut inputs = Vec::new();
+    let mut explicit_script = false;
+    let mut consumed_script = false;
+    let mut in_place = false;
+    let mut positional_only = false;
+    let mut index = 1usize;
+
+    while index < argv.len() {
+        let token = argv[index].as_str();
+        if !positional_only && token == "--" {
+            positional_only = true;
+            index += 1;
+            continue;
+        }
+
+        if !positional_only {
+            if token == "-e" || token == "--expression" {
+                explicit_script = true;
+                index += 2;
+                continue;
+            }
+            if token == "-f" || token == "--file" {
+                explicit_script = true;
+                if let Some(value) = argv.get(index + 1) {
+                    push_inferred_input(&mut inputs, value.as_str(), cwd)?;
+                }
+                index += 2;
+                continue;
+            }
+            if token == "-i" || token == "--in-place" {
+                in_place = true;
+                if argv
+                    .get(index + 1)
+                    .is_some_and(|value| !value.starts_with('-'))
+                {
+                    index += 2;
+                } else {
+                    index += 1;
+                }
+                continue;
+            }
+            if token.starts_with("--expression=") {
+                explicit_script = true;
+                index += 1;
+                continue;
+            }
+            if let Some(value) = token.strip_prefix("--file=") {
+                explicit_script = true;
+                push_inferred_input(&mut inputs, value, cwd)?;
+                index += 1;
+                continue;
+            }
+            if token.starts_with("--in-place=") || token.starts_with("-i") {
+                in_place = true;
+                index += 1;
+                continue;
+            }
+            if token.starts_with("-e") && token.len() > 2 {
+                explicit_script = true;
+                index += 1;
+                continue;
+            }
+            if let Some(value) = token.strip_prefix("-f") {
+                if !value.is_empty() {
+                    explicit_script = true;
+                    push_inferred_input(&mut inputs, value, cwd)?;
+                    index += 1;
+                    continue;
+                }
+            }
+            if token.starts_with('-') {
+                index += 1;
+                continue;
+            }
+        }
+
+        if !explicit_script && !consumed_script {
+            consumed_script = true;
+        } else if token != "-" {
+            push_inferred_input(&mut inputs, token, cwd)?;
+        }
+        index += 1;
+    }
+
+    let mut analysis = SingleCommandAnalysis {
+        inputs,
+        adapter_ids: vec![CommandAdapterId::Sed],
+        fallback_used: false,
+        default_watch_root_used: false,
+        filtered_output_count: 0,
+        side_effect_profile: if in_place {
+            SideEffectProfile::WritesWatchedInputs
+        } else {
+            SideEffectProfile::ReadOnly
+        },
+        status: CommandAnalysisStatus::NoInputs,
+    };
+    apply_redirects(&mut analysis, redirects, cwd)?;
+    Ok(analysis)
+}
+
+fn analyze_awk(
+    argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut inputs = Vec::new();
+    let mut explicit_program = false;
+    let mut consumed_program = false;
+    let mut positional_only = false;
+    let mut index = 1usize;
+
+    while index < argv.len() {
+        let token = argv[index].as_str();
+        if !positional_only && token == "--" {
+            positional_only = true;
+            index += 1;
+            continue;
+        }
+
+        if !positional_only {
+            if token == "-f" || token == "--file" {
+                explicit_program = true;
+                if let Some(value) = argv.get(index + 1) {
+                    push_inferred_input(&mut inputs, value.as_str(), cwd)?;
+                }
+                index += 2;
+                continue;
+            }
+            if token == "-v" || token == "-F" {
+                index += 2;
+                continue;
+            }
+            if let Some(value) = token.strip_prefix("--file=") {
+                explicit_program = true;
+                push_inferred_input(&mut inputs, value, cwd)?;
+                index += 1;
+                continue;
+            }
+            if let Some(value) = token.strip_prefix("-f") {
+                if !value.is_empty() {
+                    explicit_program = true;
+                    push_inferred_input(&mut inputs, value, cwd)?;
+                    index += 1;
+                    continue;
+                }
+            }
+            if token.starts_with("-v") || token.starts_with("-F") || token.starts_with('-') {
+                index += 1;
+                continue;
+            }
+        }
+
+        if !explicit_program && !consumed_program {
+            consumed_program = true;
+        } else if token != "-" && !looks_like_variable_assignment(token) {
+            push_inferred_input(&mut inputs, token, cwd)?;
+        }
+        index += 1;
+    }
+
+    let mut analysis = SingleCommandAnalysis {
+        inputs,
+        adapter_ids: vec![CommandAdapterId::Awk],
+        fallback_used: false,
+        default_watch_root_used: false,
+        filtered_output_count: 0,
+        side_effect_profile: SideEffectProfile::ReadOnly,
+        status: CommandAnalysisStatus::NoInputs,
+    };
+    apply_redirects(&mut analysis, redirects, cwd)?;
+    Ok(analysis)
+}
+
+fn analyze_find(
+    argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut inputs = Vec::new();
+    let mut saw_expression = false;
+    let mut index = 1usize;
+
+    while index < argv.len() {
+        let token = argv[index].as_str();
+        if token == "--" {
+            index += 1;
+            continue;
+        }
+        if !saw_expression && FIND_GLOBAL_OPTIONS.contains(&token) {
+            index += 1;
+            continue;
+        }
+        if !saw_expression && !is_find_expression_token(token) {
+            push_inferred_input(&mut inputs, token, cwd)?;
+        } else {
+            saw_expression = true;
+        }
+        index += 1;
+    }
+
+    let mut analysis = SingleCommandAnalysis {
+        inputs,
+        adapter_ids: vec![CommandAdapterId::Find],
+        fallback_used: false,
+        default_watch_root_used: false,
+        filtered_output_count: 0,
+        side_effect_profile: SideEffectProfile::ReadOnly,
+        status: CommandAnalysisStatus::NoInputs,
+    };
+
+    if analysis.inputs.is_empty() {
+        push_inferred_input(&mut analysis.inputs, ".", cwd)?;
+        analysis.default_watch_root_used = true;
+    }
+
+    apply_redirects(&mut analysis, redirects, cwd)?;
+    Ok(analysis)
+}
+
+const FIND_GLOBAL_OPTIONS: &[&str] = &["-H", "-L", "-P", "-D", "-O"];
+
+fn analyze_xargs(
+    argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut inputs = Vec::new();
+    let mut index = 1usize;
+
+    while index < argv.len() {
+        let token = argv[index].as_str();
+        if token == "--" {
+            break;
+        }
+        if token == "-a" || token == "--arg-file" {
+            if let Some(value) = argv.get(index + 1) {
+                push_inferred_input(&mut inputs, value.as_str(), cwd)?;
+            }
+            index += 2;
+            continue;
+        }
+        if token == "-I" || token == "-i" || token == "--replace" {
+            index += 2;
+            continue;
+        }
+        if token == "-n"
+            || token == "-L"
+            || token == "-s"
+            || token == "-P"
+            || token == "-E"
+            || token == "--delimiter"
+            || token == "--eof"
+            || token == "--max-args"
+            || token == "--max-lines"
+            || token == "--max-procs"
+            || token == "--max-chars"
+        {
+            index += 2;
+            continue;
+        }
+        if let Some(value) = token.strip_prefix("--arg-file=") {
+            push_inferred_input(&mut inputs, value, cwd)?;
+        }
+        index += 1;
+    }
+
+    let mut analysis = SingleCommandAnalysis {
+        inputs,
+        adapter_ids: vec![CommandAdapterId::Xargs],
+        fallback_used: false,
+        default_watch_root_used: false,
+        filtered_output_count: 0,
+        side_effect_profile: SideEffectProfile::ReadOnly,
+        status: CommandAnalysisStatus::NoInputs,
+    };
+    apply_redirects(&mut analysis, redirects, cwd)?;
+    Ok(analysis)
+}
+
+fn analyze_tar(
+    argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut inputs = Vec::new();
+    let mut filtered_output_count = 0usize;
+    let mut mode = TarMode::Unknown;
+    let mut archive_path = None::<String>;
+    let mut positional_operands = Vec::new();
+    let mut positional_only = false;
+    let mut index = 1usize;
+
+    while index < argv.len() {
+        let token = argv[index].as_str();
+        if !positional_only && token == "--" {
+            positional_only = true;
+            index += 1;
+            continue;
+        }
+
+        if !positional_only {
+            if token == "-f" || token == "--file" {
+                if let Some(value) = argv.get(index + 1) {
+                    archive_path = Some(value.clone());
+                }
+                index += 2;
+                continue;
+            }
+            if token == "-C" || token == "--directory" {
+                filtered_output_count += usize::from(matches!(mode, TarMode::ReadArchive));
+                index += 2;
+                continue;
+            }
+            if let Some(value) = token.strip_prefix("--file=") {
+                archive_path = Some(value.to_string());
+                index += 1;
+                continue;
+            }
+            if let Some(value) = token.strip_prefix("--directory=") {
+                if matches!(mode, TarMode::ReadArchive) {
+                    let _ = value;
+                    filtered_output_count += 1;
+                }
+                index += 1;
+                continue;
+            }
+            if token.starts_with("--create")
+                || token.starts_with("--append")
+                || token.starts_with("--update")
+            {
+                mode = TarMode::CreateLike;
+                index += 1;
+                continue;
+            }
+            if token.starts_with("--extract")
+                || token.starts_with("--get")
+                || token.starts_with("--list")
+                || token.starts_with("--diff")
+                || token.starts_with("--compare")
+            {
+                mode = TarMode::ReadArchive;
+                index += 1;
+                continue;
+            }
+            if token.starts_with('-') {
+                mode = mode.merge(parse_tar_short_mode(token));
+                if let Some(archive_value) = parse_tar_short_archive(token) {
+                    archive_path = Some(archive_value);
+                    index += 1;
+                    continue;
+                }
+                if tar_short_option_consumes_next_archive(token) {
+                    if let Some(value) = argv.get(index + 1) {
+                        archive_path = Some(value.clone());
+                    }
+                    index += 2;
+                    continue;
+                }
+                index += 1;
+                continue;
+            }
+        }
+
+        positional_operands.push(argv[index].clone());
+        index += 1;
+    }
+
+    match mode {
+        TarMode::CreateLike => {
+            if let Some(archive_path) = archive_path {
+                let _ = archive_path;
+                filtered_output_count += 1;
+            }
+            for operand in positional_operands {
+                push_inferred_input(&mut inputs, operand.as_str(), cwd)?;
+            }
+        }
+        TarMode::ReadArchive | TarMode::Unknown => {
+            if let Some(archive_path) = archive_path {
+                push_inferred_input(&mut inputs, archive_path.as_str(), cwd)?;
+            }
+        }
+    }
+
+    let mut analysis = SingleCommandAnalysis {
+        inputs,
+        adapter_ids: vec![CommandAdapterId::Tar],
+        fallback_used: false,
+        default_watch_root_used: false,
+        filtered_output_count,
+        side_effect_profile: if matches!(mode, TarMode::CreateLike) {
+            SideEffectProfile::WritesExcludedOutputs
+        } else {
+            SideEffectProfile::ReadOnly
+        },
+        status: CommandAnalysisStatus::NoInputs,
+    };
+    apply_redirects(&mut analysis, redirects, cwd)?;
+    Ok(analysis)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TarMode {
+    Unknown,
+    CreateLike,
+    ReadArchive,
+}
+
+impl TarMode {
+    fn merge(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::CreateLike, _) | (_, Self::CreateLike) => Self::CreateLike,
+            (Self::ReadArchive, _) | (_, Self::ReadArchive) => Self::ReadArchive,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+fn parse_tar_short_mode(token: &str) -> TarMode {
+    let raw = token.trim_start_matches('-');
+    if raw.contains('c') || raw.contains('r') || raw.contains('u') {
+        TarMode::CreateLike
+    } else if raw.contains('x') || raw.contains('t') || raw.contains('d') {
+        TarMode::ReadArchive
+    } else {
+        TarMode::Unknown
+    }
+}
+
+fn parse_tar_short_archive(token: &str) -> Option<String> {
+    let raw = token.trim_start_matches('-');
+    let index = raw.find('f')?;
+    let attached = &raw[index + 1..];
+    if attached.is_empty() {
+        None
+    } else {
+        Some(attached.to_string())
+    }
+}
+
+fn tar_short_option_consumes_next_archive(token: &str) -> bool {
+    let raw = token.trim_start_matches('-');
+    raw.contains('f') && parse_tar_short_archive(token).is_none()
+}
+
+fn analyze_touch_like(
+    argv: &[String],
+    adapter_id: CommandAdapterId,
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut inputs = Vec::new();
+    let mut positional_only = false;
+    let mut index = 1usize;
+
+    while index < argv.len() {
+        let token = argv[index].as_str();
+        if !positional_only && token == "--" {
+            positional_only = true;
+            index += 1;
+            continue;
+        }
+        if !positional_only {
+            if token == "-r" || token == "--reference" {
+                if let Some(value) = argv.get(index + 1) {
+                    push_inferred_input(&mut inputs, value.as_str(), cwd)?;
+                }
+                index += 2;
+                continue;
+            }
+            if let Some(value) = token.strip_prefix("--reference=") {
+                push_inferred_input(&mut inputs, value, cwd)?;
+                index += 1;
+                continue;
+            }
+            if token.starts_with('-') {
+                index += 1;
+                continue;
+            }
+        }
+        push_inferred_input(&mut inputs, token, cwd)?;
+        index += 1;
+    }
+
+    let mut analysis = SingleCommandAnalysis {
+        inputs,
+        adapter_ids: vec![adapter_id],
+        fallback_used: false,
+        default_watch_root_used: false,
+        filtered_output_count: 0,
+        side_effect_profile: SideEffectProfile::WritesWatchedInputs,
+        status: CommandAnalysisStatus::NoInputs,
+    };
+    apply_redirects(&mut analysis, redirects, cwd)?;
+    Ok(analysis)
+}
+
+fn analyze_change_attributes(
+    argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut inputs = Vec::new();
+    let mut positional_only = false;
+    let mut index = 1usize;
+    let mut metadata_arg_consumed = false;
+
+    while index < argv.len() {
+        let token = argv[index].as_str();
+        if !positional_only && token == "--" {
+            positional_only = true;
+            index += 1;
+            continue;
+        }
+        if !positional_only {
+            if token == "--reference" {
+                if let Some(value) = argv.get(index + 1) {
+                    push_inferred_input(&mut inputs, value.as_str(), cwd)?;
+                }
+                index += 2;
+                continue;
+            }
+            if let Some(value) = token.strip_prefix("--reference=") {
+                push_inferred_input(&mut inputs, value, cwd)?;
+                index += 1;
+                continue;
+            }
+            if token.starts_with('-') {
+                index += 1;
+                continue;
+            }
+        }
+        if !metadata_arg_consumed {
+            metadata_arg_consumed = true;
+        } else {
+            push_inferred_input(&mut inputs, token, cwd)?;
+        }
+        index += 1;
+    }
+
+    let mut analysis = SingleCommandAnalysis {
+        inputs,
+        adapter_ids: vec![CommandAdapterId::ChangeAttributes],
+        fallback_used: false,
+        default_watch_root_used: false,
+        filtered_output_count: 0,
+        side_effect_profile: SideEffectProfile::WritesWatchedInputs,
+        status: CommandAnalysisStatus::NoInputs,
+    };
+    apply_redirects(&mut analysis, redirects, cwd)?;
+    Ok(analysis)
+}
+
+fn analyze_dd(
+    argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut inputs = Vec::new();
+    let mut filtered_output_count = 0usize;
+
+    for token in argv.iter().skip(1) {
+        if let Some(value) = token.strip_prefix("if=") {
+            push_inferred_input(&mut inputs, value, cwd)?;
+        } else if token.starts_with("iflag=") {
+        } else if token.starts_with("of=") || token.starts_with("seek=") {
+            filtered_output_count += 1;
+        }
+    }
+
+    let mut analysis = SingleCommandAnalysis {
+        inputs,
+        adapter_ids: vec![CommandAdapterId::Dd],
+        fallback_used: false,
+        default_watch_root_used: false,
+        filtered_output_count,
+        side_effect_profile: if filtered_output_count > 0 {
+            SideEffectProfile::WritesExcludedOutputs
+        } else {
+            SideEffectProfile::ReadOnly
+        },
+        status: CommandAnalysisStatus::NoInputs,
+    };
+    apply_redirects(&mut analysis, redirects, cwd)?;
+    Ok(analysis)
+}
+
+fn analyze_default_current_dir_reader(
+    argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut inputs = Vec::new();
+    let mut positional_only = false;
+    let mut index = 1usize;
+
+    while index < argv.len() {
+        let token = argv[index].as_str();
+        if !positional_only && token == "--" {
+            positional_only = true;
+            index += 1;
+            continue;
+        }
+        if !positional_only && token.starts_with('-') {
+            index += 1;
+            continue;
+        }
+        push_inferred_input(&mut inputs, token, cwd)?;
+        index += 1;
+    }
+
+    let mut analysis = SingleCommandAnalysis {
+        inputs,
+        adapter_ids: vec![CommandAdapterId::DefaultCurrentDir],
+        fallback_used: false,
+        default_watch_root_used: false,
+        filtered_output_count: 0,
+        side_effect_profile: SideEffectProfile::ReadOnly,
+        status: CommandAnalysisStatus::NoInputs,
+    };
+
+    if analysis.inputs.is_empty() {
+        push_inferred_input(&mut analysis.inputs, ".", cwd)?;
+        analysis.default_watch_root_used = true;
+    }
+
+    apply_redirects(&mut analysis, redirects, cwd)?;
+    Ok(analysis)
+}
+
+fn analyze_non_watchable(
+    _argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut analysis = SingleCommandAnalysis::empty(CommandAdapterId::NonWatchable);
+    apply_redirects(&mut analysis, redirects, cwd)?;
+    Ok(analysis)
+}
+
+fn analyze_generic_read_paths(
+    argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut inputs = Vec::new();
+    let mut positional_only = false;
+    let mut index = 1usize;
+
+    while index < argv.len() {
+        let token = argv[index].as_str();
+        if !positional_only && token == "--" {
+            positional_only = true;
+            index += 1;
+            continue;
+        }
+        if !positional_only {
+            if try_push_path_option_value(&mut inputs, argv, &mut index, cwd)? {
+                continue;
+            }
+            if token.starts_with('-') {
+                index += 1;
+                continue;
+            }
+        }
+        if token != "-" {
+            push_inferred_input(&mut inputs, token, cwd)?;
+        }
+        index += 1;
+    }
+
+    let mut analysis = SingleCommandAnalysis {
+        inputs,
+        adapter_ids: vec![CommandAdapterId::ReadPaths],
+        fallback_used: false,
+        default_watch_root_used: false,
+        filtered_output_count: 0,
+        side_effect_profile: SideEffectProfile::ReadOnly,
+        status: CommandAnalysisStatus::NoInputs,
+    };
+    apply_redirects(&mut analysis, redirects, cwd)?;
+    Ok(analysis)
+}
+
+fn analyze_fallback(
+    argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut inputs = Vec::new();
+    let mut ambiguous_missing = Vec::new();
+    let mut positional_only = false;
+    let mut index = 1usize;
+
+    while index < argv.len() {
+        let token = argv[index].as_str();
+        if !positional_only && token == "--" {
+            positional_only = true;
+            index += 1;
+            continue;
+        }
+        if !positional_only {
+            if try_push_path_option_value(&mut inputs, argv, &mut index, cwd)? {
+                continue;
+            }
+            if token.starts_with('-') {
+                index += 1;
+                continue;
+            }
+        }
+
+        if should_ignore_fallback_token(token) {
+            index += 1;
+            continue;
+        }
+
+        if has_glob_magic(token) || path_exists(token, cwd) {
+            push_inferred_input(&mut inputs, token, cwd)?;
+        } else if is_path_shaped(token) {
+            ambiguous_missing.push(token.to_string());
+        }
+        index += 1;
+    }
+
+    let mut analysis = SingleCommandAnalysis {
+        inputs,
+        adapter_ids: vec![CommandAdapterId::Fallback],
+        fallback_used: true,
+        default_watch_root_used: false,
+        filtered_output_count: 0,
+        side_effect_profile: SideEffectProfile::ReadOnly,
+        status: CommandAnalysisStatus::NoInputs,
+    };
+
+    if ambiguous_missing.len() > 1 {
+        analysis.status = CommandAnalysisStatus::AmbiguousFallback;
+    } else if let Some(token) = ambiguous_missing.first() {
+        push_inferred_input(&mut analysis.inputs, token, cwd)?;
+    }
+
+    apply_redirects(&mut analysis, redirects, cwd)?;
+    Ok(analysis)
+}
+
+fn apply_redirects(
+    analysis: &mut SingleCommandAnalysis,
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<()> {
+    for redirect in redirects {
+        if is_dynamic_shell_token(redirect.target.as_str()) {
+            continue;
+        }
+        if redirect.operator.reads_input() {
+            push_inferred_input(&mut analysis.inputs, redirect.target.as_str(), cwd)?;
+        } else if redirect.operator.writes_output()
+            || matches!(redirect.operator, ShellRedirectOperator::Other(_))
+        {
+            analysis.filtered_output_count += 1;
+        }
+    }
+    Ok(())
+}
+
+fn try_push_path_option_value(
+    inputs: &mut Vec<WatchInput>,
+    argv: &[String],
+    index: &mut usize,
+    cwd: &Path,
+) -> Result<bool> {
+    let token = argv[*index].as_str();
+    if let Some((option_name, value)) = split_long_option(token) {
+        if is_path_option_name(option_name) {
+            push_inferred_input(inputs, value, cwd)?;
+            *index += 1;
+            return Ok(true);
+        }
+        return Ok(false);
+    }
+
+    if token.starts_with("--") && is_path_option_name(token) {
+        if let Some(value) = argv.get(*index + 1) {
+            push_inferred_input(inputs, value.as_str(), cwd)?;
+        }
+        *index += 2;
+        return Ok(true);
+    }
+
+    Ok(false)
+}
+
+fn split_long_option(token: &str) -> Option<(&str, &str)> {
+    if !token.starts_with("--") {
+        return None;
+    }
+    let (name, value) = token.split_once('=')?;
+    Some((name, value))
+}
+
+fn is_path_option_name(option_name: &str) -> bool {
+    matches!(
+        option_name
+            .trim_start_matches('-')
+            .to_ascii_lowercase()
+            .as_str(),
+        "file"
+            | "files"
+            | "files0-from"
+            | "path"
+            | "paths"
+            | "dir"
+            | "directory"
+            | "input"
+            | "inputs"
+            | "from"
+            | "glob"
+            | "arg-file"
+            | "reference"
+    )
+}
+
+fn push_inferred_input(inputs: &mut Vec<WatchInput>, raw: &str, cwd: &Path) -> Result<()> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed == "-" {
+        return Ok(());
+    }
+
+    let input = if has_glob_magic(trimmed) {
+        WatchInput::glob(trimmed, cwd)?
+    } else {
+        WatchInput::path(trimmed, cwd, WatchInputKind::Inferred)?
+    };
+
+    if !inputs.contains(&input) {
+        inputs.push(input);
+    }
+
+    Ok(())
+}
+
+fn has_glob_magic(raw: &str) -> bool {
+    raw.contains('*') || raw.contains('?') || raw.contains('[')
+}
+
+fn path_exists(raw: &str, cwd: &Path) -> bool {
+    let expanded = expand_tilde(raw);
+    let path = Path::new(expanded.as_str());
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    };
+    absolute.exists()
+}
+
+fn expand_tilde(raw: &str) -> String {
+    if let Some(suffix) = raw.strip_prefix("~/") {
+        if let Ok(home) = std::env::var("HOME") {
+            return format!("{home}/{suffix}");
+        }
+    }
+    raw.to_string()
+}
+
+fn is_path_shaped(token: &str) -> bool {
+    token.starts_with('/')
+        || token.starts_with("./")
+        || token.starts_with("../")
+        || token.starts_with("~/")
+        || token.contains('/')
+        || token.contains('\\')
+        || token.contains('.')
+}
+
+fn looks_like_variable_assignment(token: &str) -> bool {
+    let Some((name, _value)) = token.split_once('=') else {
+        return false;
+    };
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|character| character == '_' || character.is_ascii_alphanumeric())
+}
+
+fn is_signed_integer(token: &str) -> bool {
+    let trimmed = token.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    let rest = trimmed
+        .strip_prefix('+')
+        .or_else(|| trimmed.strip_prefix('-'))
+        .unwrap_or(trimmed);
+    !rest.is_empty() && rest.chars().all(|character| character.is_ascii_digit())
+}
+
+fn is_find_expression_token(token: &str) -> bool {
+    token == "!" || token == "(" || token == ")" || token.starts_with('-') || token.starts_with(',')
+}
+
+fn should_ignore_fallback_token(token: &str) -> bool {
+    token.is_empty()
+        || is_signed_integer(token)
+        || looks_like_variable_assignment(token)
+        || is_dynamic_shell_token(token)
+}
+
+fn is_dynamic_shell_token(token: &str) -> bool {
+    token.starts_with("$(")
+        || token.starts_with("`")
+        || token.starts_with("<(")
+        || token.starts_with(">(")
+        || token.starts_with("${")
+        || token == "$@"
+        || token == "$*"
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+
+    use super::{
+        analyze_argv, analyze_shell_expression, CommandAdapterId, CommandAnalysisStatus,
+        SideEffectProfile,
+    };
+    use crate::parser::parse_shell_expression;
+
+    #[test]
+    fn cp_watches_only_sources() {
+        let cwd = tempfile::tempdir().expect("create tempdir");
+        let analysis = analyze_argv(
+            &[
+                OsString::from("cp"),
+                OsString::from("src.txt"),
+                OsString::from("dest.txt"),
+            ],
+            cwd.path(),
+        )
+        .expect("analyze");
+
+        assert_eq!(analysis.adapter_ids, vec![CommandAdapterId::CopyLike]);
+        assert_eq!(analysis.inputs.len(), 1);
+        assert_eq!(analysis.filtered_output_count, 1);
+        assert_eq!(
+            analysis.side_effect_profile,
+            SideEffectProfile::WritesExcludedOutputs
+        );
+    }
+
+    #[test]
+    fn mv_marks_watched_inputs_as_self_mutating() {
+        let cwd = tempfile::tempdir().expect("create tempdir");
+        let analysis = analyze_argv(
+            &[
+                OsString::from("mv"),
+                OsString::from("src.txt"),
+                OsString::from("dest.txt"),
+            ],
+            cwd.path(),
+        )
+        .expect("analyze");
+
+        assert_eq!(analysis.inputs.len(), 1);
+        assert_eq!(
+            analysis.side_effect_profile,
+            SideEffectProfile::WritesWatchedInputs
+        );
+    }
+
+    #[test]
+    fn grep_ignores_pattern_but_keeps_pattern_files() {
+        let cwd = tempfile::tempdir().expect("create tempdir");
+        let analysis = analyze_argv(
+            &[
+                OsString::from("grep"),
+                OsString::from("hello"),
+                OsString::from("file.txt"),
+            ],
+            cwd.path(),
+        )
+        .expect("analyze");
+        assert_eq!(analysis.inputs.len(), 1);
+
+        let analysis = analyze_argv(
+            &[
+                OsString::from("grep"),
+                OsString::from("-f"),
+                OsString::from("patterns.txt"),
+                OsString::from("file.txt"),
+            ],
+            cwd.path(),
+        )
+        .expect("analyze");
+        assert_eq!(analysis.inputs.len(), 2);
+    }
+
+    #[test]
+    fn sed_and_awk_ignore_inline_scripts() {
+        let cwd = tempfile::tempdir().expect("create tempdir");
+        let sed = analyze_argv(
+            &[
+                OsString::from("sed"),
+                OsString::from("-n"),
+                OsString::from("1,2p"),
+                OsString::from("file.txt"),
+            ],
+            cwd.path(),
+        )
+        .expect("analyze");
+        assert_eq!(sed.inputs.len(), 1);
+
+        let awk = analyze_argv(
+            &[
+                OsString::from("awk"),
+                OsString::from("{print $1}"),
+                OsString::from("file.txt"),
+            ],
+            cwd.path(),
+        )
+        .expect("analyze");
+        assert_eq!(awk.inputs.len(), 1);
+    }
+
+    #[test]
+    fn pathless_allowlist_defaults_to_current_directory() {
+        let cwd = tempfile::tempdir().expect("create tempdir");
+        let analysis = analyze_argv(&[OsString::from("ls"), OsString::from("-l")], cwd.path())
+            .expect("analyze");
+
+        assert_eq!(analysis.inputs.len(), 1);
+        assert!(analysis.default_watch_root_used);
+
+        let analysis = analyze_argv(&[OsString::from("find")], cwd.path()).expect("analyze");
+        assert_eq!(analysis.inputs.len(), 1);
+        assert!(analysis.default_watch_root_used);
+    }
+
+    #[test]
+    fn tar_excludes_archive_outputs_for_create_and_reads_archives_for_extract() {
+        let cwd = tempfile::tempdir().expect("create tempdir");
+        let create = analyze_argv(
+            &[
+                OsString::from("tar"),
+                OsString::from("-cf"),
+                OsString::from("out.tar"),
+                OsString::from("src"),
+                OsString::from("dir"),
+            ],
+            cwd.path(),
+        )
+        .expect("analyze");
+        assert_eq!(create.inputs.len(), 2);
+        assert_eq!(create.filtered_output_count, 1);
+
+        let extract = analyze_argv(
+            &[
+                OsString::from("tar"),
+                OsString::from("-xf"),
+                OsString::from("archive.tar"),
+            ],
+            cwd.path(),
+        )
+        .expect("analyze");
+        assert_eq!(extract.inputs.len(), 1);
+    }
+
+    #[test]
+    fn wrappers_unwrap_before_adapter_selection() {
+        let cwd = tempfile::tempdir().expect("create tempdir");
+        let analysis = analyze_argv(
+            &[
+                OsString::from("env"),
+                OsString::from("FOO=bar"),
+                OsString::from("grep"),
+                OsString::from("hello"),
+                OsString::from("file.txt"),
+            ],
+            cwd.path(),
+        )
+        .expect("analyze");
+        assert_eq!(
+            analysis.adapter_ids,
+            vec![CommandAdapterId::WrapperEnv, CommandAdapterId::Grep]
+        );
+
+        let analysis = analyze_argv(
+            &[
+                OsString::from("timeout"),
+                OsString::from("5"),
+                OsString::from("grep"),
+                OsString::from("hello"),
+                OsString::from("file.txt"),
+            ],
+            cwd.path(),
+        )
+        .expect("analyze");
+        assert_eq!(
+            analysis.adapter_ids,
+            vec![CommandAdapterId::WrapperTimeout, CommandAdapterId::Grep]
+        );
+    }
+
+    #[test]
+    fn unknown_command_fallback_ignores_opaque_words() {
+        let cwd = tempfile::tempdir().expect("create tempdir");
+        let analysis = analyze_argv(
+            &[
+                OsString::from("mystery"),
+                OsString::from("hello"),
+                OsString::from("1,2p"),
+            ],
+            cwd.path(),
+        )
+        .expect("analyze");
+
+        assert_eq!(analysis.adapter_ids, vec![CommandAdapterId::Fallback]);
+        assert_eq!(analysis.status, CommandAnalysisStatus::NoInputs);
+    }
+
+    #[test]
+    fn shell_analysis_keeps_input_redirects_and_filters_outputs() {
+        let cwd = tempfile::tempdir().expect("create tempdir");
+        let parsed =
+            parse_shell_expression("grep hello < input.txt > output.txt").expect("parse shell");
+        let analysis = analyze_shell_expression(&parsed, cwd.path()).expect("analyze shell");
+
+        assert_eq!(analysis.inputs.len(), 1);
+        assert_eq!(analysis.filtered_output_count, 1);
+    }
+}

--- a/crates/with-watch/src/lib.rs
+++ b/crates/with-watch/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod analysis;
 pub mod cli;
 pub mod error;
 pub mod logging;
@@ -8,11 +9,13 @@ pub mod watch;
 
 use std::path::Path;
 
+use analysis::{analyze_argv, analyze_shell_expression, CommandAnalysis, CommandAnalysisStatus};
 use cli::{Cli, CommandMode};
 use error::{Result, WithWatchError};
 use parser::parse_shell_expression;
-use runner::{ExecutionPlan, RunnerOptions};
+use runner::{ExecutionMetadata, ExecutionPlan, RunnerOptions};
 use snapshot::{ChangeDetectionMode, WatchInput, WatchInputKind};
+use tracing::debug;
 
 pub fn run_cli(cli: Cli, options: RunnerOptions) -> Result<i32> {
     let mode = cli.command_mode()?;
@@ -29,49 +32,81 @@ fn build_execution_plan(
 ) -> Result<ExecutionPlan> {
     match mode {
         CommandMode::Passthrough { argv } => {
-            let inputs = infer_watch_inputs_from_argv(&argv, cwd)?;
-            Ok(ExecutionPlan::passthrough(argv, inputs, detection_mode))
+            let analysis = analyze_argv(&argv, cwd)?;
+            log_analysis("passthrough", &analysis);
+            let inputs = require_inferred_inputs(&analysis)?;
+            Ok(ExecutionPlan::passthrough(
+                argv,
+                inputs,
+                detection_mode,
+                execution_metadata(&analysis),
+            ))
         }
         CommandMode::Shell { expression } => {
             let parsed = parse_shell_expression(&expression)?;
-            let inputs = infer_watch_inputs_from_values(&parsed.input_candidates, cwd)?;
-            Ok(ExecutionPlan::shell(expression, inputs, detection_mode))
+            let analysis = analyze_shell_expression(&parsed, cwd)?;
+            log_analysis("shell", &analysis);
+            let inputs = require_inferred_inputs(&analysis)?;
+            Ok(ExecutionPlan::shell(
+                expression,
+                inputs,
+                detection_mode,
+                execution_metadata(&analysis),
+            ))
         }
         CommandMode::Exec { inputs, argv } => {
+            let analysis = analyze_argv(&argv, cwd)?;
+            log_analysis("exec", &analysis);
             let planned_inputs = explicit_watch_inputs(&inputs, cwd)?;
-            Ok(ExecutionPlan::exec(argv, planned_inputs, detection_mode))
+            Ok(ExecutionPlan::exec(
+                argv,
+                planned_inputs,
+                detection_mode,
+                execution_metadata(&analysis),
+            ))
         }
     }
 }
 
-fn infer_watch_inputs_from_argv(
-    argv: &[std::ffi::OsString],
-    cwd: &Path,
-) -> Result<Vec<WatchInput>> {
-    if argv.is_empty() {
-        return Err(WithWatchError::MissingCommand);
+fn require_inferred_inputs(analysis: &CommandAnalysis) -> Result<Vec<WatchInput>> {
+    if analysis.status == CommandAnalysisStatus::Resolved && !analysis.inputs.is_empty() {
+        return Ok(analysis.inputs.clone());
     }
 
-    let mut values = Vec::new();
-    for raw in argv.iter().skip(1) {
-        push_watch_candidates_from_os(raw, &mut values);
-    }
+    debug!(
+        adapter_id = analysis.adapter_field(),
+        inference_status = analysis.status.as_str(),
+        fallback_used = analysis.fallback_used,
+        filtered_output_count = analysis.filtered_output_count,
+        "Command analysis did not yield safe inferred inputs"
+    );
 
-    infer_watch_inputs_from_values(&values, cwd)
+    Err(WithWatchError::NoWatchInputs)
 }
 
-fn infer_watch_inputs_from_values(values: &[String], cwd: &Path) -> Result<Vec<WatchInput>> {
-    let mut inputs = Vec::new();
-
-    for value in values {
-        push_watch_input_from_token(value, cwd, &mut inputs)?;
+fn execution_metadata(analysis: &CommandAnalysis) -> ExecutionMetadata {
+    ExecutionMetadata {
+        adapter_ids: analysis.adapter_ids.clone(),
+        fallback_used: analysis.fallback_used,
+        default_watch_root_used: analysis.default_watch_root_used,
+        filtered_output_count: analysis.filtered_output_count,
+        side_effect_profile: analysis.side_effect_profile,
+        status: analysis.status,
     }
+}
 
-    if inputs.is_empty() {
-        return Err(WithWatchError::NoWatchInputs);
-    }
-
-    Ok(inputs)
+fn log_analysis(mode: &str, analysis: &CommandAnalysis) {
+    debug!(
+        mode,
+        adapter_id = analysis.adapter_field(),
+        fallback_used = analysis.fallback_used,
+        default_watch_root_used = analysis.default_watch_root_used,
+        filtered_output_count = analysis.filtered_output_count,
+        side_effect_profile = analysis.side_effect_profile.as_str(),
+        inference_status = analysis.status.as_str(),
+        inferred_input_count = analysis.inputs.len(),
+        "Built command analysis"
+    );
 }
 
 fn explicit_watch_inputs(raw_inputs: &[String], cwd: &Path) -> Result<Vec<WatchInput>> {
@@ -91,46 +126,6 @@ fn explicit_watch_inputs(raw_inputs: &[String], cwd: &Path) -> Result<Vec<WatchI
     Ok(inputs)
 }
 
-fn push_watch_candidates_from_os(raw: &std::ffi::OsString, values: &mut Vec<String>) {
-    let text = raw.to_string_lossy();
-    push_watch_candidates_from_text(&text, values);
-}
-
-fn push_watch_candidates_from_text(raw: &str, values: &mut Vec<String>) {
-    if raw.is_empty() {
-        return;
-    }
-
-    if let Some((prefix, value)) = raw.split_once('=') {
-        if prefix.starts_with('-') && !value.is_empty() {
-            values.push(value.to_string());
-            return;
-        }
-    }
-
-    if raw.starts_with('-') {
-        return;
-    }
-
-    values.push(raw.to_string());
-}
-
-fn push_watch_input_from_token(raw: &str, cwd: &Path, inputs: &mut Vec<WatchInput>) -> Result<()> {
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
-        return Ok(());
-    }
-
-    let input = if has_glob_magic(trimmed) {
-        WatchInput::glob(trimmed, cwd)?
-    } else {
-        WatchInput::path(trimmed, cwd, WatchInputKind::Inferred)?
-    };
-
-    push_unique_input(inputs, input);
-    Ok(())
-}
-
 fn push_unique_input(inputs: &mut Vec<WatchInput>, input: WatchInput) {
     if !inputs.contains(&input) {
         inputs.push(input);
@@ -143,43 +138,7 @@ fn has_glob_magic(raw: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::{ffi::OsString, fs, path::Path};
-
-    use super::{
-        explicit_watch_inputs, infer_watch_inputs_from_argv, infer_watch_inputs_from_values,
-    };
-    use crate::snapshot::WatchInputKind;
-
-    #[test]
-    fn infers_existing_and_missing_paths_from_passthrough_argv() {
-        let temp_dir = tempfile::tempdir().expect("create tempdir");
-        let existing = temp_dir.path().join("input.txt");
-        fs::write(&existing, "hello").expect("write input");
-
-        let inputs = infer_watch_inputs_from_argv(
-            &[
-                OsString::from("cp"),
-                existing.as_os_str().to_os_string(),
-                OsString::from("output.txt"),
-            ],
-            temp_dir.path(),
-        )
-        .expect("infer inputs");
-
-        assert_eq!(inputs.len(), 2);
-        assert!(inputs
-            .iter()
-            .any(|input| input.kind() == WatchInputKind::Inferred));
-    }
-
-    #[test]
-    fn inferred_values_require_at_least_one_candidate() {
-        let error =
-            infer_watch_inputs_from_values(&[], Path::new(".")).expect_err("expected error");
-        assert!(error
-            .to_string()
-            .contains("No watch inputs could be inferred"));
-    }
+    use super::explicit_watch_inputs;
 
     #[test]
     fn explicit_inputs_accept_globs_and_paths() {

--- a/crates/with-watch/src/parser.rs
+++ b/crates/with-watch/src/parser.rs
@@ -3,7 +3,64 @@ use crate::error::{Result, WithWatchError};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParsedShellExpression {
     pub expression: String,
-    pub input_candidates: Vec<String>,
+    pub commands: Vec<ShellCommand>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ShellCommand {
+    pub env_assignments: Vec<ShellEnvAssignment>,
+    pub argv: Vec<String>,
+    pub redirects: Vec<ShellRedirect>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShellEnvAssignment {
+    pub key: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShellRedirect {
+    pub operator: ShellRedirectOperator,
+    pub target: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ShellRedirectOperator {
+    Read,
+    ReadWrite,
+    Write,
+    Append,
+    WriteAll,
+    AppendAll,
+    Clobber,
+    Other(String),
+}
+
+impl ShellRedirectOperator {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Read => "<",
+            Self::ReadWrite => "<>",
+            Self::Write => ">",
+            Self::Append => ">>",
+            Self::WriteAll => "&>",
+            Self::AppendAll => "&>>",
+            Self::Clobber => ">|",
+            Self::Other(operator) => operator.as_str(),
+        }
+    }
+
+    pub fn reads_input(&self) -> bool {
+        matches!(self, Self::Read | Self::ReadWrite)
+    }
+
+    pub fn writes_output(&self) -> bool {
+        matches!(
+            self,
+            Self::Write | Self::Append | Self::WriteAll | Self::AppendAll | Self::Clobber
+        )
+    }
 }
 
 pub fn parse_shell_expression(expression: &str) -> Result<ParsedShellExpression> {
@@ -11,20 +68,20 @@ pub fn parse_shell_expression(expression: &str) -> Result<ParsedShellExpression>
         message: error.to_string(),
     })?;
 
-    let mut input_candidates = Vec::new();
+    let mut commands = Vec::new();
     for pipeline in parsed.0 {
-        collect_pipeline_inputs(pipeline, &mut input_candidates)?;
+        collect_pipeline_commands(pipeline, &mut commands)?;
     }
 
     Ok(ParsedShellExpression {
         expression: expression.to_string(),
-        input_candidates,
+        commands,
     })
 }
 
-fn collect_pipeline_inputs(
+fn collect_pipeline_commands(
     pipeline: starbase_args::Pipeline,
-    input_candidates: &mut Vec<String>,
+    commands: &mut Vec<ShellCommand>,
 ) -> Result<()> {
     match pipeline {
         starbase_args::Pipeline::Start(command_list)
@@ -32,24 +89,34 @@ fn collect_pipeline_inputs(
         | starbase_args::Pipeline::Pipe(command_list)
         | starbase_args::Pipeline::PipeAll(command_list)
         | starbase_args::Pipeline::PipeWith(command_list, _) => {
-            collect_command_list_inputs(command_list, input_candidates)
+            collect_command_list_commands(command_list, commands)
         }
     }
 }
 
-fn collect_command_list_inputs(
+fn collect_command_list_commands(
     command_list: starbase_args::CommandList,
-    input_candidates: &mut Vec<String>,
+    commands: &mut Vec<ShellCommand>,
 ) -> Result<()> {
+    let mut current_command_index: Option<usize> = None;
+
     for sequence in command_list.0 {
         match sequence {
             starbase_args::Sequence::Start(command)
             | starbase_args::Sequence::Then(command)
             | starbase_args::Sequence::AndThen(command)
             | starbase_args::Sequence::OrElse(command)
-            | starbase_args::Sequence::Passthrough(command)
-            | starbase_args::Sequence::Redirect(command, _) => {
-                collect_command_inputs(command, input_candidates)?;
+            | starbase_args::Sequence::Passthrough(command) => {
+                let shell_command = build_shell_command(command)?;
+                if !shell_command.argv.is_empty() {
+                    commands.push(shell_command);
+                    current_command_index = Some(commands.len() - 1);
+                }
+            }
+            starbase_args::Sequence::Redirect(command, operator) => {
+                if let Some(index) = current_command_index {
+                    collect_redirects(command, operator, &mut commands[index].redirects);
+                }
             }
             starbase_args::Sequence::Stop(_) => {}
         }
@@ -58,35 +125,70 @@ fn collect_command_list_inputs(
     Ok(())
 }
 
-fn collect_command_inputs(
-    command: starbase_args::Command,
-    input_candidates: &mut Vec<String>,
-) -> Result<()> {
-    let mut command_name_seen = false;
+fn build_shell_command(command: starbase_args::Command) -> Result<ShellCommand> {
+    let mut shell_command = ShellCommand::default();
 
     for argument in command.0 {
         match argument {
-            starbase_args::Argument::EnvVar(_, value, _) => {
-                input_candidates.push(value.as_str().to_string());
+            starbase_args::Argument::EnvVar(key, value, _) => {
+                shell_command.env_assignments.push(ShellEnvAssignment {
+                    key,
+                    value: value.as_str().to_string(),
+                });
             }
-            starbase_args::Argument::Flag(_) | starbase_args::Argument::FlagGroup(_) => {}
-            starbase_args::Argument::Option(_, Some(value)) => {
-                input_candidates.push(value.as_str().to_string());
+            starbase_args::Argument::FlagGroup(flag) | starbase_args::Argument::Flag(flag) => {
+                shell_command.argv.push(flag);
             }
-            starbase_args::Argument::Option(_, None) => {}
+            starbase_args::Argument::Option(option, Some(value)) => {
+                shell_command
+                    .argv
+                    .push(format!("{option}={}", value.as_str()));
+            }
+            starbase_args::Argument::Option(option, None) => {
+                shell_command.argv.push(option);
+            }
             starbase_args::Argument::Value(value) => {
-                if !command_name_seen {
+                if shell_command.argv.is_empty() {
                     validate_command_name(value.as_str())?;
-                    command_name_seen = true;
-                    continue;
                 }
-
-                input_candidates.push(value.as_str().to_string());
+                shell_command.argv.push(value.as_str().to_string());
             }
         }
     }
 
-    Ok(())
+    Ok(shell_command)
+}
+
+fn collect_redirects(
+    command: starbase_args::Command,
+    operator: String,
+    redirects: &mut Vec<ShellRedirect>,
+) {
+    for argument in command.0 {
+        match argument {
+            starbase_args::Argument::Option(_, _)
+            | starbase_args::Argument::Flag(_)
+            | starbase_args::Argument::FlagGroup(_)
+            | starbase_args::Argument::EnvVar(_, _, _) => {}
+            starbase_args::Argument::Value(value) => redirects.push(ShellRedirect {
+                operator: classify_redirect_operator(&operator),
+                target: value.as_str().to_string(),
+            }),
+        }
+    }
+}
+
+fn classify_redirect_operator(operator: &str) -> ShellRedirectOperator {
+    match operator {
+        "<" => ShellRedirectOperator::Read,
+        "<>" => ShellRedirectOperator::ReadWrite,
+        ">" => ShellRedirectOperator::Write,
+        ">>" => ShellRedirectOperator::Append,
+        "&>" | "1&>" | "2&>" => ShellRedirectOperator::WriteAll,
+        "&>>" | "1&>>" | "2&>>" => ShellRedirectOperator::AppendAll,
+        ">|" => ShellRedirectOperator::Clobber,
+        other => ShellRedirectOperator::Other(other.to_string()),
+    }
 }
 
 fn validate_command_name(command_name: &str) -> Result<()> {
@@ -120,16 +222,32 @@ fn validate_command_name(command_name: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_shell_expression;
+    use super::{parse_shell_expression, ShellRedirectOperator};
 
     #[test]
     fn parses_command_lines_with_and_or_and_pipeline_operators() {
         let parsed = parse_shell_expression("cp src.txt dest.txt && cat dest.txt | grep hello")
             .expect("parse shell");
 
-        assert!(parsed.input_candidates.contains(&"src.txt".to_string()));
-        assert!(parsed.input_candidates.contains(&"dest.txt".to_string()));
-        assert!(parsed.input_candidates.contains(&"hello".to_string()));
+        assert_eq!(parsed.commands.len(), 3);
+        assert_eq!(parsed.commands[0].argv, vec!["cp", "src.txt", "dest.txt"]);
+        assert_eq!(parsed.commands[1].argv, vec!["cat", "dest.txt"]);
+        assert_eq!(parsed.commands[2].argv, vec!["grep", "hello"]);
+    }
+
+    #[test]
+    fn preserves_redirect_targets_as_structured_metadata() {
+        let parsed =
+            parse_shell_expression("grep hello < input.txt > output.txt").expect("parse shell");
+
+        assert_eq!(parsed.commands.len(), 1);
+        let command = &parsed.commands[0];
+        assert_eq!(command.argv, vec!["grep", "hello"]);
+        assert_eq!(command.redirects.len(), 2);
+        assert_eq!(command.redirects[0].operator, ShellRedirectOperator::Read);
+        assert_eq!(command.redirects[0].target, "input.txt");
+        assert_eq!(command.redirects[1].operator, ShellRedirectOperator::Write);
+        assert_eq!(command.redirects[1].target, "output.txt");
     }
 
     #[test]

--- a/crates/with-watch/src/runner.rs
+++ b/crates/with-watch/src/runner.rs
@@ -8,8 +8,9 @@ use std::{
 use tracing::{debug, info, warn};
 
 use crate::{
+    analysis::{CommandAdapterId, CommandAnalysisStatus, SideEffectProfile},
     error::{Result, WithWatchError},
-    snapshot::{capture_snapshot, ChangeDetectionMode, CommandSource, SnapshotState, WatchInput},
+    snapshot::{capture_snapshot, ChangeDetectionMode, CommandSource, WatchInput},
     watch::{CollectedEvents, WatchLoop},
 };
 
@@ -22,6 +23,7 @@ pub struct ExecutionPlan {
     pub detection_mode: ChangeDetectionMode,
     pub inputs: Vec<WatchInput>,
     pub delegated_command: DelegatedCommand,
+    pub metadata: ExecutionMetadata,
 }
 
 impl ExecutionPlan {
@@ -29,12 +31,14 @@ impl ExecutionPlan {
         argv: Vec<OsString>,
         inputs: Vec<WatchInput>,
         detection_mode: ChangeDetectionMode,
+        metadata: ExecutionMetadata,
     ) -> Self {
         Self {
             source: CommandSource::Argv,
             detection_mode,
             inputs,
             delegated_command: DelegatedCommand::Argv(argv),
+            metadata,
         }
     }
 
@@ -42,12 +46,14 @@ impl ExecutionPlan {
         expression: String,
         inputs: Vec<WatchInput>,
         detection_mode: ChangeDetectionMode,
+        metadata: ExecutionMetadata,
     ) -> Self {
         Self {
             source: CommandSource::Shell,
             detection_mode,
             inputs,
             delegated_command: DelegatedCommand::Shell(expression),
+            metadata,
         }
     }
 
@@ -55,13 +61,35 @@ impl ExecutionPlan {
         argv: Vec<OsString>,
         inputs: Vec<WatchInput>,
         detection_mode: ChangeDetectionMode,
+        metadata: ExecutionMetadata,
     ) -> Self {
         Self {
             source: CommandSource::Exec,
             detection_mode,
             inputs,
             delegated_command: DelegatedCommand::Argv(argv),
+            metadata,
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ExecutionMetadata {
+    pub adapter_ids: Vec<CommandAdapterId>,
+    pub fallback_used: bool,
+    pub default_watch_root_used: bool,
+    pub filtered_output_count: usize,
+    pub side_effect_profile: SideEffectProfile,
+    pub status: CommandAnalysisStatus,
+}
+
+impl ExecutionMetadata {
+    pub fn adapter_field(&self) -> String {
+        self.adapter_ids
+            .iter()
+            .map(|adapter| adapter.as_str())
+            .collect::<Vec<_>>()
+            .join(",")
     }
 }
 
@@ -130,12 +158,18 @@ pub fn run(plan: ExecutionPlan, options: RunnerOptions) -> Result<i32> {
     let mut baseline = capture_snapshot(&plan.inputs, plan.detection_mode)?;
     let mut child = Some(spawn_command(&plan.delegated_command)?);
     let mut completed_runs = 0usize;
-    let mut queued_snapshot: Option<SnapshotState> = None;
+    let mut pending_rerun = false;
 
     info!(
         command_source = plan.source.as_str(),
         detection_mode = plan.detection_mode.as_str(),
         input_count = plan.inputs.len(),
+        adapter_id = plan.metadata.adapter_field(),
+        fallback_used = plan.metadata.fallback_used,
+        default_watch_root_used = plan.metadata.default_watch_root_used,
+        filtered_output_count = plan.metadata.filtered_output_count,
+        side_effect_profile = plan.metadata.side_effect_profile.as_str(),
+        analysis_status = plan.metadata.status.as_str(),
         "Starting with-watch run loop"
     );
 
@@ -151,13 +185,34 @@ pub fn run(plan: ExecutionPlan, options: RunnerOptions) -> Result<i32> {
             {
                 completed_runs += 1;
                 let last_exit_code = exit_code_from_status(status);
+                let post_run_snapshot = capture_snapshot(&plan.inputs, plan.detection_mode)?;
+                let inputs_changed_since_baseline =
+                    post_run_snapshot.is_meaningfully_different(&baseline, plan.detection_mode);
+                let should_rerun = pending_rerun
+                    && plan.metadata.side_effect_profile != SideEffectProfile::WritesWatchedInputs
+                    && inputs_changed_since_baseline;
+
+                if pending_rerun
+                    && plan.metadata.side_effect_profile == SideEffectProfile::WritesWatchedInputs
+                {
+                    debug!(
+                        rerun_suppressed = true,
+                        side_effect_profile = plan.metadata.side_effect_profile.as_str(),
+                        "Suppressing rerun after self-mutating command activity"
+                    );
+                }
+
+                baseline = post_run_snapshot;
+                pending_rerun = false;
+                child = None;
+
                 info!(
                     completed_runs,
                     last_exit_code,
                     command_source = plan.source.as_str(),
+                    rerun_queued = should_rerun,
                     "Delegated command finished"
                 );
-                child = None;
 
                 if options
                     .max_runs
@@ -166,8 +221,7 @@ pub fn run(plan: ExecutionPlan, options: RunnerOptions) -> Result<i32> {
                     return Ok(last_exit_code);
                 }
 
-                if let Some(next_snapshot) = queued_snapshot.take() {
-                    baseline = next_snapshot;
+                if should_rerun {
                     child = Some(spawn_command(&plan.delegated_command)?);
                     continue;
                 }
@@ -189,13 +243,17 @@ pub fn run(plan: ExecutionPlan, options: RunnerOptions) -> Result<i32> {
                 );
 
                 if child.is_some() {
-                    queued_snapshot = Some(current_snapshot);
+                    pending_rerun = true;
                 } else {
                     baseline = current_snapshot;
                     child = Some(spawn_command(&plan.delegated_command)?);
                 }
-            } else {
-                queued_snapshot = None;
+            } else if child.is_some() {
+                pending_rerun = false;
+                debug!(
+                    rerun_suppressed = true,
+                    "Ignored non-meaningful filesystem churn"
+                );
             }
         } else if child.is_none() {
             thread::sleep(Duration::from_millis(10));

--- a/crates/with-watch/src/runner.rs
+++ b/crates/with-watch/src/runner.rs
@@ -1,5 +1,7 @@
 use std::{
     ffi::OsString,
+    fs,
+    path::PathBuf,
     process::{Child, Command, ExitStatus, Stdio},
     thread,
     time::Duration,
@@ -16,6 +18,7 @@ use crate::{
 
 const DEFAULT_POLL_TIMEOUT: Duration = Duration::from_millis(50);
 const DEFAULT_DEBOUNCE_WINDOW: Duration = Duration::from_millis(200);
+const WITH_WATCH_TEST_RUN_MARKER_DIR_ENV: &str = "WITH_WATCH_TEST_RUN_MARKER_DIR";
 
 #[derive(Debug, Clone)]
 pub struct ExecutionPlan {
@@ -205,6 +208,7 @@ pub fn run(plan: ExecutionPlan, options: RunnerOptions) -> Result<i32> {
                 baseline = post_run_snapshot;
                 pending_rerun = false;
                 child = None;
+                write_test_run_marker(completed_runs);
 
                 info!(
                     completed_runs,
@@ -336,4 +340,30 @@ fn spawn_shell(expression: &str) -> Result<Child> {
 
 fn exit_code_from_status(status: ExitStatus) -> i32 {
     status.code().unwrap_or(1)
+}
+
+fn write_test_run_marker(completed_runs: usize) {
+    let Ok(marker_dir) = std::env::var(WITH_WATCH_TEST_RUN_MARKER_DIR_ENV) else {
+        return;
+    };
+
+    let marker_path = PathBuf::from(marker_dir).join(format!("run-{completed_runs}.done"));
+    if let Some(parent) = marker_path.parent() {
+        if let Err(error) = fs::create_dir_all(parent) {
+            warn!(
+                path = parent.display().to_string(),
+                %error,
+                "Failed to create test run marker directory"
+            );
+            return;
+        }
+    }
+
+    if let Err(error) = fs::write(&marker_path, completed_runs.to_string()) {
+        warn!(
+            path = marker_path.display().to_string(),
+            %error,
+            "Failed to write test run marker"
+        );
+    }
 }

--- a/crates/with-watch/src/snapshot.rs
+++ b/crates/with-watch/src/snapshot.rs
@@ -68,7 +68,7 @@ pub enum WatchInput {
 impl WatchInput {
     pub fn path(raw: &str, cwd: &Path, kind: WatchInputKind) -> Result<Self> {
         let absolute_path = absolutize(raw, cwd);
-        let watch_anchor = nearest_existing_parent(&absolute_path).ok_or_else(|| {
+        let watch_anchor = path_watch_anchor(&absolute_path).ok_or_else(|| {
             WithWatchError::MissingWatchAnchor {
                 path: absolute_path.clone(),
             }
@@ -372,6 +372,17 @@ fn nearest_existing_parent(path: &Path) -> Option<PathBuf> {
     None
 }
 
+fn path_watch_anchor(path: &Path) -> Option<PathBuf> {
+    let nearest = nearest_existing_parent(path)?;
+    if nearest.is_dir() {
+        return Some(nearest);
+    }
+
+    // Watch the containing directory for file inputs so replace-style writers such
+    // as GNU `sed -i` do not orphan the watch after swapping the inode.
+    nearest.parent().map(Path::to_path_buf)
+}
+
 fn glob_anchor(raw: &str, cwd: &Path) -> PathBuf {
     let expanded = expand_tilde(raw);
     let original_path = PathBuf::from(&expanded);
@@ -420,6 +431,27 @@ mod tests {
 
         match input {
             WatchInput::Glob { watch_anchor, .. } => {
+                assert_eq!(watch_anchor, temp_dir.path());
+            }
+            other => panic!("unexpected watch input: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn path_inputs_anchor_to_parent_directory_for_files() {
+        let temp_dir = tempfile::tempdir().expect("create tempdir");
+        let input_path = temp_dir.path().join("input.txt");
+        fs::write(&input_path, "alpha\n").expect("write file");
+
+        let input = WatchInput::path(
+            input_path.to_string_lossy().as_ref(),
+            temp_dir.path(),
+            WatchInputKind::Inferred,
+        )
+        .expect("path input");
+
+        match input {
+            WatchInput::Path { watch_anchor, .. } => {
                 assert_eq!(watch_anchor, temp_dir.path());
             }
             other => panic!("unexpected watch input: {other:?}"),

--- a/crates/with-watch/tests/cli.rs
+++ b/crates/with-watch/tests/cli.rs
@@ -129,7 +129,7 @@ fn passthrough_cp_does_not_rerun_from_its_own_output_write() {
 
     fs::write(&input_path, "beta\n").expect("rewrite input");
 
-    let status = child.wait().expect("wait for child");
+    let status = wait_for_child_exit(&mut child, Duration::from_secs(10));
     assert!(status.success());
     assert_eq!(
         fs::read_to_string(&output_path).expect("read output"),
@@ -142,12 +142,14 @@ fn passthrough_cp_does_not_rerun_from_its_own_output_write() {
 fn passthrough_sed_in_place_does_not_loop_on_its_own_write() {
     let temp_dir = tempfile::tempdir().expect("create tempdir");
     let input_path = temp_dir.path().join("input.txt");
+    let marker_dir = temp_dir.path().join("markers");
     fs::write(&input_path, "alpha\n").expect("write input");
 
     let mut child = ProcessCommand::new(assert_cmd::cargo::cargo_bin!("with-watch"))
         .current_dir(temp_dir.path())
         .env("WITH_WATCH_TEST_MAX_RUNS", "2")
         .env("WITH_WATCH_TEST_DEBOUNCE_MS", "25")
+        .env("WITH_WATCH_TEST_RUN_MARKER_DIR", &marker_dir)
         .args([
             "sed",
             "-i.bak",
@@ -162,12 +164,13 @@ fn passthrough_sed_in_place_does_not_loop_on_its_own_write() {
         .expect("spawn with-watch");
 
     wait_for_file_contents(&input_path, "beta\n");
-    thread::sleep(Duration::from_millis(150));
+    wait_for_path(&marker_dir.join("run-1.done"));
     assert!(child.try_wait().expect("poll child").is_none());
 
     fs::write(&input_path, "alpha\n").expect("rewrite input");
+    wait_for_path(&marker_dir.join("run-2.done"));
 
-    let status = child.wait().expect("wait for child");
+    let status = wait_for_child_exit(&mut child, Duration::from_secs(10));
     assert!(status.success());
     assert_eq!(
         fs::read_to_string(&input_path).expect("read input"),
@@ -210,7 +213,7 @@ fn exec_mode_reruns_when_an_explicit_input_changes() {
     thread::sleep(Duration::from_millis(50));
     fs::write(&input_path, "beta\n").expect("rewrite input");
 
-    let status = child.wait().expect("wait for child");
+    let status = wait_for_child_exit(&mut child, Duration::from_secs(10));
     assert!(status.success());
 
     let output = fs::read_to_string(&output_path).expect("read output");
@@ -232,6 +235,35 @@ fn wait_for_file_contents(path: &Path, expected_contents: &str) {
         "timed out waiting for contents `{expected_contents}` in {}",
         path.display()
     );
+}
+
+#[cfg(unix)]
+fn wait_for_path(path: &Path) {
+    for _ in 0..400 {
+        if path.exists() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+    panic!("timed out waiting for {}", path.display());
+}
+
+#[cfg(unix)]
+fn wait_for_child_exit(
+    child: &mut std::process::Child,
+    timeout: Duration,
+) -> std::process::ExitStatus {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait().expect("poll child") {
+            return status;
+        }
+        if std::time::Instant::now() >= deadline {
+            child.kill().expect("kill child after timeout");
+            panic!("timed out waiting for child process to exit");
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
 }
 
 #[cfg(unix)]

--- a/crates/with-watch/tests/cli.rs
+++ b/crates/with-watch/tests/cli.rs
@@ -25,9 +25,9 @@ fn help_lists_shell_and_exec_modes() {
 }
 
 #[test]
-fn pathless_passthrough_guides_users_to_exec_input() {
+fn commands_without_filesystem_inputs_guide_users_to_exec_input() {
     with_watch_command()
-        .args(["ls", "-l"])
+        .args(["echo", "hello"])
         .assert()
         .failure()
         .stderr(predicate::str::contains(
@@ -71,6 +71,19 @@ fn passthrough_mode_runs_a_posix_utility_once_with_test_hook() {
 
 #[cfg(unix)]
 #[test]
+fn pathless_allowlist_command_runs_once_with_test_hook() {
+    let temp_dir = tempfile::tempdir().expect("create tempdir");
+
+    with_watch_command()
+        .current_dir(temp_dir.path())
+        .env("WITH_WATCH_TEST_MAX_RUNS", "1")
+        .args(["ls", "-l"])
+        .assert()
+        .success();
+}
+
+#[cfg(unix)]
+#[test]
 fn shell_mode_supports_operators_and_exits_after_one_run_with_test_hook() {
     let temp_dir = tempfile::tempdir().expect("create tempdir");
     let input_path = temp_dir.path().join("input.txt");
@@ -85,6 +98,81 @@ fn shell_mode_supports_operators_and_exits_after_one_run_with_test_hook() {
         .assert()
         .success()
         .stdout(predicate::str::contains("hello"));
+}
+
+#[cfg(unix)]
+#[test]
+fn passthrough_cp_does_not_rerun_from_its_own_output_write() {
+    let temp_dir = tempfile::tempdir().expect("create tempdir");
+    let input_path = temp_dir.path().join("input.txt");
+    let output_path = temp_dir.path().join("output.txt");
+    fs::write(&input_path, "alpha\n").expect("write input");
+
+    let mut child = ProcessCommand::new(assert_cmd::cargo::cargo_bin!("with-watch"))
+        .current_dir(temp_dir.path())
+        .env("WITH_WATCH_TEST_MAX_RUNS", "2")
+        .env("WITH_WATCH_TEST_DEBOUNCE_MS", "25")
+        .args([
+            "cp",
+            input_path.to_string_lossy().as_ref(),
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn with-watch");
+
+    wait_for_file_contents(&output_path, "alpha\n");
+    thread::sleep(Duration::from_millis(150));
+    assert!(child.try_wait().expect("poll child").is_none());
+
+    fs::write(&input_path, "beta\n").expect("rewrite input");
+
+    let status = child.wait().expect("wait for child");
+    assert!(status.success());
+    assert_eq!(
+        fs::read_to_string(&output_path).expect("read output"),
+        "beta\n"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn passthrough_sed_in_place_does_not_loop_on_its_own_write() {
+    let temp_dir = tempfile::tempdir().expect("create tempdir");
+    let input_path = temp_dir.path().join("input.txt");
+    fs::write(&input_path, "alpha\n").expect("write input");
+
+    let mut child = ProcessCommand::new(assert_cmd::cargo::cargo_bin!("with-watch"))
+        .current_dir(temp_dir.path())
+        .env("WITH_WATCH_TEST_MAX_RUNS", "2")
+        .env("WITH_WATCH_TEST_DEBOUNCE_MS", "25")
+        .args([
+            "sed",
+            "-i.bak",
+            "-e",
+            "s/alpha/beta/",
+            input_path.to_string_lossy().as_ref(),
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn with-watch");
+
+    wait_for_file_contents(&input_path, "beta\n");
+    thread::sleep(Duration::from_millis(150));
+    assert!(child.try_wait().expect("poll child").is_none());
+
+    fs::write(&input_path, "alpha\n").expect("rewrite input");
+
+    let status = child.wait().expect("wait for child");
+    assert!(status.success());
+    assert_eq!(
+        fs::read_to_string(&input_path).expect("read input"),
+        "beta\n"
+    );
 }
 
 #[cfg(unix)]
@@ -128,6 +216,22 @@ fn exec_mode_reruns_when_an_explicit_input_changes() {
     let output = fs::read_to_string(&output_path).expect("read output");
     let lines = output.lines().collect::<Vec<_>>();
     assert_eq!(lines, vec!["alpha", "beta"]);
+}
+
+#[cfg(unix)]
+fn wait_for_file_contents(path: &Path, expected_contents: &str) {
+    for _ in 0..80 {
+        if let Ok(contents) = fs::read_to_string(path) {
+            if contents == expected_contents {
+                return;
+            }
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+    panic!(
+        "timed out waiting for contents `{expected_contents}` in {}",
+        path.display()
+    );
 }
 
 #[cfg(unix)]

--- a/docs/crates-with-watch-foundation.md
+++ b/docs/crates-with-watch-foundation.md
@@ -19,10 +19,19 @@
 - Stable internal enums must remain aligned with the current v1 contract:
   - `ChangeDetectionMode::{ContentHash, MtimeOnly}`
   - `CommandSource::{Argv, Shell, Exec}`
+  - `CommandAnalysisStatus::{Resolved, NoInputs, AmbiguousFallback}`
+  - `CommandAdapterId` adapter categories used for built-in inference
+  - `SideEffectProfile::{ReadOnly, WritesExcludedOutputs, WritesWatchedInputs}`
   - `WatchInput::{Path, Glob}`
   - `SnapshotEntryKind::{File, Directory, Missing}`
 - Shell mode must parse command-line expressions with `&&`, `||`, and `|`, while shell control-flow constructs remain out of scope for v1.
-- Generic watch planning must infer inputs from delegated non-flag argument values and option values, while `exec --input` remains the canonical explicit input contract when inference is insufficient.
+- Shell redirects must treat `<` and `<>` targets as watched inputs and `>`, `>>`, `&>`, `&>>`, and `>|` targets as filtered outputs.
+- Generic watch planning must use adapter-driven inference for built-in command families and a conservative fallback for unknown tools.
+- Safe pathless `.` defaults are limited to `ls`, `dir`, `vdir`, `du`, and `find`.
+- Built-in inference must exclude known outputs, scripts, inline patterns, and opaque fallback operands from the watch set.
+- Wrapper commands (`env`, `nice`, `nohup`, `stdbuf`, and `timeout`) must unwrap to the delegated command before adapter selection.
+- `exec --input` remains the canonical explicit input contract when inference is insufficient, but command-side side-effect metadata may still be inferred for rerun suppression and logging.
+- Commands marked as `WritesWatchedInputs` must refresh the baseline snapshot after each run and suppress reruns caused only by their own writes while they were executing.
 
 ## Storage
 - `with-watch` does not persist project state.
@@ -35,12 +44,12 @@
 
 ## Logging
 - Use structured `tracing` logs for command planning, watcher setup, snapshot capture, debounce decisions, and rerun causes.
-- Logs must include `command_source`, `detection_mode`, input counts, and rerun outcomes.
+- Logs must include `command_source`, `detection_mode`, input counts, `adapter_id`, `fallback_used`, `default_watch_root_used`, `filtered_output_count`, `side_effect_profile`, and rerun suppression outcomes.
 
 ## Build and Test
 - Local validation: `cargo test -p with-watch`
 - Workspace validation baseline: `cargo test --workspace --all-targets`
-- Tests must cover CLI modes, shell parsing, input planning, snapshot diffing, and representative rerun flows.
+- Tests must cover CLI modes, shell parsing, adapter classification, fallback ambiguity handling, snapshot diffing, self-write suppression, and representative rerun flows.
 
 ## Dependencies and Integrations
 - Uses `clap` for CLI parsing.

--- a/docs/crates-with-watch-foundation.md
+++ b/docs/crates-with-watch-foundation.md
@@ -35,6 +35,7 @@
 - Wrapper commands (`env`, `nice`, `nohup`, `stdbuf`, and `timeout`) must unwrap to the delegated command before adapter selection.
 - `exec --input` remains the canonical explicit input contract when inference is insufficient, but command-side side-effect metadata may still be inferred for rerun suppression and logging.
 - Commands marked as `WritesWatchedInputs` must refresh the baseline snapshot after each run and suppress reruns caused only by their own writes while they were executing.
+- Path watch inputs must attach their OS watcher to the nearest existing directory so replace-style writers such as GNU `sed -i` do not orphan follow-up change detection on Linux.
 - Homebrew installation must consume prebuilt GitHub release archives for `darwin/amd64`, `darwin/arm64`, and `linux/amd64`.
 
 ## Storage

--- a/docs/project-with-watch.md
+++ b/docs/project-with-watch.md
@@ -22,6 +22,7 @@ Provide a Rust-based CLI wrapper that reruns delegated shell utilities and arbit
 - Shell redirects must treat `<` and `<>` targets as watched inputs and `>`, `>>`, `&>`, `&>>`, and `>|` targets as filtered outputs.
 - Safe pathless default watch roots are limited to the built-in allowlist (`ls`, `dir`, `vdir`, `du`, and `find`).
 - Commands that mutate watched inputs directly must refresh the baseline snapshot after each run and suppress self-triggered reruns caused by their own writes.
+- Path-based watch inputs must anchor watcher subscriptions at the nearest existing directory so replace-style writers keep emitting later external changes.
 - Public crate distribution must remain `cargo install with-watch`.
 - Publish tag eligibility must remain enabled through root `[workspace.metadata.cargo-mono.publish.tag].packages`, and release tag naming must remain `with-watch@v<version>`.
 - Release automation must publish signed GitHub Release assets for `linux/amd64`, `darwin/amd64`, `darwin/arm64`, and `windows/amd64`, including standalone binaries (`with-watch-<os>-<arch>[.exe]`) and archives (`with-watch-<os>-<arch>.tar.gz|zip`).

--- a/docs/project-with-watch.md
+++ b/docs/project-with-watch.md
@@ -18,9 +18,13 @@ Provide a Rust-based CLI wrapper that reruns delegated shell utilities and arbit
 - Arbitrary command mode must remain `with-watch exec [--no-hash] --input <glob>... -- <command> [args...]`.
 - Default change detection must prefer content hashing, while `--no-hash` must switch the rerun filter to metadata-only comparison.
 - `exec --input` reruns the delegated command unchanged and must not inject changed paths into argv or environment variables.
+- Passthrough and shell modes must use adapter-driven input inference that excludes known outputs, scripts, and pattern operands from the watch set.
+- Shell redirects must treat `<` and `<>` targets as watched inputs and `>`, `>>`, `&>`, `&>>`, and `>|` targets as filtered outputs.
+- Safe pathless default watch roots are limited to the built-in allowlist (`ls`, `dir`, `vdir`, `du`, and `find`).
+- Commands that mutate watched inputs directly must refresh the baseline snapshot after each run and suppress self-triggered reruns caused by their own writes.
 
 ## Change Policy
-- Update this index and `docs/crates-with-watch-foundation.md` together when CLI shape, watch inference behavior, or storage/logging contracts change.
+- Update this index and `docs/crates-with-watch-foundation.md` together when CLI shape, watch inference behavior, side-effect suppression, or storage/logging contracts change.
 - Keep root `AGENTS.md` and `crates/AGENTS.md` aligned with ownership and project-ID changes.
 
 ## References


### PR DESCRIPTION
## Summary
- add adapter-driven command analysis for passthrough and shell mode, including wrapper unwrapping, shell redirect handling, and conservative fallback inference
- exclude known outputs, scripts, and pattern operands from watched inputs while enabling safe current-directory defaults for ls/dir/vdir/du/find
- suppress self-triggered reruns for commands that mutate watched inputs and cover the new behavior with CLI/integration tests

## Testing
- cargo test -p with-watch
- cargo test --workspace --all-targets