### PR TITLE
feat(with-watch): codify immediate startup run contract

### DIFF
--- a/apps/public-docs/with-watch.mdx
+++ b/apps/public-docs/with-watch.mdx
@@ -2,6 +2,8 @@
 
 `with-watch` is a Rust-based command rerun watcher that repeats a delegated command when its inferred or explicit filesystem inputs change.
 
+It performs one initial run immediately after input inference, watcher setup, and baseline capture, then listens for later filesystem changes.
+
 ## Why use with-watch
 
 - Keep familiar CLI tools such as `cat`, `cp`, `sed`, and `find`.
@@ -78,6 +80,7 @@ with-watch exec --input 'src/**/*.rs' -- cargo test -p with-watch
 
 ## Rerun behavior
 
+- `with-watch` always performs one initial run after it has inferred inputs and armed the watcher, even before any external filesystem change occurs.
 - Default rerun filtering uses content hashes.
 - `--no-hash` switches to metadata-only comparison.
 - Self-mutating commands such as `sed -i.bak -e 's/old/new/' config.txt` refresh their baseline after each run so they do not loop on their own writes.

--- a/crates/with-watch/README.md
+++ b/crates/with-watch/README.md
@@ -2,6 +2,8 @@
 
 `with-watch` reruns a delegated command when its inferred or explicit filesystem inputs change.
 
+It executes the delegated command once immediately after input inference, watcher setup, and baseline capture, then waits for later filesystem changes to trigger reruns.
+
 ## Why use
 
 - Keep familiar POSIX/coreutils-style commands while adding automatic reruns.
@@ -63,6 +65,7 @@ with-watch exec --input 'src/**/*.rs' -- cargo test -p with-watch
 
 ## Rerun behavior
 
+- `with-watch` always performs one initial run after it has inferred inputs and armed the watcher, even before any external filesystem change occurs.
 - The default rerun filter compares content hashes, which avoids reruns from metadata churn alone.
 - `--no-hash` switches the filter to metadata-only comparison.
 - Commands that write excluded outputs such as `cp src.txt dest.txt` should rerun when the source input changes, not when the output file changes.

--- a/crates/with-watch/src/runner.rs
+++ b/crates/with-watch/src/runner.rs
@@ -187,6 +187,9 @@ impl RunnerOptions {
 pub fn run(plan: ExecutionPlan, options: RunnerOptions) -> Result<i32> {
     let mut watch_loop = WatchLoop::new(&plan.inputs)?;
     let mut baseline = capture_snapshot(&plan.inputs, plan.detection_mode)?;
+    // v1 contract: after inference, watcher setup, and baseline capture succeed,
+    // the delegated command must run immediately once before waiting for any
+    // filesystem change events.
     let mut child = Some(spawn_command(&plan.delegated_command)?);
     let mut completed_runs = 0usize;
     let mut pending_rerun = false;
@@ -202,6 +205,7 @@ pub fn run(plan: ExecutionPlan, options: RunnerOptions) -> Result<i32> {
         filtered_output_count = plan.metadata.filtered_output_count,
         side_effect_profile = plan.metadata.side_effect_profile.as_str(),
         analysis_status = plan.metadata.status.as_str(),
+        initial_run_armed = true,
         "Starting with-watch run loop"
     );
 

--- a/crates/with-watch/tests/cli.rs
+++ b/crates/with-watch/tests/cli.rs
@@ -55,7 +55,7 @@ fn shell_and_subcommand_cannot_be_combined() {
 
 #[cfg(unix)]
 #[test]
-fn passthrough_mode_runs_a_posix_utility_once_with_test_hook() {
+fn passthrough_mode_runs_immediately_once_at_startup_with_test_hook() {
     let temp_dir = tempfile::tempdir().expect("create tempdir");
     let input_path = temp_dir.path().join("input.txt");
     fs::write(&input_path, "hello\n").expect("write input");
@@ -71,7 +71,7 @@ fn passthrough_mode_runs_a_posix_utility_once_with_test_hook() {
 
 #[cfg(unix)]
 #[test]
-fn pathless_allowlist_command_runs_once_with_test_hook() {
+fn pathless_allowlist_command_runs_immediately_once_at_startup_with_test_hook() {
     let temp_dir = tempfile::tempdir().expect("create tempdir");
 
     with_watch_command()
@@ -84,7 +84,7 @@ fn pathless_allowlist_command_runs_once_with_test_hook() {
 
 #[cfg(unix)]
 #[test]
-fn shell_mode_supports_operators_and_exits_after_one_run_with_test_hook() {
+fn shell_mode_runs_immediately_once_at_startup_with_test_hook() {
     let temp_dir = tempfile::tempdir().expect("create tempdir");
     let input_path = temp_dir.path().join("input.txt");
     fs::write(&input_path, "hello\n").expect("write input");
@@ -98,6 +98,39 @@ fn shell_mode_supports_operators_and_exits_after_one_run_with_test_hook() {
         .assert()
         .success()
         .stdout(predicate::str::contains("hello"));
+}
+
+#[cfg(unix)]
+#[test]
+fn exec_mode_runs_immediately_once_at_startup_with_test_hook() {
+    let temp_dir = tempfile::tempdir().expect("create tempdir");
+    let input_path = temp_dir.path().join("input.txt");
+    let output_path = temp_dir.path().join("output.txt");
+    fs::write(&input_path, "alpha\n").expect("write input");
+
+    with_watch_command()
+        .current_dir(temp_dir.path())
+        .env("WITH_WATCH_TEST_MAX_RUNS", "1")
+        .args([
+            "exec",
+            "--input",
+            input_path.to_string_lossy().as_ref(),
+            "--",
+            "sh",
+            "-c",
+            &format!(
+                "cat '{}' > '{}'",
+                input_path.display(),
+                output_path.display()
+            ),
+        ])
+        .assert()
+        .success();
+
+    assert_eq!(
+        fs::read_to_string(&output_path).expect("read output"),
+        "alpha\n"
+    );
 }
 
 #[cfg(unix)]

--- a/docs/crates-with-watch-foundation.md
+++ b/docs/crates-with-watch-foundation.md
@@ -19,6 +19,7 @@
 - `exec` mode must remain `with-watch exec [--no-hash] --input <glob>... -- <command> [args...]`.
 - The CLI must continue to reject mixed modes and empty delegated-command requests with operator-facing guidance.
 - Passthrough and shell modes must infer watch inputs before the first run; if inference does not produce safe filesystem inputs, the command must fail with `exec --input` guidance instead of guessing.
+- After watch input inference, watcher setup, and baseline snapshot capture succeed, all command modes must execute the delegated command immediately once before waiting for the first filesystem change event.
 - `exec --input` must accept repeatable explicit glob/path values, keep the delegated command unchanged, and remain the canonical fallback for otherwise ambiguous or pathless commands.
 - `--no-hash` must remain a global flag that switches rerun filtering from content hashes to metadata-only comparison.
 - Public crate installation must remain `cargo install with-watch`.
@@ -60,7 +61,7 @@
 ## Build and Test
 - Local validation: `cargo test -p with-watch`
 - Workspace validation baseline: `cargo test --workspace --all-targets`
-- Tests must cover CLI modes, shell parsing, adapter classification, fallback ambiguity handling, snapshot diffing, self-write suppression, and representative rerun flows.
+- Tests must cover CLI modes, immediate startup execution, shell parsing, adapter classification, fallback ambiguity handling, snapshot diffing, self-write suppression, and representative rerun flows.
 - Documentation changes should be checked against `cargo run -p with-watch -- --help` and the integration scenarios in `crates/with-watch/tests/cli.rs`.
 - Publishability validation: `cargo publish -p with-watch --dry-run`
 - Release contract checks should align with `.github/workflows/release-with-watch.yml`.

--- a/docs/project-with-watch.md
+++ b/docs/project-with-watch.md
@@ -17,6 +17,7 @@ Provide a Rust-based CLI wrapper that reruns delegated shell utilities and arbit
 - Shell mode must remain `with-watch [--no-hash] --shell '<expr>'` and is the supported entrypoint for `&&`, `||`, and `|`.
 - Arbitrary command mode must remain `with-watch exec [--no-hash] --input <glob>... -- <command> [args...]`.
 - The public CLI surface must keep exactly one delegated-command entrypoint per invocation: passthrough argv, `--shell`, or `exec --input`.
+- After watch input inference, watcher setup, and baseline snapshot capture succeed, `with-watch` must execute the delegated command immediately once before waiting for the first filesystem change event.
 - Default change detection must prefer content hashing, while `--no-hash` must switch the rerun filter to metadata-only comparison.
 - `exec --input` reruns the delegated command unchanged and must not inject changed paths into argv or environment variables.
 - Commands without safe inferred filesystem inputs must fail clearly and direct operators to `with-watch exec --input ...`.


### PR DESCRIPTION
## Summary
- document that with-watch runs the delegated command once immediately after watcher setup and baseline capture
- make the runtime contract explicit in the runner and strengthen startup-run regression coverage for passthrough, shell, and exec modes
- align crate docs, project contracts, and public docs around the same startup behavior

## Testing
- cargo test
- pnpm --filter public-docs test