### PR TITLE
chore(with-watch): bump version to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3548,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "with-watch"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "assert_cmd",
  "blake3",

--- a/crates/with-watch/Cargo.toml
+++ b/crates/with-watch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "with-watch"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT"
 description = "Watch command inputs and rerun commands when they change"


### PR DESCRIPTION
## Summary
- bump `with-watch` crate version from `0.1.2` to `0.1.3`
- update the workspace lockfile entry for `with-watch` to keep metadata aligned

## Testing
- `cargo test --locked -p with-watch`
- `cargo publish -p with-watch --dry-run --locked --allow-dirty`