### PR TITLE
release: Expand Rust release platform targets

### DIFF
--- a/.github/workflows/release-cargo-mono.yml
+++ b/.github/workflows/release-cargo-mono.yml
@@ -68,6 +68,11 @@ jobs:
             asset_os: linux
             asset_arch: amd64
             archive_ext: tar.gz
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            asset_os: linux
+            asset_arch: arm64
+            archive_ext: tar.gz
           - os: macos-15-intel
             target: x86_64-apple-darwin
             asset_os: darwin
@@ -82,6 +87,11 @@ jobs:
             target: x86_64-pc-windows-msvc
             asset_os: windows
             asset_arch: amd64
+            archive_ext: zip
+          - os: windows-11-arm
+            target: aarch64-pc-windows-msvc
+            asset_os: windows
+            asset_arch: arm64
             archive_ext: zip
     steps:
       - name: Checkout

--- a/.github/workflows/release-nodeup.yml
+++ b/.github/workflows/release-nodeup.yml
@@ -68,6 +68,11 @@ jobs:
             asset_os: linux
             asset_arch: amd64
             archive_ext: tar.gz
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            asset_os: linux
+            asset_arch: arm64
+            archive_ext: tar.gz
           - os: macos-15-intel
             target: x86_64-apple-darwin
             asset_os: darwin
@@ -82,6 +87,11 @@ jobs:
             target: x86_64-pc-windows-msvc
             asset_os: windows
             asset_arch: amd64
+            archive_ext: zip
+          - os: windows-11-arm
+            target: aarch64-pc-windows-msvc
+            asset_os: windows
+            asset_arch: arm64
             archive_ext: zip
     steps:
       - name: Checkout
@@ -201,6 +211,10 @@ jobs:
           linux_amd64_sha="$(grep " ${linux_amd64_asset}$" dist/SHA256SUMS | awk '{print $1}')"
           linux_amd64_url="https://github.com/delinoio/oss/releases/download/${RELEASE_TAG}/${linux_amd64_asset}"
 
+          linux_arm64_asset="nodeup-linux-arm64.tar.gz"
+          linux_arm64_sha="$(grep " ${linux_arm64_asset}$" dist/SHA256SUMS | awk '{print $1}')"
+          linux_arm64_url="https://github.com/delinoio/oss/releases/download/${RELEASE_TAG}/${linux_arm64_asset}"
+
           ./scripts/release/update-homebrew.sh \
             --project nodeup \
             --version "$RELEASE_VERSION" \
@@ -210,6 +224,8 @@ jobs:
             --darwin-arm64-sha256 "$darwin_arm64_sha" \
             --linux-amd64-url "$linux_amd64_url" \
             --linux-amd64-sha256 "$linux_amd64_sha" \
+            --linux-arm64-url "$linux_arm64_url" \
+            --linux-arm64-sha256 "$linux_arm64_sha" \
             --dry-run >/dev/null
 
       - name: Submit Homebrew update
@@ -234,6 +250,10 @@ jobs:
           linux_amd64_sha="$(grep " ${linux_amd64_asset}$" dist/SHA256SUMS | awk '{print $1}')"
           linux_amd64_url="https://github.com/delinoio/oss/releases/download/${RELEASE_TAG}/${linux_amd64_asset}"
 
+          linux_arm64_asset="nodeup-linux-arm64.tar.gz"
+          linux_arm64_sha="$(grep " ${linux_arm64_asset}$" dist/SHA256SUMS | awk '{print $1}')"
+          linux_arm64_url="https://github.com/delinoio/oss/releases/download/${RELEASE_TAG}/${linux_arm64_asset}"
+
           ./scripts/release/update-homebrew.sh \
             --project nodeup \
             --version "$RELEASE_VERSION" \
@@ -242,4 +262,6 @@ jobs:
             --darwin-arm64-url "$darwin_arm64_url" \
             --darwin-arm64-sha256 "$darwin_arm64_sha" \
             --linux-amd64-url "$linux_amd64_url" \
-            --linux-amd64-sha256 "$linux_amd64_sha"
+            --linux-amd64-sha256 "$linux_amd64_sha" \
+            --linux-arm64-url "$linux_arm64_url" \
+            --linux-arm64-sha256 "$linux_arm64_sha"

--- a/.github/workflows/release-with-watch.yml
+++ b/.github/workflows/release-with-watch.yml
@@ -68,6 +68,11 @@ jobs:
             asset_os: linux
             asset_arch: amd64
             archive_ext: tar.gz
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            asset_os: linux
+            asset_arch: arm64
+            archive_ext: tar.gz
           - os: macos-15-intel
             target: x86_64-apple-darwin
             asset_os: darwin
@@ -82,6 +87,11 @@ jobs:
             target: x86_64-pc-windows-msvc
             asset_os: windows
             asset_arch: amd64
+            archive_ext: zip
+          - os: windows-11-arm
+            target: aarch64-pc-windows-msvc
+            asset_os: windows
+            asset_arch: arm64
             archive_ext: zip
     steps:
       - name: Checkout
@@ -203,6 +213,10 @@ jobs:
           linux_amd64_sha="$(grep " ${linux_amd64_asset}$" dist/SHA256SUMS | awk '{print $1}')"
           linux_amd64_url="https://github.com/delinoio/oss/releases/download/${RELEASE_TAG}/${linux_amd64_asset}"
 
+          linux_arm64_asset="with-watch-linux-arm64.tar.gz"
+          linux_arm64_sha="$(grep " ${linux_arm64_asset}$" dist/SHA256SUMS | awk '{print $1}')"
+          linux_arm64_url="https://github.com/delinoio/oss/releases/download/${RELEASE_TAG}/${linux_arm64_asset}"
+
           ./scripts/release/update-homebrew.sh \
             --project with-watch \
             --version "$RELEASE_VERSION" \
@@ -212,6 +226,8 @@ jobs:
             --darwin-arm64-sha256 "$darwin_arm64_sha" \
             --linux-amd64-url "$linux_amd64_url" \
             --linux-amd64-sha256 "$linux_amd64_sha" \
+            --linux-arm64-url "$linux_arm64_url" \
+            --linux-arm64-sha256 "$linux_arm64_sha" \
             --dry-run >/dev/null
 
       - name: Submit Homebrew update
@@ -236,6 +252,10 @@ jobs:
           linux_amd64_sha="$(grep " ${linux_amd64_asset}$" dist/SHA256SUMS | awk '{print $1}')"
           linux_amd64_url="https://github.com/delinoio/oss/releases/download/${RELEASE_TAG}/${linux_amd64_asset}"
 
+          linux_arm64_asset="with-watch-linux-arm64.tar.gz"
+          linux_arm64_sha="$(grep " ${linux_arm64_asset}$" dist/SHA256SUMS | awk '{print $1}')"
+          linux_arm64_url="https://github.com/delinoio/oss/releases/download/${RELEASE_TAG}/${linux_arm64_asset}"
+
           ./scripts/release/update-homebrew.sh \
             --project with-watch \
             --version "$RELEASE_VERSION" \
@@ -244,4 +264,6 @@ jobs:
             --darwin-arm64-url "$darwin_arm64_url" \
             --darwin-arm64-sha256 "$darwin_arm64_sha" \
             --linux-amd64-url "$linux_amd64_url" \
-            --linux-amd64-sha256 "$linux_amd64_sha"
+            --linux-amd64-sha256 "$linux_amd64_sha" \
+            --linux-arm64-url "$linux_arm64_url" \
+            --linux-arm64-sha256 "$linux_arm64_sha"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,16 +334,16 @@ Release automation baseline:
 - Required secret contract: `CARGO_REGISTRY_TOKEN` (crate publish) and `GH_TOKEN` (tag push authentication and Homebrew release workflow PR submissions). `GH_TOKEN` must be a dedicated non-`GITHUB_TOKEN` credential so tag pushes emit downstream `push` events for tag-triggered workflows.
 - `release-cargo-mono` is defined in `.github/workflows/release-cargo-mono.yml`.
 - Trigger contract: runs on tag push `cargo-mono@v*` and supports `workflow_dispatch` (`version`, `dry_run`).
-- Distribution contract: publishes signed multi-OS cargo-mono release artifacts to GitHub Releases.
+- Distribution contract: publishes signed multi-OS cargo-mono release artifacts to GitHub Releases for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`.
 - `release-nodeup` is defined in `.github/workflows/release-nodeup.yml`.
 - Trigger contract: runs on tag push `nodeup@v*` and supports `workflow_dispatch` (`version`, `dry_run`).
-- Distribution contract: publishes signed multi-OS nodeup release artifacts, including standalone prebuilt binaries (`nodeup-<os>-<arch>[.exe]`) and archive assets (`nodeup-<os>-<arch>.tar.gz|zip`), then updates Homebrew (`nodeup`).
+- Distribution contract: publishes signed multi-OS nodeup release artifacts for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`, including standalone prebuilt binaries (`nodeup-<os>-<arch>[.exe]`) and archive assets (`nodeup-<os>-<arch>.tar.gz|zip`), then updates Homebrew (`nodeup`) from prebuilt archives for `darwin/amd64`, `darwin/arm64`, `linux/amd64`, and `linux/arm64`.
 - `release-derun` is defined in `.github/workflows/release-derun.yml`.
 - Trigger contract: runs on tag push `derun@v*` and supports `workflow_dispatch` (`version`, `dry_run`).
 - Distribution contract: publishes signed multi-OS derun release artifacts and updates Homebrew (`derun`) from GitHub release prebuilt archives (`darwin-amd64`, `darwin-arm64`, `linux-amd64`).
 - `release-with-watch` is defined in `.github/workflows/release-with-watch.yml`.
 - Trigger contract: runs on tag push `with-watch@v*` and supports `workflow_dispatch` (`version`, `dry_run`).
-- Distribution contract: publishes signed multi-OS with-watch release artifacts, including standalone prebuilt binaries (`with-watch-<os>-<arch>[.exe]`) and archive assets (`with-watch-<os>-<arch>.tar.gz|zip`), then updates Homebrew (`with-watch`) from GitHub release prebuilt archives (`darwin-amd64`, `darwin-arm64`, `linux-amd64`).
+- Distribution contract: publishes signed multi-OS with-watch release artifacts for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`, including standalone prebuilt binaries (`with-watch-<os>-<arch>[.exe]`) and archive assets (`with-watch-<os>-<arch>.tar.gz|zip`), then updates Homebrew (`with-watch`) from GitHub release prebuilt archives (`darwin-amd64`, `darwin-arm64`, `linux-amd64`, `linux-arm64`).
 - `release-dexdex` is defined in `.github/workflows/release-dexdex.yml`.
 - Trigger contract: runs on tag push `dexdex@v*` and supports `workflow_dispatch` (`version`, `dry_run`).
 - Distribution contract: publishes signed DexDex desktop + main/worker server artifacts and applies desktop signing/notarization secrets, then updates Homebrew (`dexdex`, `dexdex-main-server`, `dexdex-worker-server`) where DexDex server formulas consume prebuilt release artifacts for `darwin/amd64`, `darwin/arm64`, and `linux/amd64`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +246,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +459,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,6 +661,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "float-cmp"
@@ -1406,6 +1437,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,6 +1498,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "xz2",
+ "zip",
 ]
 
 [[package]]
@@ -2411,6 +2453,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "similar"
@@ -3691,6 +3739,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
 ]
 
 [[package]]

--- a/apps/public-docs/nodeup.mdx
+++ b/apps/public-docs/nodeup.mdx
@@ -25,12 +25,12 @@ Tag contract:
 Package manager:
 
 - macOS/Linux: `brew install delinoio/tap/nodeup`
-- Homebrew installs prebuilt archives on macOS Intel, macOS Apple Silicon, and Linux amd64
-- Linux arm64 is not yet published for the Homebrew package
+- Homebrew installs prebuilt archives on macOS Intel, macOS Apple Silicon, Linux amd64, and Linux arm64
 
 Windows direct install:
 
 - `./scripts/install/nodeup.ps1 -Version latest -Method direct`
+- The PowerShell installer selects the `windows/amd64` or `windows/arm64` archive automatically based on the host architecture
 
 Script installer:
 
@@ -43,6 +43,7 @@ Script installer:
 ```
 
 Direct installers verify Sigstore bundle sidecars (`*.sigstore.json`) and only support bundle-enabled releases.
+`nodeup toolchain install` supports `macOS`, `Linux`, and `Windows` x64/arm64 hosts.
 
 ## Common workflows
 

--- a/apps/public-docs/with-watch.mdx
+++ b/apps/public-docs/with-watch.mdx
@@ -17,6 +17,7 @@ Tag contract:
 Package manager:
 
 - macOS/Linux: `brew install delinoio/tap/with-watch`
+- Homebrew installs prebuilt archives on macOS Intel, macOS Apple Silicon, Linux amd64, and Linux arm64
 
 Cargo:
 

--- a/crates/nodeup/Cargo.toml
+++ b/crates/nodeup/Cargo.toml
@@ -22,6 +22,7 @@ toml = "0.8.20"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["fmt", "env-filter"] }
 xz2 = "0.1.7"
+zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.16"

--- a/crates/nodeup/src/cli.rs
+++ b/crates/nodeup/src/cli.rs
@@ -158,7 +158,7 @@ pub enum ToolchainCommand {
     Link {
         /// Alias used to reference the linked runtime.
         name: String,
-        /// Path to a runtime directory containing `bin/node`.
+        /// Path to a runtime directory containing `bin/node` or `bin/node.exe`.
         path: String,
     },
 }

--- a/crates/nodeup/src/commands/toolchain.rs
+++ b/crates/nodeup/src/commands/toolchain.rs
@@ -9,6 +9,7 @@ use crate::{
     errors::{NodeupError, Result},
     resolver::ResolvedRuntimeTarget,
     selectors::{is_reserved_channel_selector_token, is_valid_linked_name, RuntimeSelector},
+    store::runtime_executable_path,
     NodeupApp,
 };
 
@@ -397,12 +398,12 @@ fn link(
                 "Linked runtime path is not a directory: {}",
                 runtime_path.display()
             ),
-            "Provide a runtime directory that contains a `bin/node` executable.",
+            "Provide a runtime directory that contains a `bin/node` or `bin/node.exe` executable.",
         ));
     }
 
     let absolute = fs::canonicalize(&runtime_path)?;
-    let node_executable = absolute.join("bin").join("node");
+    let node_executable = runtime_executable_path(&absolute, "node");
     if !node_executable.exists() {
         info!(
             command_path = "nodeup.toolchain.link",
@@ -416,10 +417,11 @@ fn link(
         );
         return Err(NodeupError::invalid_input_with_hint(
             format!(
-                "Linked runtime path must contain `bin/node`: {}",
+                "Linked runtime path must contain a node executable under `bin/`: {}",
                 absolute.display()
             ),
-            "Verify the runtime root path and ensure `<path>/bin/node` exists before linking.",
+            "Verify the runtime root path and ensure `<path>/bin/node` or `<path>/bin/node.exe` \
+             exists before linking.",
         ));
     }
 

--- a/crates/nodeup/src/errors.rs
+++ b/crates/nodeup/src/errors.rs
@@ -55,7 +55,7 @@ fn default_hint_for_kind(kind: ErrorKind) -> &'static str {
             "Check the command arguments with `nodeup --help` and try again."
         }
         ErrorKind::UnsupportedPlatform => {
-            "Run this command on a supported macOS/Linux x64/arm64 host."
+            "Run this command on a supported macOS/Linux/Windows x64/arm64 host."
         }
         ErrorKind::Network => {
             "Check your network connection and retry. If it keeps failing, run again with \

--- a/crates/nodeup/src/installer.rs
+++ b/crates/nodeup/src/installer.rs
@@ -7,13 +7,14 @@ use std::{
 
 use sha2::{Digest, Sha256};
 use tracing::info;
+use zip::ZipArchive;
 
 use crate::{
     errors::{sanitize_url_text, NodeupError, Result},
     paths::NodeupPaths,
     release_index::{normalize_version, ReleaseIndexClient},
     store::Store,
-    types::PlatformTarget,
+    types::{ArchiveFormat, PlatformTarget},
 };
 
 #[derive(Debug, Clone)]
@@ -57,7 +58,7 @@ impl RuntimeInstaller {
         let target = PlatformTarget::from_host().ok_or_else(|| {
             NodeupError::unsupported_platform_with_hint(
                 format!(
-                    "nodeup currently supports macOS/Linux x64/arm64 only. host={}/{}",
+                    "nodeup currently supports macOS/Linux/Windows x64/arm64 only. host={}/{}",
                     std::env::consts::OS,
                     std::env::consts::ARCH
                 ),
@@ -75,7 +76,7 @@ impl RuntimeInstaller {
             });
         }
 
-        let archive_url = release_client.archive_url(&canonical_version, target.archive_segment());
+        let archive_url = release_client.archive_url(&canonical_version, target);
         let archive_url_sanitized = sanitize_url_text(&archive_url);
         let archive_filename = archive_url.rsplit('/').next().ok_or_else(|| {
             NodeupError::internal_with_hint(
@@ -173,7 +174,7 @@ impl RuntimeInstaller {
         }
 
         let runtime_dir = self.paths.runtime_dir(&canonical_version);
-        extract_archive_to_runtime(&archive_path, &runtime_dir)?;
+        extract_archive_to_runtime(&archive_path, &runtime_dir, target)?;
 
         Ok(InstallReport {
             version: canonical_version,
@@ -215,7 +216,11 @@ fn download_file(release_client: &ReleaseIndexClient, url: &str, destination: &P
     Ok(())
 }
 
-fn extract_archive_to_runtime(archive_path: &Path, runtime_dir: &Path) -> Result<()> {
+fn extract_archive_to_runtime(
+    archive_path: &Path,
+    runtime_dir: &Path,
+    target: PlatformTarget,
+) -> Result<()> {
     if runtime_dir.exists() {
         return Ok(());
     }
@@ -235,26 +240,146 @@ fn extract_archive_to_runtime(archive_path: &Path, runtime_dir: &Path) -> Result
         .prefix("nodeup-extract-")
         .tempdir_in(parent)?;
 
+    match target.archive_format() {
+        ArchiveFormat::TarXz => unpack_tar_xz_archive(archive_path, temp_dir.path())?,
+        ArchiveFormat::Zip => unpack_zip_archive(archive_path, temp_dir.path())?,
+    }
+
+    let extracted_root = normalize_runtime_root(temp_dir.path(), target)?;
+
+    fs::rename(extracted_root, runtime_dir)?;
+    Ok(())
+}
+
+fn unpack_tar_xz_archive(archive_path: &Path, destination: &Path) -> Result<()> {
     let archive_file = File::open(archive_path)?;
     let decoder = xz2::read::XzDecoder::new(archive_file);
     let mut archive = tar::Archive::new(decoder);
-    archive.unpack(temp_dir.path())?;
+    archive.unpack(destination)?;
+    Ok(())
+}
 
-    let extracted_root = fs::read_dir(temp_dir.path())?
-        .next()
-        .ok_or_else(|| {
+fn unpack_zip_archive(archive_path: &Path, destination: &Path) -> Result<()> {
+    let archive_file = File::open(archive_path)?;
+    let mut archive = ZipArchive::new(archive_file).map_err(|error| {
+        NodeupError::internal_with_hint(
+            format!(
+                "Failed to open zip archive {}: {error}",
+                archive_path.display()
+            ),
+            "Retry the install command. If it repeats, remove the archive and re-download.",
+        )
+    })?;
+
+    for index in 0..archive.len() {
+        let mut entry = archive.by_index(index).map_err(|error| {
             NodeupError::internal_with_hint(
                 format!(
-                    "Archive unpack produced an empty directory (archive={}, temp_dir={})",
-                    archive_path.display(),
-                    temp_dir.path().display()
+                    "Failed to read zip entry {index} from {}: {error}",
+                    archive_path.display()
                 ),
                 "Retry the install command. If it repeats, remove the archive and re-download.",
             )
-        })??
-        .path();
+        })?;
 
-    fs::rename(extracted_root, runtime_dir)?;
+        let entry_path = entry.enclosed_name().ok_or_else(|| {
+            NodeupError::invalid_input_with_hint(
+                format!(
+                    "Zip archive contains an unsafe path (archive={}, entry={})",
+                    archive_path.display(),
+                    entry.name()
+                ),
+                "Retry later in case the upstream archive is incomplete, or inspect the archive \
+                 contents.",
+            )
+        })?;
+        let destination_path = destination.join(entry_path);
+
+        if entry.is_dir() {
+            fs::create_dir_all(&destination_path)?;
+            continue;
+        }
+
+        if let Some(parent) = destination_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let mut output = File::create(&destination_path)?;
+        std::io::copy(&mut entry, &mut output)?;
+        output.flush()?;
+
+        #[cfg(unix)]
+        if let Some(mode) = entry.unix_mode() {
+            use std::os::unix::fs::PermissionsExt;
+
+            fs::set_permissions(&destination_path, fs::Permissions::from_mode(mode))?;
+        }
+    }
+
+    Ok(())
+}
+
+fn normalize_runtime_root(extraction_dir: &Path, target: PlatformTarget) -> Result<PathBuf> {
+    let mut entries =
+        fs::read_dir(extraction_dir)?.collect::<std::result::Result<Vec<_>, std::io::Error>>()?;
+
+    if entries.is_empty() {
+        return Err(NodeupError::internal_with_hint(
+            format!(
+                "Archive unpack produced an empty directory (temp_dir={})",
+                extraction_dir.display()
+            ),
+            "Retry the install command. If it repeats, remove the archive and re-download.",
+        ));
+    }
+
+    if entries.len() == 1 && entries[0].file_type()?.is_dir() {
+        let extracted_root = entries.pop().unwrap().path();
+        if matches!(target.archive_format(), ArchiveFormat::Zip) {
+            normalize_windows_runtime_layout(&extracted_root)?;
+        }
+        return Ok(extracted_root);
+    }
+
+    let normalized_root = extraction_dir.join("nodeup-runtime");
+    fs::create_dir(&normalized_root)?;
+
+    if matches!(target.archive_format(), ArchiveFormat::Zip) {
+        let bin_dir = normalized_root.join("bin");
+        fs::create_dir(&bin_dir)?;
+        for entry in entries {
+            let destination = bin_dir.join(entry.file_name());
+            fs::rename(entry.path(), destination)?;
+        }
+    } else {
+        for entry in entries {
+            let destination = normalized_root.join(entry.file_name());
+            fs::rename(entry.path(), destination)?;
+        }
+    }
+
+    Ok(normalized_root)
+}
+
+fn normalize_windows_runtime_layout(runtime_root: &Path) -> Result<()> {
+    let bin_dir = runtime_root.join("bin");
+    if bin_dir.exists() {
+        return Ok(());
+    }
+
+    let entries =
+        fs::read_dir(runtime_root)?.collect::<std::result::Result<Vec<_>, std::io::Error>>()?;
+    fs::create_dir(&bin_dir)?;
+
+    for entry in entries {
+        let file_name = entry.file_name();
+        if file_name == "bin" {
+            continue;
+        }
+
+        fs::rename(entry.path(), bin_dir.join(file_name))?;
+    }
+
     Ok(())
 }
 
@@ -383,6 +508,8 @@ impl Drop for InstallLock {
 
 #[cfg(test)]
 mod tests {
+    use zip::{write::FileOptions, ZipWriter};
+
     use super::*;
     use crate::errors::ErrorKind;
 
@@ -399,6 +526,43 @@ mod tests {
         );
     }
 
+    fn make_test_tar_xz() -> Vec<u8> {
+        let mut tar_payload = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut tar_payload);
+            let mut header = tar::Header::new_gnu();
+            header.set_mode(0o755);
+            header.set_size(4);
+            header.set_cksum();
+            builder
+                .append_data(
+                    &mut header,
+                    "node-v22.1.0-linux-arm64/bin/node",
+                    &b"echo"[..],
+                )
+                .unwrap();
+            builder.finish().unwrap();
+        }
+
+        let mut encoder = xz2::write::XzEncoder::new(Vec::new(), 6);
+        encoder.write_all(&tar_payload).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    fn make_test_zip() -> Vec<u8> {
+        let mut cursor = std::io::Cursor::new(Vec::new());
+        {
+            let mut writer = ZipWriter::new(&mut cursor);
+            let options = FileOptions::default().unix_permissions(0o755);
+            writer.start_file("node.exe", options).unwrap();
+            writer.write_all(b"node").unwrap();
+            writer.start_file("npm.cmd", options).unwrap();
+            writer.write_all(b"npm").unwrap();
+            writer.finish().unwrap();
+        }
+        cursor.into_inner()
+    }
+
     #[test]
     fn computes_sha256_checksum() {
         let dir = tempfile::tempdir().unwrap();
@@ -408,6 +572,35 @@ mod tests {
             sha256_file(&path).unwrap(),
             "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
         );
+    }
+
+    #[test]
+    fn tar_xz_extracts_to_runtime_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let archive_path = dir.path().join("node-v22.1.0-linux-arm64.tar.xz");
+        let runtime_dir = dir.path().join("toolchains").join("v22.1.0");
+        fs::create_dir_all(runtime_dir.parent().unwrap()).unwrap();
+        fs::write(&archive_path, make_test_tar_xz()).unwrap();
+
+        extract_archive_to_runtime(&archive_path, &runtime_dir, PlatformTarget::LinuxArm64)
+            .unwrap();
+
+        assert!(runtime_dir.join("bin").join("node").exists());
+    }
+
+    #[test]
+    fn zip_extracts_and_normalizes_flat_windows_layout() {
+        let dir = tempfile::tempdir().unwrap();
+        let archive_path = dir.path().join("node-v22.1.0-win-arm64.zip");
+        let runtime_dir = dir.path().join("toolchains").join("v22.1.0");
+        fs::create_dir_all(runtime_dir.parent().unwrap()).unwrap();
+        fs::write(&archive_path, make_test_zip()).unwrap();
+
+        extract_archive_to_runtime(&archive_path, &runtime_dir, PlatformTarget::WindowsArm64)
+            .unwrap();
+
+        assert!(runtime_dir.join("bin").join("node.exe").exists());
+        assert!(runtime_dir.join("bin").join("npm.cmd").exists());
     }
 
     #[test]

--- a/crates/nodeup/src/release_index.rs
+++ b/crates/nodeup/src/release_index.rs
@@ -13,7 +13,7 @@ use tracing::{info, warn};
 
 use crate::{
     errors::{sanitize_url_text, NodeupError, Result},
-    types::NodeupChannel,
+    types::{NodeupChannel, PlatformTarget},
 };
 
 const DEFAULT_INDEX_URL: &str = "https://nodejs.org/download/release/index.json";
@@ -404,11 +404,15 @@ impl ReleaseIndexClient {
         })
     }
 
-    pub fn archive_url(&self, version: &str, target_segment: &str) -> String {
+    pub fn archive_url(&self, version: &str, target: PlatformTarget) -> String {
         let version = normalize_version(version);
         format!(
-            "{}/{}/node-{}-{}.tar.xz",
-            self.download_base_url, version, version, target_segment
+            "{}/{}/node-{}-{}.{}",
+            self.download_base_url,
+            version,
+            version,
+            target.archive_segment(),
+            target.archive_format().extension()
         )
     }
 
@@ -472,6 +476,31 @@ mod tests {
     fn normalize_version_prefixes_when_missing() {
         assert_eq!(normalize_version("22.1.0"), "v22.1.0");
         assert_eq!(normalize_version("v22.1.0"), "v22.1.0");
+    }
+
+    #[test]
+    fn archive_urls_follow_platform_specific_extensions() {
+        let dir = tempdir().unwrap();
+        let client = ReleaseIndexClient::with_urls(
+            dir.path().join("release-index.json"),
+            Duration::from_secs(60),
+            "https://example.com/index.json".to_string(),
+            "https://example.com/release".to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            client.archive_url("22.1.0", PlatformTarget::LinuxArm64),
+            "https://example.com/release/v22.1.0/node-v22.1.0-linux-arm64.tar.xz"
+        );
+        assert_eq!(
+            client.archive_url("22.1.0", PlatformTarget::WindowsX64),
+            "https://example.com/release/v22.1.0/node-v22.1.0-win-x64.zip"
+        );
+        assert_eq!(
+            client.archive_url("22.1.0", PlatformTarget::WindowsArm64),
+            "https://example.com/release/v22.1.0/node-v22.1.0-win-arm64.zip"
+        );
     }
 
     #[test]

--- a/crates/nodeup/src/resolver.rs
+++ b/crates/nodeup/src/resolver.rs
@@ -8,7 +8,7 @@ use crate::{
     overrides::OverrideStore,
     release_index::{normalize_version, ReleaseIndexClient},
     selectors::RuntimeSelector,
-    store::Store,
+    store::{runtime_executable_path, Store},
     types::{OverrideLookupFallbackReason, RuntimeSelectorSource},
 };
 
@@ -38,7 +38,9 @@ impl ResolvedRuntime {
             ResolvedRuntimeTarget::Version { version } => {
                 store.runtime_executable(version, command)
             }
-            ResolvedRuntimeTarget::LinkedPath { path, .. } => path.join("bin").join(command),
+            ResolvedRuntimeTarget::LinkedPath { path, .. } => {
+                runtime_executable_path(path, command)
+            }
         }
     }
 

--- a/crates/nodeup/src/store.rs
+++ b/crates/nodeup/src/store.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
-    fs,
+    env, fs,
     io::Write,
     path::{Path, PathBuf},
 };
@@ -104,7 +104,7 @@ impl Store {
     }
 
     pub fn runtime_executable(&self, version: &str, command: &str) -> PathBuf {
-        self.runtime_dir(version).join("bin").join(command)
+        runtime_executable_path(&self.runtime_dir(version), command)
     }
 
     pub fn remove_runtime(&self, version: &str) -> Result<()> {
@@ -123,6 +123,46 @@ impl Store {
 
     pub fn paths(&self) -> &NodeupPaths {
         &self.paths
+    }
+}
+
+pub fn runtime_executable_path(runtime_root: &Path, command: &str) -> PathBuf {
+    let bin_dir = runtime_root.join("bin");
+    for candidate in runtime_executable_candidates(command) {
+        let candidate_path = bin_dir.join(&candidate);
+        if candidate_path.exists() {
+            return candidate_path;
+        }
+    }
+
+    bin_dir.join(runtime_primary_executable_name(command))
+}
+
+fn runtime_executable_candidates(command: &str) -> Vec<String> {
+    let primary = runtime_primary_executable_name(command);
+    if primary == command {
+        vec![primary]
+    } else {
+        vec![primary, command.to_string()]
+    }
+}
+
+fn runtime_primary_executable_name(command: &str) -> String {
+    if runtime_host_is_windows() {
+        match command {
+            "node" => "node.exe".to_string(),
+            "npm" | "npx" | "yarn" | "pnpm" | "corepack" => format!("{command}.cmd"),
+            _ => format!("{command}.exe"),
+        }
+    } else {
+        command.to_string()
+    }
+}
+
+fn runtime_host_is_windows() -> bool {
+    match env::var("NODEUP_FORCE_PLATFORM") {
+        Ok(value) => value.starts_with("windows-"),
+        Err(_) => cfg!(windows),
     }
 }
 

--- a/crates/nodeup/src/types.rs
+++ b/crates/nodeup/src/types.rs
@@ -163,11 +163,29 @@ impl OverrideLookupFallbackReason {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+pub enum ArchiveFormat {
+    TarXz,
+    Zip,
+}
+
+impl ArchiveFormat {
+    pub fn extension(self) -> &'static str {
+        match self {
+            Self::TarXz => "tar.xz",
+            Self::Zip => "zip",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum PlatformTarget {
     DarwinX64,
     DarwinArm64,
     LinuxX64,
     LinuxArm64,
+    WindowsX64,
+    WindowsArm64,
 }
 
 impl PlatformTarget {
@@ -177,6 +195,17 @@ impl PlatformTarget {
             Self::DarwinArm64 => "darwin-arm64",
             Self::LinuxX64 => "linux-x64",
             Self::LinuxArm64 => "linux-arm64",
+            Self::WindowsX64 => "win-x64",
+            Self::WindowsArm64 => "win-arm64",
+        }
+    }
+
+    pub fn archive_format(self) -> ArchiveFormat {
+        match self {
+            Self::DarwinX64 | Self::DarwinArm64 | Self::LinuxX64 | Self::LinuxArm64 => {
+                ArchiveFormat::TarXz
+            }
+            Self::WindowsX64 | Self::WindowsArm64 => ArchiveFormat::Zip,
         }
     }
 
@@ -190,6 +219,8 @@ impl PlatformTarget {
             ("macos", "aarch64") => Some(Self::DarwinArm64),
             ("linux", "x86_64") => Some(Self::LinuxX64),
             ("linux", "aarch64") => Some(Self::LinuxArm64),
+            ("windows", "x86_64") => Some(Self::WindowsX64),
+            ("windows", "aarch64") => Some(Self::WindowsArm64),
             _ => None,
         }
     }
@@ -200,6 +231,8 @@ impl PlatformTarget {
             "darwin-arm64" => Some(Self::DarwinArm64),
             "linux-x64" => Some(Self::LinuxX64),
             "linux-arm64" => Some(Self::LinuxArm64),
+            "windows-x64" => Some(Self::WindowsX64),
+            "windows-arm64" => Some(Self::WindowsArm64),
             _ => None,
         }
     }

--- a/crates/nodeup/tests/cli.rs
+++ b/crates/nodeup/tests/cli.rs
@@ -11,6 +11,7 @@ use serde_json::Value;
 use serial_test::serial;
 use sha2::{Digest, Sha256};
 use xz2::write::XzEncoder;
+use zip::{write::FileOptions, ZipWriter};
 
 struct TestEnv {
     root: PathBuf,
@@ -94,9 +95,23 @@ impl TestEnv {
         archive_bytes: Vec<u8>,
         shasums_override: Option<HashMap<String, String>>,
     ) {
+        self.register_release_for_target(version, "linux-x64", archive_bytes, shasums_override);
+    }
+
+    fn register_release_for_target(
+        &self,
+        version: &str,
+        target: &str,
+        archive_bytes: Vec<u8>,
+        shasums_override: Option<HashMap<String, String>>,
+    ) {
         let version = normalize(version);
-        let segment = "linux-x64";
-        let archive_name = format!("node-{version}-{segment}.tar.xz");
+        let extension = if target.starts_with("win-") {
+            "zip"
+        } else {
+            "tar.xz"
+        };
+        let archive_name = format!("node-{version}-{target}.{extension}");
 
         let digest = Sha256::digest(&archive_bytes);
         let mut table = HashMap::new();
@@ -183,6 +198,23 @@ fn make_archive(version: &str, target: &str, scripts: &[(&str, &str)]) -> Vec<u8
     let mut encoder = XzEncoder::new(Vec::new(), 6);
     encoder.write_all(&tar_payload).unwrap();
     encoder.finish().unwrap()
+}
+
+fn make_windows_zip(files: &[(&str, &str)]) -> Vec<u8> {
+    let mut cursor = std::io::Cursor::new(Vec::new());
+    {
+        let mut writer = ZipWriter::new(&mut cursor);
+        let options = FileOptions::default().unix_permissions(0o755);
+
+        for (file_name, file_body) in files {
+            writer.start_file(*file_name, options).unwrap();
+            writer.write_all(file_body.as_bytes()).unwrap();
+        }
+
+        writer.finish().unwrap();
+    }
+
+    cursor.into_inner()
 }
 
 fn make_npm_argv_script(prefix: &str) -> String {
@@ -633,7 +665,7 @@ fn toolchain_link_rejects_directory_without_node_binary() {
 
     assert_eq!(output.status.code(), Some(2));
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("Linked runtime path must contain `bin/node`"));
+    assert!(stderr.contains("Linked runtime path must contain a node executable under `bin/`"));
 }
 
 #[test]
@@ -665,7 +697,7 @@ fn json_toolchain_link_failure_emits_invalid_input_error_envelope() {
     assert!(payload["message"]
         .as_str()
         .unwrap()
-        .contains("Linked runtime path must contain `bin/node`"));
+        .contains("Linked runtime path must contain a node executable under `bin/`"));
 }
 
 #[test]
@@ -2101,11 +2133,85 @@ fn unsupported_platform_is_reported() {
     env.register_index(&[("22.1.0", Some("Jod"))]);
 
     let mut cmd = env.command();
-    cmd.env("NODEUP_FORCE_PLATFORM", "windows-x64")
+    cmd.env("NODEUP_FORCE_PLATFORM", "windows-x86")
         .args(["toolchain", "install", "22.1.0"])
         .assert()
         .failure()
-        .stderr(predicates::str::contains("supports macOS/Linux"));
+        .stderr(predicates::str::contains("supports macOS/Linux/Windows"));
+}
+
+#[test]
+#[serial]
+fn linux_arm64_platform_installs_from_tar_xz_archive() {
+    let env = TestEnv::new();
+    env.register_index(&[("22.1.0", Some("Jod"))]);
+    env.register_release_for_target(
+        "22.1.0",
+        "linux-arm64",
+        make_archive(
+            "22.1.0",
+            "linux-arm64",
+            &[("node", "#!/bin/sh\necho arm64\n")],
+        ),
+        None,
+    );
+
+    let runtime_root = env.data_root.join("toolchains").join("v22.1.0");
+
+    env.command()
+        .env("NODEUP_FORCE_PLATFORM", "linux-arm64")
+        .args(["toolchain", "install", "22.1.0"])
+        .assert()
+        .success();
+
+    assert!(runtime_root.join("bin").join("node").exists());
+}
+
+#[test]
+#[serial]
+fn windows_x64_platform_installs_from_zip_archive() {
+    let env = TestEnv::new();
+    env.register_index(&[("22.1.0", Some("Jod"))]);
+    env.register_release_for_target(
+        "22.1.0",
+        "win-x64",
+        make_windows_zip(&[("node.exe", "node"), ("npm.cmd", "@echo off\r\n")]),
+        None,
+    );
+
+    let runtime_root = env.data_root.join("toolchains").join("v22.1.0");
+
+    env.command()
+        .env("NODEUP_FORCE_PLATFORM", "windows-x64")
+        .args(["toolchain", "install", "22.1.0"])
+        .assert()
+        .success();
+
+    assert!(runtime_root.join("bin").join("node.exe").exists());
+    assert!(runtime_root.join("bin").join("npm.cmd").exists());
+}
+
+#[test]
+#[serial]
+fn windows_arm64_platform_installs_from_zip_archive() {
+    let env = TestEnv::new();
+    env.register_index(&[("22.1.0", Some("Jod"))]);
+    env.register_release_for_target(
+        "22.1.0",
+        "win-arm64",
+        make_windows_zip(&[("node.exe", "node"), ("npm.cmd", "@echo off\r\n")]),
+        None,
+    );
+
+    let runtime_root = env.data_root.join("toolchains").join("v22.1.0");
+
+    env.command()
+        .env("NODEUP_FORCE_PLATFORM", "windows-arm64")
+        .args(["toolchain", "install", "22.1.0"])
+        .assert()
+        .success();
+
+    assert!(runtime_root.join("bin").join("node.exe").exists());
 }
 
 #[test]

--- a/docs/crates-cargo-mono-foundation.md
+++ b/docs/crates-cargo-mono-foundation.md
@@ -66,6 +66,7 @@
 - Workspace validation baseline: `cargo test --workspace --all-targets`
 - CI alignment: `.github/workflows/CI.yml` Rust jobs
 - Release contract checks should align with `.github/workflows/release-cargo-mono.yml`.
+- Release assets must cover `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`.
 - Release signing outputs must use Sigstore bundle sidecars (`SHA256SUMS.sigstore.json` and `<artifact>.sigstore.json`).
 
 ## Dependencies and Integrations

--- a/docs/crates-nodeup-foundation.md
+++ b/docs/crates-nodeup-foundation.md
@@ -17,8 +17,11 @@
 - Binary entrypoints must force-link `swc_malloc` allocator policy, while the library target remains allocator-agnostic for downstream consumers.
 - Shim dispatch behavior must remain deterministic by executable name (`node`, `npm`, `npx`, `yarn`, `pnpm`).
 - Install/update command surfaces must preserve backward-compatible flags and outputs.
-- Homebrew installation must consume prebuilt release archives for `darwin/amd64`, `darwin/arm64`, and `linux/amd64`; Linux arm64 must fail with a clear unsupported-platform message.
+- Host support must include `macOS`, `Linux`, and `Windows` x64/arm64, while x86 hosts remain unsupported.
+- Homebrew installation must consume prebuilt release archives for `darwin/amd64`, `darwin/arm64`, `linux/amd64`, and `linux/arm64`.
 - Direct install scripts must verify release artifacts with `SHA256SUMS` and Sigstore bundle sidecars (`<artifact>.sigstore.json`) via `cosign verify-blob --bundle`.
+- Runtime archive selection must remain enum-driven: `tar.xz` for `darwin/*` and `linux/*`, `zip` for `windows/*`.
+- Windows runtime archives that unpack without a top-level directory must be normalized into the stable `bin/` runtime layout used by nodeup execution and linking flows.
 - `yarn`/`pnpm` delegated execution must honor nearest `package.json` `packageManager` when present.
 - `packageManager` parsing contract is strict: `<manager>@<exact-semver>` with manager limited to `yarn|pnpm`.
 - `packageManager` manager-command mismatch must fail with `conflict`; malformed values must fail with `invalid-input`.
@@ -53,12 +56,13 @@
 - Local validation: `cargo test -p nodeup`
 - Workspace baseline: `cargo test --workspace --all-targets`
 - Release contract checks should align with `release-nodeup` workflow expectations.
-- Release assets must include both standalone prebuilt binaries (`nodeup-<os>-<arch>[.exe]`) and compressed archives (`nodeup-<os>-<arch>.tar.gz|zip`) for the supported release matrix.
+- Release assets must include both standalone prebuilt binaries (`nodeup-<os>-<arch>[.exe]`) and compressed archives (`nodeup-<os>-<arch>.tar.gz|zip`) for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`.
 - Release signing outputs must include `SHA256SUMS.sigstore.json` and `<artifact>.sigstore.json` sidecars; legacy `.sig`/`.pem` sidecars are out of scope for direct installation.
 - Homebrew release automation must render the prebuilt formula from release asset URLs and push tap updates directly to `delinoio/homebrew-tap` `main` with a dedicated tap-write credential.
 - Completion coverage must include successful script generation, invalid shell/scope validation, and JSON-mode raw output behavior.
 - Output color coverage must include flag/env precedence, invalid env fallback, stream-aware auto-mode behavior, and JSON/completion ANSI exclusion.
 - `packageManager` coverage must include strict parsing, mismatch conflicts, yarn v1 vs v2+ mapping, direct-binary preference, and npm-exec fallback behavior.
+- Runtime install coverage must include `linux-arm64`, `windows-x64`, and `windows-arm64` archive selection and extraction behavior.
 
 ## Dependencies and Integrations
 - Integrates with filesystem runtime shims and remote distribution channels.

--- a/docs/crates-with-watch-foundation.md
+++ b/docs/crates-with-watch-foundation.md
@@ -41,7 +41,7 @@
 - Commands marked as `WritesWatchedInputs` must refresh the baseline snapshot after each run and suppress reruns caused only by their own writes while they were executing.
 - Path watch inputs must attach their OS watcher to the nearest existing directory so replace-style writers such as GNU `sed -i` do not orphan follow-up change detection on Linux.
 - Operator-facing documentation must explain the three command modes, the `exec --input` escape hatch, shell support boundaries, and why self-mutating commands do not loop on their own writes.
-- Homebrew installation must consume prebuilt GitHub release archives for `darwin/amd64`, `darwin/arm64`, and `linux/amd64`.
+- Homebrew installation must consume prebuilt GitHub release archives for `darwin/amd64`, `darwin/arm64`, `linux/amd64`, and `linux/arm64`.
 
 ## Storage
 - `with-watch` does not persist project state.
@@ -64,7 +64,7 @@
 - Documentation changes should be checked against `cargo run -p with-watch -- --help` and the integration scenarios in `crates/with-watch/tests/cli.rs`.
 - Publishability validation: `cargo publish -p with-watch --dry-run`
 - Release contract checks should align with `.github/workflows/release-with-watch.yml`.
-- Release assets must include standalone binaries (`with-watch-<os>-<arch>[.exe]`) and compressed archives (`with-watch-<os>-<arch>.tar.gz|zip`) for the supported release matrix.
+- Release assets must include standalone binaries (`with-watch-<os>-<arch>[.exe]`) and compressed archives (`with-watch-<os>-<arch>.tar.gz|zip`) for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`.
 - Release signing outputs must include `SHA256SUMS.sigstore.json` and `<artifact>.sigstore.json` sidecars.
 
 ## Dependencies and Integrations

--- a/docs/project-cargo-mono.md
+++ b/docs/project-cargo-mono.md
@@ -21,7 +21,7 @@ Provide a Cargo subcommand for Rust monorepo lifecycle management, including ver
 - `publish` retry overrides must remain operator-controlled through `--max-attempts <count>` and `CARGO_MONO_PUBLISH_MAX_ATTEMPTS`, with precedence `--max-attempts` > env > default unlimited retries.
 - Remote tag publication remains CI-owned: `auto-publish` pushes release tags with `git push --tags` after a successful `publish` run, with checkout credential persistence disabled and authentication bound to `secrets.GH_TOKEN` (non-`GITHUB_TOKEN`) so downstream tag-triggered workflows run.
 - Publish tag configuration must be opt-in through `[workspace.metadata.cargo-mono.publish.tag].packages`, and tag naming must remain `<crate>@v<version>`.
-- Tag release automation must detect `cargo-mono@v*` and produce signed multi-OS prebuilt artifacts with Sigstore bundle sidecars (`*.sigstore.json`) without changing CLI command behavior.
+- Tag release automation must detect `cargo-mono@v*` and produce signed prebuilt artifacts for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`, plus Sigstore bundle sidecars (`*.sigstore.json`) without changing CLI command behavior.
 - Runtime failure messaging must follow the `Summary/Context/Hint` three-line contract while command behavior, output schema, and exit code semantics remain stable.
 - Dependency-cycle conflicts in package ordering must identify cycle package names and dependency scope in `Context` without changing CLI flags, command behavior, or JSON output schema.
 - Human output color controls must remain stable: global `--color <auto|always|never>`, `CARGO_MONO_OUTPUT_COLOR`, and `NO_COLOR` with precedence `--color` > `CARGO_MONO_OUTPUT_COLOR` > `NO_COLOR` > auto-detection.

--- a/docs/project-nodeup.md
+++ b/docs/project-nodeup.md
@@ -18,9 +18,10 @@ Provide a Rust-based Node.js version manager with predictable channel resolution
 - `package.json` `packageManager` support for `yarn|pnpm` must remain strict and deterministic.
 - Shell completion generation must remain deterministic for supported shells and top-level command scopes.
 - Human output styling controls (`--color`, `NODEUP_COLOR`, and `NO_COLOR` precedence) must remain stable across CLI and public documentation.
-- Release automation must publish both standalone prebuilt binaries and archive assets for the supported OS/architecture matrix, plus Sigstore bundle sidecars (`*.sigstore.json`) for each artifact and `SHA256SUMS`.
+- Release automation must publish both standalone prebuilt binaries and archive assets for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`, plus Sigstore bundle sidecars (`*.sigstore.json`) for each artifact and `SHA256SUMS`.
 - Direct installers must verify `SHA256SUMS` entries and Sigstore bundle sidecars, and only support bundle-enabled releases.
-- Homebrew installation must use prebuilt `nodeup` release archives for `darwin/amd64`, `darwin/arm64`, and `linux/amd64`, while failing clearly for unsupported Linux arm64 hosts.
+- Homebrew installation must use prebuilt `nodeup` release archives for `darwin/amd64`, `darwin/arm64`, `linux/amd64`, and `linux/arm64`.
+- `nodeup` runtime installation and shim dispatch must support `macOS`, `Linux`, and `Windows` x64/arm64 hosts while leaving x86 hosts out of scope.
 
 ## Change Policy
 - Update this index and `docs/crates-nodeup-foundation.md` in the same change for behavior or storage contract updates.

--- a/docs/project-with-watch.md
+++ b/docs/project-with-watch.md
@@ -28,8 +28,8 @@ Provide a Rust-based CLI wrapper that reruns delegated shell utilities and arbit
 - Path-based watch inputs must anchor watcher subscriptions at the nearest existing directory so replace-style writers keep emitting later external changes.
 - Public crate distribution must remain `cargo install with-watch`.
 - Publish tag eligibility must remain enabled through root `[workspace.metadata.cargo-mono.publish.tag].packages`, and release tag naming must remain `with-watch@v<version>`.
-- Release automation must publish signed GitHub Release assets for `linux/amd64`, `darwin/amd64`, `darwin/arm64`, and `windows/amd64`, including standalone binaries (`with-watch-<os>-<arch>[.exe]`) and archives (`with-watch-<os>-<arch>.tar.gz|zip`).
-- Homebrew installation must consume prebuilt `with-watch` release archives for `darwin/amd64`, `darwin/arm64`, and `linux/amd64`.
+- Release automation must publish signed GitHub Release assets for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`, including standalone binaries (`with-watch-<os>-<arch>[.exe]`) and archives (`with-watch-<os>-<arch>.tar.gz|zip`).
+- Homebrew installation must consume prebuilt `with-watch` release archives for `darwin/amd64`, `darwin/arm64`, `linux/amd64`, and `linux/arm64`.
 
 ## Change Policy
 - Update this index and `docs/crates-with-watch-foundation.md` together when CLI shape, watch inference behavior, operator guidance, release automation, side-effect suppression, or storage/logging contracts change.

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -4,8 +4,8 @@ This directory contains Homebrew formula/cask templates rendered by `scripts/rel
 
 Supported package identifiers:
 
-- `nodeup` (prebuilt formula: `darwin/amd64`, `darwin/arm64`, `linux/amd64`)
-- `with-watch` (prebuilt formula: `darwin/amd64`, `darwin/arm64`, `linux/amd64`)
+- `nodeup` (prebuilt formula: `darwin/amd64`, `darwin/arm64`, `linux/amd64`, `linux/arm64`)
+- `with-watch` (prebuilt formula: `darwin/amd64`, `darwin/arm64`, `linux/amd64`, `linux/arm64`)
 - `derun`
 - `dexdex-main-server` (prebuilt formula: `darwin/amd64`, `darwin/arm64`, `linux/amd64`)
 - `dexdex-worker-server` (prebuilt formula: `darwin/amd64`, `darwin/arm64`, `linux/amd64`)

--- a/packaging/homebrew/templates/nodeup.rb.tmpl
+++ b/packaging/homebrew/templates/nodeup.rb.tmpl
@@ -18,8 +18,11 @@ class Nodeup < Formula
     if Hardware::CPU.intel?
       url "__LINUX_AMD64_URL__"
       sha256 "__LINUX_AMD64_SHA256__"
+    elsif Hardware::CPU.arm?
+      url "__LINUX_ARM64_URL__"
+      sha256 "__LINUX_ARM64_SHA256__"
     else
-      odie "nodeup prebuilt distribution currently supports Linux amd64 only"
+      odie "nodeup prebuilt distribution currently supports Linux amd64 and arm64 only"
     end
   end
 

--- a/packaging/homebrew/templates/with-watch.rb.tmpl
+++ b/packaging/homebrew/templates/with-watch.rb.tmpl
@@ -18,8 +18,11 @@ class WithWatch < Formula
     if Hardware::CPU.intel?
       url "__LINUX_AMD64_URL__"
       sha256 "__LINUX_AMD64_SHA256__"
+    elsif Hardware::CPU.arm?
+      url "__LINUX_ARM64_URL__"
+      sha256 "__LINUX_ARM64_SHA256__"
     else
-      odie "with-watch prebuilt distribution currently supports Linux amd64 only"
+      odie "with-watch prebuilt distribution currently supports Linux amd64 and arm64 only"
     end
   end
 

--- a/scripts/install/nodeup.ps1
+++ b/scripts/install/nodeup.ps1
@@ -83,7 +83,13 @@ function Verify-Bundle {
 function Install-Direct {
   $tag = Resolve-Tag
   $baseUrl = "https://github.com/$Repo/releases/download/$tag"
-  $assetName = "nodeup-windows-amd64.zip"
+  $architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
+  $assetArch = switch ($architecture) {
+    "x64" { "amd64" }
+    "arm64" { "arm64" }
+    default { throw "[install.nodeup] unsupported Windows architecture: $architecture" }
+  }
+  $assetName = "nodeup-windows-$assetArch.zip"
 
   $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ("nodeup-install-" + [System.Guid]::NewGuid().ToString("N"))
   New-Item -Path $tmpDir -ItemType Directory | Out-Null

--- a/scripts/install/nodeup.sh
+++ b/scripts/install/nodeup.sh
@@ -155,11 +155,6 @@ install_direct() {
       ;;
   esac
 
-  if [ "$os" = "linux" ] && [ "$arch" = "arm64" ]; then
-    echo "[install.nodeup] linux arm64 direct artifacts are not published yet" >&2
-    exit 1
-  fi
-
   local ext="tar.gz"
   local asset_name="nodeup-${os}-${arch}.${ext}"
   local base_url="https://github.com/${repo}/releases/download/${tag}"

--- a/scripts/release/update-homebrew.sh
+++ b/scripts/release/update-homebrew.sh
@@ -13,6 +13,7 @@ Usage:
     [--darwin-amd64-url <url>] [--darwin-amd64-sha256 <sha>] \
     [--darwin-arm64-url <url>] [--darwin-arm64-sha256 <sha>] \
     [--linux-amd64-url <url>] [--linux-amd64-sha256 <sha>] \
+    [--linux-arm64-url <url>] [--linux-arm64-sha256 <sha>] \
     [--desktop-url <url>] [--desktop-sha256 <sha>] \
     [--tap-repo <owner/repo>] [--dry-run]
 
@@ -31,6 +32,10 @@ Options:
                          Linux amd64 prebuilt artifact URL (nodeup, with-watch, derun, and DexDex server formulas).
   --linux-amd64-sha256 <sha>
                          Linux amd64 prebuilt artifact SHA256 (nodeup, with-watch, derun, and DexDex server formulas).
+  --linux-arm64-url <url>
+                         Linux arm64 prebuilt artifact URL (nodeup and with-watch formulas).
+  --linux-arm64-sha256 <sha>
+                         Linux arm64 prebuilt artifact SHA256 (nodeup and with-watch formulas).
   --desktop-url <url>    Desktop installer URL (dexdex cask).
   --desktop-sha256 <sha> Desktop installer SHA256 (dexdex cask).
   --tap-repo <repo>      Homebrew tap repository (default: delinoio/homebrew-tap).
@@ -46,6 +51,8 @@ darwin_arm64_url=""
 darwin_arm64_sha256=""
 linux_amd64_url=""
 linux_amd64_sha256=""
+linux_arm64_url=""
+linux_arm64_sha256=""
 desktop_url=""
 desktop_sha256=""
 tap_repo="delinoio/homebrew-tap"
@@ -87,6 +94,14 @@ while [ "$#" -gt 0 ]; do
       ;;
     --linux-amd64-sha256)
       linux_amd64_sha256="${2:-}"
+      shift 2
+      ;;
+    --linux-arm64-url)
+      linux_arm64_url="${2:-}"
+      shift 2
+      ;;
+    --linux-arm64-sha256)
+      linux_arm64_sha256="${2:-}"
       shift 2
       ;;
     --desktop-url)
@@ -135,6 +150,11 @@ case "$project" in
       exit 1
     fi
 
+    if { [ "$project" = "nodeup" ] || [ "$project" = "with-watch" ]; } && { [ -z "$linux_arm64_url" ] || [ -z "$linux_arm64_sha256" ]; }; then
+      log "$project requires --linux-arm64-url and --linux-arm64-sha256"
+      exit 1
+    fi
+
     template_path="$repo_root/packaging/homebrew/templates/${project}.rb.tmpl"
     destination_path="Formula/${project}.rb"
 
@@ -151,6 +171,8 @@ case "$project" in
       -e "s|__DARWIN_ARM64_SHA256__|$darwin_arm64_sha256|g" \
       -e "s|__LINUX_AMD64_URL__|$linux_amd64_url|g" \
       -e "s|__LINUX_AMD64_SHA256__|$linux_amd64_sha256|g" \
+      -e "s|__LINUX_ARM64_URL__|$linux_arm64_url|g" \
+      -e "s|__LINUX_ARM64_SHA256__|$linux_arm64_sha256|g" \
       -e "s|__VERSION__|$version|g" \
       "$template_path" >"$rendered_file"
     ;;


### PR DESCRIPTION
## Summary
- expand the `cargo-mono`, `nodeup`, and `with-watch` release workflows to ship Linux ARM64 and Windows ARM64 artifacts on native ARM runners
- add Linux ARM64 Homebrew release metadata and install support for `nodeup` and `with-watch`
- promote `nodeup` Windows x64 and ARM64 to supported hosts with archive-format-aware runtime resolution, zip extraction, and installer updates

## Testing
- `cargo test`
- `pnpm --filter public-docs test`
- `./scripts/release/update-homebrew.sh --project nodeup --formula-repo . --version 0.0.0 --darwin-amd64-url https://example.com/nodeup-darwin-amd64.tar.gz --darwin-amd64-sha256 1111111111111111111111111111111111111111111111111111111111111111 --darwin-arm64-url https://example.com/nodeup-darwin-arm64.tar.gz --darwin-arm64-sha256 2222222222222222222222222222222222222222222222222222222222222222 --linux-amd64-url https://example.com/nodeup-linux-amd64.tar.gz --linux-amd64-sha256 3333333333333333333333333333333333333333333333333333333333333333 --linux-arm64-url https://example.com/nodeup-linux-arm64.tar.gz --linux-arm64-sha256 4444444444444444444444444444444444444444444444444444444444444444 --dry-run`
- `./scripts/release/update-homebrew.sh --project with-watch --formula-repo . --version 0.0.0 --darwin-amd64-url https://example.com/with-watch-darwin-amd64.tar.gz --darwin-amd64-sha256 1111111111111111111111111111111111111111111111111111111111111111 --darwin-arm64-url https://example.com/with-watch-darwin-arm64.tar.gz --darwin-arm64-sha256 2222222222222222222222222222222222222222222222222222222222222222 --linux-amd64-url https://example.com/with-watch-linux-amd64.tar.gz --linux-amd64-sha256 3333333333333333333333333333333333333333333333333333333333333333 --linux-arm64-url https://example.com/with-watch-linux-arm64.tar.gz --linux-arm64-sha256 4444444444444444444444444444444444444444444444444444444444444444 --dry-run`
