### PR TITLE
chore(with-watch): bump patch version to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3548,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "with-watch"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "assert_cmd",
  "blake3",

--- a/crates/with-watch/Cargo.toml
+++ b/crates/with-watch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "with-watch"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT"
 description = "Watch command inputs and rerun commands when they change"


### PR DESCRIPTION
## Summary
- bump `with-watch` crate version from `0.1.1` to `0.1.2`
- sync the `Cargo.lock` package entry with the release version

## Testing
- `cargo test -p with-watch`
- `cargo publish -p with-watch --dry-run --allow-dirty`