### PR TITLE
fix(with-watch): use metadata snapshots for ls

### DIFF
--- a/crates/with-watch/README.md
+++ b/crates/with-watch/README.md
@@ -39,6 +39,7 @@ with-watch exec --input 'src/**/*.rs' -- cargo test -p with-watch
 - Passthrough and shell modes use built-in command adapters before falling back to conservative path heuristics.
 - Known outputs, inline scripts, patterns, and shell output redirects are filtered out of the watch set.
 - Pathless defaults are intentionally narrow: only `ls`, `dir`, `vdir`, `du`, and `find` implicitly watch the current directory.
+- `ls`-style commands watch directory listings via metadata snapshots: plain `ls` watches immediate children, `ls -R` stays recursive, and `ls -d` watches only the named path.
 - `exec --input` remains the explicit escape hatch when a delegated command has no meaningful filesystem inputs or when fallback inference would be ambiguous.
 
 ## When to use exec --input
@@ -64,6 +65,7 @@ with-watch exec --input 'src/**/*.rs' -- cargo test -p with-watch
 ## Rerun behavior
 
 - The default rerun filter compares content hashes, which avoids reruns from metadata churn alone.
+- `ls`, `dir`, and `vdir` use metadata-based listing snapshots instead of hashing every file under the watched directory before the first run.
 - `--no-hash` switches the filter to metadata-only comparison.
 - Commands that write excluded outputs such as `cp src.txt dest.txt` should rerun when the source input changes, not when the output file changes.
 - Commands that mutate watched inputs directly, such as `sed -i.bak -e 's/old/new/' config.txt`, refresh their baseline after each run so they do not loop on their own writes.

--- a/crates/with-watch/src/analysis.rs
+++ b/crates/with-watch/src/analysis.rs
@@ -1,9 +1,9 @@
-use std::{ffi::OsString, path::Path};
+use std::{ffi::OsString, fs, path::Path};
 
 use crate::{
     error::Result,
     parser::{ParsedShellExpression, ShellRedirect, ShellRedirectOperator},
-    snapshot::{WatchInput, WatchInputKind},
+    snapshot::{absolutize, PathSnapshotMode, WatchInput, WatchInputKind},
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -291,6 +291,7 @@ fn analyze_command_tokens(
         "split" => analyze_split(argv, redirects, cwd)?,
         "csplit" => analyze_csplit(argv, redirects, cwd)?,
         "tee" => analyze_tee(argv, redirects, cwd)?,
+        "ls" | "dir" | "vdir" => analyze_ls_like(argv, redirects, cwd)?,
         "grep" | "egrep" | "fgrep" => analyze_grep(argv, redirects, cwd)?,
         "sed" => analyze_sed(argv, redirects, cwd)?,
         "awk" | "gawk" | "mawk" | "nawk" => analyze_awk(argv, redirects, cwd)?,
@@ -320,7 +321,7 @@ fn analyze_command_tokens(
     Ok(analysis.finalize())
 }
 
-const DEFAULT_CURRENT_DIR_COMMANDS: &[&str] = &["ls", "dir", "vdir", "du"];
+const DEFAULT_CURRENT_DIR_COMMANDS: &[&str] = &["du"];
 const NONWATCHABLE_COMMANDS: &[&str] = &[
     "echo", "printf", "seq", "yes", "sleep", "date", "uname", "pwd", "true", "false", "basename",
     "dirname", "nproc", "printenv", "whoami", "logname", "users", "hostid", "numfmt", "mktemp",
@@ -1870,6 +1871,122 @@ fn analyze_default_current_dir_reader(
     Ok(analysis)
 }
 
+fn analyze_ls_like(
+    argv: &[String],
+    redirects: &[ShellRedirect],
+    cwd: &Path,
+) -> Result<SingleCommandAnalysis> {
+    let mut inputs = Vec::new();
+    let mut positional_only = false;
+    let mut recursive = false;
+    let mut directory_mode = false;
+    let mut index = 1usize;
+
+    while index < argv.len() {
+        let token = argv[index].as_str();
+        if !positional_only && token == "--" {
+            positional_only = true;
+            index += 1;
+            continue;
+        }
+
+        if !positional_only {
+            if token == "-R" || token == "--recursive" {
+                recursive = true;
+                index += 1;
+                continue;
+            }
+            if token == "-d" || token == "--directory" {
+                directory_mode = true;
+                index += 1;
+                continue;
+            }
+            if token.starts_with("--") {
+                index += 1;
+                continue;
+            }
+            if token.starts_with('-') && token != "-" {
+                recursive |= token.contains('R');
+                directory_mode |= token.contains('d');
+                index += 1;
+                continue;
+            }
+        }
+
+        push_inferred_path_with_mode(
+            &mut inputs,
+            token,
+            cwd,
+            ls_like_snapshot_mode(token, cwd, recursive, directory_mode),
+        )?;
+        index += 1;
+    }
+
+    if inputs.is_empty() {
+        push_inferred_path_with_mode(
+            &mut inputs,
+            ".",
+            cwd,
+            default_ls_snapshot_mode(recursive, directory_mode),
+        )?;
+    }
+
+    let mut analysis = SingleCommandAnalysis {
+        inputs,
+        adapter_ids: vec![CommandAdapterId::DefaultCurrentDir],
+        fallback_used: false,
+        default_watch_root_used: false,
+        filtered_output_count: 0,
+        side_effect_profile: SideEffectProfile::ReadOnly,
+        status: CommandAnalysisStatus::NoInputs,
+    };
+
+    if argv.len() == 1
+        || argv
+            .iter()
+            .skip(1)
+            .all(|token| token == "--" || (token.starts_with('-') && token != "-"))
+    {
+        analysis.default_watch_root_used = true;
+    }
+
+    apply_redirects(&mut analysis, redirects, cwd)?;
+    Ok(analysis)
+}
+
+fn default_ls_snapshot_mode(recursive: bool, directory_mode: bool) -> PathSnapshotMode {
+    if directory_mode {
+        PathSnapshotMode::MetadataPath
+    } else if recursive {
+        PathSnapshotMode::MetadataTree
+    } else {
+        PathSnapshotMode::MetadataChildren
+    }
+}
+
+fn ls_like_snapshot_mode(
+    raw: &str,
+    cwd: &Path,
+    recursive: bool,
+    directory_mode: bool,
+) -> PathSnapshotMode {
+    if directory_mode {
+        return PathSnapshotMode::MetadataPath;
+    }
+
+    let absolute_path = absolutize(raw, cwd);
+    match fs::metadata(&absolute_path) {
+        Ok(metadata) if metadata.is_dir() => {
+            if recursive {
+                PathSnapshotMode::MetadataTree
+            } else {
+                PathSnapshotMode::MetadataChildren
+            }
+        }
+        Ok(_) | Err(_) => PathSnapshotMode::MetadataPath,
+    }
+}
+
 fn analyze_non_watchable(
     _argv: &[String],
     redirects: &[ShellRedirect],
@@ -2080,28 +2197,33 @@ fn push_inferred_input(inputs: &mut Vec<WatchInput>, raw: &str, cwd: &Path) -> R
     Ok(())
 }
 
+fn push_inferred_path_with_mode(
+    inputs: &mut Vec<WatchInput>,
+    raw: &str,
+    cwd: &Path,
+    snapshot_mode: PathSnapshotMode,
+) -> Result<()> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed == "-" {
+        return Ok(());
+    }
+
+    let input =
+        WatchInput::path_with_snapshot_mode(trimmed, cwd, WatchInputKind::Inferred, snapshot_mode)?;
+
+    if !inputs.contains(&input) {
+        inputs.push(input);
+    }
+
+    Ok(())
+}
+
 fn has_glob_magic(raw: &str) -> bool {
     raw.contains('*') || raw.contains('?') || raw.contains('[')
 }
 
 fn path_exists(raw: &str, cwd: &Path) -> bool {
-    let expanded = expand_tilde(raw);
-    let path = Path::new(expanded.as_str());
-    let absolute = if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        cwd.join(path)
-    };
-    absolute.exists()
-}
-
-fn expand_tilde(raw: &str) -> String {
-    if let Some(suffix) = raw.strip_prefix("~/") {
-        if let Ok(home) = std::env::var("HOME") {
-            return format!("{home}/{suffix}");
-        }
-    }
-    raw.to_string()
+    absolutize(raw, cwd).exists()
 }
 
 fn is_path_shaped(token: &str) -> bool {
@@ -2159,13 +2281,16 @@ fn is_dynamic_shell_token(token: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::OsString;
+    use std::{ffi::OsString, fs};
 
     use super::{
         analyze_argv, analyze_shell_expression, CommandAdapterId, CommandAnalysisStatus,
         SideEffectProfile,
     };
-    use crate::parser::parse_shell_expression;
+    use crate::{
+        parser::parse_shell_expression,
+        snapshot::{PathSnapshotMode, WatchInput},
+    };
 
     #[test]
     fn cp_watches_only_sources() {
@@ -2283,6 +2408,11 @@ mod tests {
 
         assert_eq!(analysis.inputs.len(), 1);
         assert!(analysis.default_watch_root_used);
+        assert_path_snapshot_mode(
+            &analysis.inputs[0],
+            cwd.path(),
+            PathSnapshotMode::MetadataChildren,
+        );
 
         let analysis = analyze_argv(&[OsString::from("find")], cwd.path()).expect("analyze");
         assert_eq!(analysis.inputs.len(), 1);
@@ -2315,6 +2445,61 @@ mod tests {
         .expect("analyze");
         assert_eq!(analysis.inputs.len(), 1);
         assert!(analysis.default_watch_root_used);
+    }
+
+    #[test]
+    fn ls_like_inputs_use_listing_snapshot_modes() {
+        let cwd = tempfile::tempdir().expect("create tempdir");
+        fs::create_dir_all(cwd.path().join("subdir").join("nested")).expect("create nested dir");
+        fs::write(cwd.path().join("file.txt"), "alpha\n").expect("write file");
+
+        let default_ls = analyze_argv(&[OsString::from("ls")], cwd.path()).expect("analyze");
+        assert_path_snapshot_mode(
+            &default_ls.inputs[0],
+            cwd.path(),
+            PathSnapshotMode::MetadataChildren,
+        );
+
+        let directory_ls = analyze_argv(
+            &[OsString::from("ls"), OsString::from("subdir")],
+            cwd.path(),
+        )
+        .expect("analyze");
+        assert_path_snapshot_mode(
+            &directory_ls.inputs[0],
+            &cwd.path().join("subdir"),
+            PathSnapshotMode::MetadataChildren,
+        );
+
+        let recursive_ls = analyze_argv(
+            &[
+                OsString::from("ls"),
+                OsString::from("-R"),
+                OsString::from("subdir"),
+            ],
+            cwd.path(),
+        )
+        .expect("analyze");
+        assert_path_snapshot_mode(
+            &recursive_ls.inputs[0],
+            &cwd.path().join("subdir"),
+            PathSnapshotMode::MetadataTree,
+        );
+
+        let directory_flag_ls = analyze_argv(
+            &[
+                OsString::from("ls"),
+                OsString::from("-d"),
+                OsString::from("subdir"),
+            ],
+            cwd.path(),
+        )
+        .expect("analyze");
+        assert_path_snapshot_mode(
+            &directory_flag_ls.inputs[0],
+            &cwd.path().join("subdir"),
+            PathSnapshotMode::MetadataPath,
+        );
     }
 
     #[test]
@@ -2408,5 +2593,23 @@ mod tests {
 
         assert_eq!(analysis.inputs.len(), 1);
         assert_eq!(analysis.filtered_output_count, 1);
+    }
+
+    fn assert_path_snapshot_mode(
+        input: &WatchInput,
+        expected_path: &std::path::Path,
+        expected_snapshot_mode: PathSnapshotMode,
+    ) {
+        match input {
+            WatchInput::Path {
+                path,
+                snapshot_mode,
+                ..
+            } => {
+                assert_eq!(path, expected_path);
+                assert_eq!(*snapshot_mode, expected_snapshot_mode);
+            }
+            other => panic!("unexpected watch input: {other:?}"),
+        }
     }
 }

--- a/crates/with-watch/src/runner.rs
+++ b/crates/with-watch/src/runner.rs
@@ -4,7 +4,7 @@ use std::{
     path::PathBuf,
     process::{Child, Command, ExitStatus, Stdio},
     thread,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use tracing::{debug, info, warn};
@@ -186,7 +186,8 @@ impl RunnerOptions {
 
 pub fn run(plan: ExecutionPlan, options: RunnerOptions) -> Result<i32> {
     let mut watch_loop = WatchLoop::new(&plan.inputs)?;
-    let mut baseline = capture_snapshot(&plan.inputs, plan.detection_mode)?;
+    let mut baseline =
+        capture_snapshot_with_logging("initial-baseline", &plan.inputs, plan.detection_mode)?;
     let mut child = Some(spawn_command(&plan.delegated_command)?);
     let mut completed_runs = 0usize;
     let mut pending_rerun = false;
@@ -217,7 +218,8 @@ pub fn run(plan: ExecutionPlan, options: RunnerOptions) -> Result<i32> {
             {
                 completed_runs += 1;
                 let last_exit_code = exit_code_from_status(status);
-                let post_run_snapshot = capture_snapshot(&plan.inputs, plan.detection_mode)?;
+                let post_run_snapshot =
+                    capture_snapshot_with_logging("post-run", &plan.inputs, plan.detection_mode)?;
                 let inputs_changed_since_baseline =
                     post_run_snapshot.is_meaningfully_different(&baseline, plan.detection_mode);
                 let additional_change_after_suppression = suppressed_self_change_snapshot
@@ -294,7 +296,8 @@ pub fn run(plan: ExecutionPlan, options: RunnerOptions) -> Result<i32> {
         {
             handle_watch_events(&events);
 
-            let current_snapshot = capture_snapshot(&plan.inputs, plan.detection_mode)?;
+            let current_snapshot =
+                capture_snapshot_with_logging("event-rescan", &plan.inputs, plan.detection_mode)?;
             let reference_snapshot = if child.is_some()
                 && plan.metadata.side_effect_profile == SideEffectProfile::WritesWatchedInputs
             {
@@ -341,6 +344,40 @@ pub fn run(plan: ExecutionPlan, options: RunnerOptions) -> Result<i32> {
             thread::sleep(Duration::from_millis(10));
         }
     }
+}
+
+fn capture_snapshot_with_logging(
+    phase: &str,
+    inputs: &[WatchInput],
+    detection_mode: ChangeDetectionMode,
+) -> Result<SnapshotState> {
+    let snapshot_modes = summarize_snapshot_modes(inputs);
+    let started_at = Instant::now();
+    let snapshot = capture_snapshot(inputs, detection_mode)?;
+
+    debug!(
+        phase,
+        detection_mode = detection_mode.as_str(),
+        snapshot_modes,
+        input_count = inputs.len(),
+        snapshot_entry_count = snapshot.len(),
+        elapsed_ms = started_at.elapsed().as_millis() as u64,
+        "Captured input snapshot"
+    );
+
+    Ok(snapshot)
+}
+
+fn summarize_snapshot_modes(inputs: &[WatchInput]) -> String {
+    let mut modes = Vec::new();
+    for input in inputs {
+        let snapshot_mode = input.snapshot_mode_label();
+        if !modes.contains(&snapshot_mode) {
+            modes.push(snapshot_mode);
+        }
+    }
+
+    modes.join(",")
 }
 
 fn handle_watch_events(events: &CollectedEvents) {

--- a/crates/with-watch/src/snapshot.rs
+++ b/crates/with-watch/src/snapshot.rs
@@ -4,7 +4,7 @@ use std::{
     fs::{self, File},
     io::Read,
     path::{Path, PathBuf},
-    time::SystemTime,
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use globset::Glob;
@@ -50,12 +50,34 @@ pub enum WatchInputKind {
     Inferred,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathSnapshotMode {
+    ContentPath,
+    ContentTree,
+    MetadataPath,
+    MetadataChildren,
+    MetadataTree,
+}
+
+impl PathSnapshotMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ContentPath => "content-path",
+            Self::ContentTree => "content-tree",
+            Self::MetadataPath => "metadata-path",
+            Self::MetadataChildren => "metadata-children",
+            Self::MetadataTree => "metadata-tree",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WatchInput {
     Path {
         kind: WatchInputKind,
         path: PathBuf,
         watch_anchor: PathBuf,
+        snapshot_mode: PathSnapshotMode,
     },
     Glob {
         kind: WatchInputKind,
@@ -68,6 +90,17 @@ pub enum WatchInput {
 impl WatchInput {
     pub fn path(raw: &str, cwd: &Path, kind: WatchInputKind) -> Result<Self> {
         let absolute_path = absolutize(raw, cwd);
+        let snapshot_mode = default_path_snapshot_mode(&absolute_path);
+        Self::path_with_snapshot_mode(raw, cwd, kind, snapshot_mode)
+    }
+
+    pub fn path_with_snapshot_mode(
+        raw: &str,
+        cwd: &Path,
+        kind: WatchInputKind,
+        snapshot_mode: PathSnapshotMode,
+    ) -> Result<Self> {
+        let absolute_path = absolutize(raw, cwd);
         let watch_anchor = path_watch_anchor(&absolute_path).ok_or_else(|| {
             WithWatchError::MissingWatchAnchor {
                 path: absolute_path.clone(),
@@ -78,6 +111,7 @@ impl WatchInput {
             kind,
             path: absolute_path,
             watch_anchor,
+            snapshot_mode,
         })
     }
 
@@ -113,6 +147,13 @@ impl WatchInput {
     pub fn watch_anchor(&self) -> &Path {
         match self {
             Self::Path { watch_anchor, .. } | Self::Glob { watch_anchor, .. } => watch_anchor,
+        }
+    }
+
+    pub fn snapshot_mode_label(&self) -> &'static str {
+        match self {
+            Self::Path { snapshot_mode, .. } => snapshot_mode.as_str(),
+            Self::Glob { .. } => PathSnapshotMode::ContentTree.as_str(),
         }
     }
 }
@@ -168,10 +209,7 @@ impl SnapshotEntry {
         }
 
         match mode {
-            ChangeDetectionMode::ContentHash => match self.kind {
-                SnapshotEntryKind::File => self.digest == previous.digest,
-                SnapshotEntryKind::Directory | SnapshotEntryKind::Missing => true,
-            },
+            ChangeDetectionMode::ContentHash => self.digest == previous.digest,
             ChangeDetectionMode::MtimeOnly => self.modified == previous.modified,
         }
     }
@@ -199,8 +237,12 @@ pub fn capture_snapshot(inputs: &[WatchInput], mode: ChangeDetectionMode) -> Res
 
     for input in inputs {
         match input {
-            WatchInput::Path { path, .. } => {
-                capture_path_input(path, mode, &mut entries)?;
+            WatchInput::Path {
+                path,
+                snapshot_mode,
+                ..
+            } => {
+                capture_path_input(path, *snapshot_mode, mode, &mut entries)?;
             }
             WatchInput::Glob {
                 absolute_pattern,
@@ -217,18 +259,12 @@ pub fn capture_snapshot(inputs: &[WatchInput], mode: ChangeDetectionMode) -> Res
 
 fn capture_path_input(
     path: &Path,
+    snapshot_mode: PathSnapshotMode,
     mode: ChangeDetectionMode,
     entries: &mut BTreeMap<PathBuf, SnapshotEntry>,
 ) -> Result<()> {
     if !path.exists() {
-        entries.insert(
-            path.to_path_buf(),
-            SnapshotEntry {
-                kind: SnapshotEntryKind::Missing,
-                modified: None,
-                digest: None,
-            },
-        );
+        insert_missing_entry(path, snapshot_mode, mode, entries);
         return Ok(());
     }
 
@@ -236,17 +272,25 @@ fn capture_path_input(
         path: path.to_path_buf(),
         source,
     })?;
-    if metadata.is_dir() {
-        for entry in WalkDir::new(path).follow_links(true) {
-            let entry = entry.map_err(|error| WithWatchError::Metadata {
-                path: path.to_path_buf(),
-                source: std::io::Error::other(error.to_string()),
-            })?;
-            let entry_path = entry.path().to_path_buf();
-            insert_existing_entry(&entry_path, mode, entries)?;
+
+    match snapshot_mode {
+        PathSnapshotMode::ContentPath | PathSnapshotMode::MetadataPath => {
+            insert_existing_entry(path, &metadata, snapshot_mode, mode, entries)?;
         }
-    } else {
-        insert_existing_entry(path, mode, entries)?;
+        PathSnapshotMode::ContentTree | PathSnapshotMode::MetadataTree => {
+            if metadata.is_dir() {
+                capture_directory_tree(path, snapshot_mode, mode, entries)?;
+            } else {
+                insert_existing_entry(path, &metadata, snapshot_mode, mode, entries)?;
+            }
+        }
+        PathSnapshotMode::MetadataChildren => {
+            if metadata.is_dir() {
+                capture_directory_children(path, &metadata, snapshot_mode, mode, entries)?;
+            } else {
+                insert_existing_entry(path, &metadata, snapshot_mode, mode, entries)?;
+            }
+        }
     }
 
     Ok(())
@@ -277,8 +321,70 @@ fn capture_glob_input(
         let path = entry.path().to_path_buf();
         let normalized = normalize_path_string(&path);
         if matcher.is_match(&normalized) {
-            insert_existing_entry(&path, mode, entries)?;
+            let metadata = fs::metadata(&path).map_err(|source| WithWatchError::Metadata {
+                path: path.clone(),
+                source,
+            })?;
+            insert_existing_entry(
+                &path,
+                &metadata,
+                PathSnapshotMode::ContentTree,
+                mode,
+                entries,
+            )?;
         }
+    }
+
+    Ok(())
+}
+
+fn capture_directory_tree(
+    path: &Path,
+    snapshot_mode: PathSnapshotMode,
+    mode: ChangeDetectionMode,
+    entries: &mut BTreeMap<PathBuf, SnapshotEntry>,
+) -> Result<()> {
+    for entry in WalkDir::new(path).follow_links(true) {
+        let entry = entry.map_err(|error| WithWatchError::Metadata {
+            path: path.to_path_buf(),
+            source: std::io::Error::other(error.to_string()),
+        })?;
+        let entry_path = entry.path().to_path_buf();
+        let metadata = fs::metadata(&entry_path).map_err(|source| WithWatchError::Metadata {
+            path: entry_path.clone(),
+            source,
+        })?;
+        insert_existing_entry(&entry_path, &metadata, snapshot_mode, mode, entries)?;
+    }
+
+    Ok(())
+}
+
+fn capture_directory_children(
+    path: &Path,
+    metadata: &fs::Metadata,
+    snapshot_mode: PathSnapshotMode,
+    mode: ChangeDetectionMode,
+    entries: &mut BTreeMap<PathBuf, SnapshotEntry>,
+) -> Result<()> {
+    insert_existing_entry(path, metadata, snapshot_mode, mode, entries)?;
+
+    let read_dir = fs::read_dir(path).map_err(|source| WithWatchError::Metadata {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    for entry in read_dir {
+        let entry = entry.map_err(|source| WithWatchError::Metadata {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        let entry_path = entry.path();
+        let child_metadata =
+            fs::metadata(&entry_path).map_err(|source| WithWatchError::Metadata {
+                path: entry_path.clone(),
+                source,
+            })?;
+        insert_existing_entry(&entry_path, &child_metadata, snapshot_mode, mode, entries)?;
     }
 
     Ok(())
@@ -286,25 +392,19 @@ fn capture_glob_input(
 
 fn insert_existing_entry(
     path: &Path,
+    metadata: &fs::Metadata,
+    snapshot_mode: PathSnapshotMode,
     mode: ChangeDetectionMode,
     entries: &mut BTreeMap<PathBuf, SnapshotEntry>,
 ) -> Result<()> {
-    let metadata = fs::metadata(path).map_err(|source| WithWatchError::Metadata {
-        path: path.to_path_buf(),
-        source,
-    })?;
-
     let kind = if metadata.is_dir() {
         SnapshotEntryKind::Directory
     } else {
         SnapshotEntryKind::File
     };
-    let modified = metadata.modified().ok();
-    let digest = if mode == ChangeDetectionMode::ContentHash && kind == SnapshotEntryKind::File {
-        Some(hash_file(path)?)
-    } else {
-        None
-    };
+    let modified = snapshot_entry_modified(kind, metadata);
+    let size = snapshot_entry_size(kind, metadata);
+    let digest = snapshot_digest(path, kind, modified, size, snapshot_mode, mode)?;
 
     entries.insert(
         path.to_path_buf(),
@@ -316,6 +416,78 @@ fn insert_existing_entry(
     );
 
     Ok(())
+}
+
+fn insert_missing_entry(
+    path: &Path,
+    snapshot_mode: PathSnapshotMode,
+    mode: ChangeDetectionMode,
+    entries: &mut BTreeMap<PathBuf, SnapshotEntry>,
+) {
+    let digest = if mode == ChangeDetectionMode::ContentHash {
+        Some(hash_metadata_tuple(
+            SnapshotEntryKind::Missing,
+            None,
+            None,
+            snapshot_mode,
+        ))
+    } else {
+        None
+    };
+
+    entries.insert(
+        path.to_path_buf(),
+        SnapshotEntry {
+            kind: SnapshotEntryKind::Missing,
+            modified: None,
+            digest,
+        },
+    );
+}
+
+fn snapshot_entry_size(kind: SnapshotEntryKind, metadata: &fs::Metadata) -> Option<u64> {
+    match kind {
+        SnapshotEntryKind::File => Some(metadata.len()),
+        SnapshotEntryKind::Directory | SnapshotEntryKind::Missing => None,
+    }
+}
+
+fn snapshot_entry_modified(kind: SnapshotEntryKind, metadata: &fs::Metadata) -> Option<SystemTime> {
+    match kind {
+        SnapshotEntryKind::File => metadata.modified().ok(),
+        SnapshotEntryKind::Directory | SnapshotEntryKind::Missing => None,
+    }
+}
+
+fn snapshot_digest(
+    path: &Path,
+    kind: SnapshotEntryKind,
+    modified: Option<SystemTime>,
+    size: Option<u64>,
+    snapshot_mode: PathSnapshotMode,
+    mode: ChangeDetectionMode,
+) -> Result<Option<blake3::Hash>> {
+    if mode != ChangeDetectionMode::ContentHash {
+        return Ok(None);
+    }
+
+    match snapshot_mode {
+        PathSnapshotMode::ContentPath | PathSnapshotMode::ContentTree => {
+            if kind == SnapshotEntryKind::File {
+                Ok(Some(hash_file(path)?))
+            } else {
+                Ok(None)
+            }
+        }
+        PathSnapshotMode::MetadataPath
+        | PathSnapshotMode::MetadataChildren
+        | PathSnapshotMode::MetadataTree => Ok(Some(hash_metadata_tuple(
+            kind,
+            modified,
+            size,
+            snapshot_mode,
+        ))),
+    }
 }
 
 fn hash_file(path: &Path) -> Result<blake3::Hash> {
@@ -342,7 +514,55 @@ fn hash_file(path: &Path) -> Result<blake3::Hash> {
     Ok(hasher.finalize())
 }
 
-fn absolutize(raw: &str, cwd: &Path) -> PathBuf {
+fn hash_metadata_tuple(
+    kind: SnapshotEntryKind,
+    modified: Option<SystemTime>,
+    size: Option<u64>,
+    snapshot_mode: PathSnapshotMode,
+) -> blake3::Hash {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(snapshot_mode.as_str().as_bytes());
+    hasher.update(kind.to_string().as_bytes());
+
+    if let Some(modified) = modified {
+        let (sign, duration) = if let Ok(duration) = modified.duration_since(UNIX_EPOCH) {
+            (0u8, duration)
+        } else {
+            (
+                1u8,
+                UNIX_EPOCH
+                    .duration_since(modified)
+                    .unwrap_or(Duration::ZERO),
+            )
+        };
+        hasher.update(&[sign]);
+        hasher.update(&duration.as_secs().to_le_bytes());
+        hasher.update(&duration.subsec_nanos().to_le_bytes());
+    } else {
+        hasher.update(&[2u8]);
+    }
+
+    match size {
+        Some(size) => {
+            hasher.update(&[1u8]);
+            hasher.update(&size.to_le_bytes());
+        }
+        None => {
+            hasher.update(&[0u8]);
+        }
+    }
+
+    hasher.finalize()
+}
+
+fn default_path_snapshot_mode(path: &Path) -> PathSnapshotMode {
+    match fs::metadata(path) {
+        Ok(metadata) if metadata.is_dir() => PathSnapshotMode::ContentTree,
+        Ok(_) | Err(_) => PathSnapshotMode::ContentPath,
+    }
+}
+
+pub(crate) fn absolutize(raw: &str, cwd: &Path) -> PathBuf {
     let expanded = expand_tilde(raw);
     let path = PathBuf::from(expanded);
     if path.is_absolute() {
@@ -421,7 +641,8 @@ mod tests {
     use std::{fs, thread, time::Duration};
 
     use super::{
-        capture_snapshot, ChangeDetectionMode, SnapshotEntryKind, WatchInput, WatchInputKind,
+        capture_snapshot, ChangeDetectionMode, PathSnapshotMode, SnapshotEntryKind, WatchInput,
+        WatchInputKind,
     };
 
     #[test]
@@ -516,5 +737,78 @@ mod tests {
         assert_eq!(snapshot.len(), 1);
         let entry = snapshot.entries.values().next().expect("snapshot entry");
         assert_eq!(entry.kind, SnapshotEntryKind::Missing);
+    }
+
+    #[test]
+    fn metadata_children_excludes_nested_descendants() {
+        let temp_dir = tempfile::tempdir().expect("create tempdir");
+        let root = temp_dir.path().join("root");
+        fs::create_dir_all(root.join("nested")).expect("create nested dir");
+        fs::write(root.join("direct.txt"), "alpha").expect("write direct child");
+        fs::write(root.join("nested").join("deep.txt"), "beta").expect("write nested child");
+
+        let input =
+            metadata_path_input(temp_dir.path(), "root", PathSnapshotMode::MetadataChildren);
+        let snapshot =
+            capture_snapshot(&[input], ChangeDetectionMode::ContentHash).expect("capture snapshot");
+
+        assert!(snapshot.entries.contains_key(&root));
+        assert!(snapshot.entries.contains_key(&root.join("direct.txt")));
+        assert!(snapshot.entries.contains_key(&root.join("nested")));
+        assert!(!snapshot
+            .entries
+            .contains_key(&root.join("nested").join("deep.txt")));
+    }
+
+    #[test]
+    fn metadata_tree_includes_nested_descendants() {
+        let temp_dir = tempfile::tempdir().expect("create tempdir");
+        let root = temp_dir.path().join("root");
+        fs::create_dir_all(root.join("nested")).expect("create nested dir");
+        fs::write(root.join("nested").join("deep.txt"), "beta").expect("write nested child");
+
+        let input = metadata_path_input(temp_dir.path(), "root", PathSnapshotMode::MetadataTree);
+        let snapshot =
+            capture_snapshot(&[input], ChangeDetectionMode::ContentHash).expect("capture snapshot");
+
+        assert!(snapshot.entries.contains_key(&root));
+        assert!(snapshot.entries.contains_key(&root.join("nested")));
+        assert!(snapshot
+            .entries
+            .contains_key(&root.join("nested").join("deep.txt")));
+    }
+
+    #[test]
+    fn metadata_listing_hash_mode_tracks_metadata_without_file_content_hashing() {
+        let temp_dir = tempfile::tempdir().expect("create tempdir");
+        let root = temp_dir.path().join("root");
+        fs::create_dir_all(&root).expect("create root");
+        let file_path = root.join("file.txt");
+        fs::write(&file_path, "hello").expect("write file");
+
+        let input =
+            metadata_path_input(temp_dir.path(), "root", PathSnapshotMode::MetadataChildren);
+        let first = capture_snapshot(
+            std::slice::from_ref(&input),
+            ChangeDetectionMode::ContentHash,
+        )
+        .expect("first snapshot");
+
+        thread::sleep(Duration::from_millis(20));
+        fs::write(&file_path, "hello").expect("rewrite same content");
+
+        let second =
+            capture_snapshot(&[input], ChangeDetectionMode::ContentHash).expect("second snapshot");
+
+        assert!(second.is_meaningfully_different(&first, ChangeDetectionMode::ContentHash));
+    }
+
+    fn metadata_path_input(
+        cwd: &std::path::Path,
+        raw: &str,
+        snapshot_mode: PathSnapshotMode,
+    ) -> WatchInput {
+        WatchInput::path_with_snapshot_mode(raw, cwd, WatchInputKind::Explicit, snapshot_mode)
+            .expect("metadata path input")
     }
 }

--- a/crates/with-watch/tests/cli.rs
+++ b/crates/with-watch/tests/cli.rs
@@ -84,6 +84,127 @@ fn pathless_allowlist_command_runs_once_with_test_hook() {
 
 #[cfg(unix)]
 #[test]
+fn ls_reruns_when_an_immediate_child_changes() {
+    let temp_dir = tempfile::tempdir().expect("create tempdir");
+    let watch_dir = temp_dir.path().join("watch");
+    let marker_dir = temp_dir.path().join("aux").join("markers");
+    fs::create_dir_all(&watch_dir).expect("create watch dir");
+
+    let mut child = ProcessCommand::new(assert_cmd::cargo::cargo_bin!("with-watch"))
+        .current_dir(&watch_dir)
+        .env("WITH_WATCH_TEST_MAX_RUNS", "2")
+        .env("WITH_WATCH_TEST_DEBOUNCE_MS", "25")
+        .env("WITH_WATCH_TEST_RUN_MARKER_DIR", &marker_dir)
+        .arg("ls")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn with-watch");
+
+    wait_for_path(&marker_dir.join("run-1.done"));
+    assert!(child.try_wait().expect("poll child").is_none());
+
+    fs::write(watch_dir.join("created.txt"), "alpha\n").expect("write immediate child");
+    wait_for_path(&marker_dir.join("run-2.done"));
+
+    let status = wait_for_child_exit(&mut child, Duration::from_secs(10));
+    assert!(status.success());
+}
+
+#[cfg(unix)]
+#[test]
+fn ls_does_not_rerun_for_nested_descendant_changes() {
+    let temp_dir = tempfile::tempdir().expect("create tempdir");
+    let watch_dir = temp_dir.path().join("watch");
+    let marker_dir = temp_dir.path().join("aux").join("markers");
+    let subdir = watch_dir.join("subdir");
+    fs::create_dir_all(&subdir).expect("create subdir");
+
+    let mut child = ProcessCommand::new(assert_cmd::cargo::cargo_bin!("with-watch"))
+        .current_dir(&watch_dir)
+        .env("WITH_WATCH_TEST_MAX_RUNS", "2")
+        .env("WITH_WATCH_TEST_DEBOUNCE_MS", "25")
+        .env("WITH_WATCH_TEST_RUN_MARKER_DIR", &marker_dir)
+        .arg("ls")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn with-watch");
+
+    wait_for_path(&marker_dir.join("run-1.done"));
+    fs::write(subdir.join("nested.txt"), "alpha\n").expect("write nested file");
+
+    assert_path_stays_absent(&marker_dir.join("run-2.done"), Duration::from_millis(300));
+    assert!(child.try_wait().expect("poll child").is_none());
+
+    child.kill().expect("kill child");
+    child.wait().expect("wait for child");
+}
+
+#[cfg(unix)]
+#[test]
+fn ls_recursive_reruns_for_nested_descendant_changes() {
+    let temp_dir = tempfile::tempdir().expect("create tempdir");
+    let watch_dir = temp_dir.path().join("watch");
+    let marker_dir = temp_dir.path().join("aux").join("markers");
+    let subdir = watch_dir.join("subdir");
+    fs::create_dir_all(&subdir).expect("create subdir");
+
+    let mut child = ProcessCommand::new(assert_cmd::cargo::cargo_bin!("with-watch"))
+        .current_dir(&watch_dir)
+        .env("WITH_WATCH_TEST_MAX_RUNS", "2")
+        .env("WITH_WATCH_TEST_DEBOUNCE_MS", "25")
+        .env("WITH_WATCH_TEST_RUN_MARKER_DIR", &marker_dir)
+        .args(["ls", "-R"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn with-watch");
+
+    wait_for_path(&marker_dir.join("run-1.done"));
+    fs::write(subdir.join("nested.txt"), "alpha\n").expect("write nested file");
+    wait_for_path(&marker_dir.join("run-2.done"));
+
+    let status = wait_for_child_exit(&mut child, Duration::from_secs(10));
+    assert!(status.success());
+}
+
+#[cfg(unix)]
+#[test]
+fn ls_directory_mode_does_not_rerun_for_directory_contents_changes() {
+    let temp_dir = tempfile::tempdir().expect("create tempdir");
+    let root_dir = temp_dir.path().join("root");
+    let marker_dir = temp_dir.path().join("aux").join("markers");
+    let listed_dir = root_dir.join("dir");
+    fs::create_dir_all(&listed_dir).expect("create listed dir");
+
+    let mut child = ProcessCommand::new(assert_cmd::cargo::cargo_bin!("with-watch"))
+        .current_dir(&root_dir)
+        .env("WITH_WATCH_TEST_MAX_RUNS", "2")
+        .env("WITH_WATCH_TEST_DEBOUNCE_MS", "25")
+        .env("WITH_WATCH_TEST_RUN_MARKER_DIR", &marker_dir)
+        .args(["ls", "-d", "dir"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn with-watch");
+
+    wait_for_path(&marker_dir.join("run-1.done"));
+    fs::write(listed_dir.join("child.txt"), "alpha\n").expect("write nested child");
+
+    assert_path_stays_absent(&marker_dir.join("run-2.done"), Duration::from_millis(300));
+    assert!(child.try_wait().expect("poll child").is_none());
+
+    child.kill().expect("kill child");
+    child.wait().expect("wait for child");
+}
+
+#[cfg(unix)]
+#[test]
 fn shell_mode_supports_operators_and_exits_after_one_run_with_test_hook() {
     let temp_dir = tempfile::tempdir().expect("create tempdir");
     let input_path = temp_dir.path().join("input.txt");
@@ -286,6 +407,15 @@ fn wait_for_path(path: &Path) {
         thread::sleep(Duration::from_millis(25));
     }
     panic!("timed out waiting for {}", path.display());
+}
+
+#[cfg(unix)]
+fn assert_path_stays_absent(path: &Path, duration: Duration) {
+    let deadline = std::time::Instant::now() + duration;
+    while std::time::Instant::now() < deadline {
+        assert!(!path.exists(), "expected {} to stay absent", path.display());
+        thread::sleep(Duration::from_millis(25));
+    }
 }
 
 #[cfg(unix)]

--- a/docs/crates-with-watch-foundation.md
+++ b/docs/crates-with-watch-foundation.md
@@ -25,16 +25,19 @@
 - Publish tag naming must remain `with-watch@v<version>`.
 - Stable internal enums must remain aligned with the current v1 contract:
   - `ChangeDetectionMode::{ContentHash, MtimeOnly}`
-- `CommandSource::{Argv, Shell, Exec}`
-- `CommandAnalysisStatus::{Resolved, NoInputs, AmbiguousFallback}`
-- `CommandAdapterId` adapter categories used for built-in inference
-- `SideEffectProfile::{ReadOnly, WritesExcludedOutputs, WritesWatchedInputs}`
-- `WatchInput::{Path, Glob}`
-- `SnapshotEntryKind::{File, Directory, Missing}`
+  - `CommandSource::{Argv, Shell, Exec}`
+  - `CommandAnalysisStatus::{Resolved, NoInputs, AmbiguousFallback}`
+  - `CommandAdapterId` adapter categories used for built-in inference
+  - `SideEffectProfile::{ReadOnly, WritesExcludedOutputs, WritesWatchedInputs}`
+  - `PathSnapshotMode::{ContentPath, ContentTree, MetadataPath, MetadataChildren, MetadataTree}`
+  - `WatchInput::{Path, Glob}`
+  - `SnapshotEntryKind::{File, Directory, Missing}`
 - Shell mode must parse command-line expressions with `&&`, `||`, and `|`, while shell control-flow constructs remain out of scope for v1.
 - Shell redirects must treat `<` and `<>` targets as watched inputs and `>`, `>>`, `&>`, `&>>`, and `>|` targets as filtered outputs.
 - Generic watch planning must use adapter-driven inference for built-in command families and a conservative fallback for unknown tools.
 - Safe pathless `.` defaults are limited to `ls`, `dir`, `vdir`, `du`, and `find`.
+- `ls`, `dir`, and `vdir` must use metadata listing snapshots so the first run does not recurse through large trees before spawning the delegated command.
+- Plain `ls`/`dir`/`vdir` directory operands must watch only the named directory plus immediate children, `-R` must switch them to recursive metadata tree snapshots, and `-d`/`--directory` must watch only the named path entry.
 - Built-in inference must exclude known outputs, scripts, inline patterns, and opaque fallback operands from the watch set.
 - Wrapper commands (`env`, `nice`, `nohup`, `stdbuf`, and `timeout`) must unwrap to the delegated command before adapter selection.
 - `exec --input` remains the canonical explicit input contract when inference is insufficient, but command-side side-effect metadata may still be inferred for rerun suppression and logging.
@@ -55,7 +58,7 @@
 
 ## Logging
 - Use structured `tracing` logs for command planning, watcher setup, snapshot capture, debounce decisions, and rerun causes.
-- Logs must include `command_source`, `detection_mode`, input counts, `adapter_id`, `fallback_used`, `default_watch_root_used`, `filtered_output_count`, `side_effect_profile`, and rerun suppression outcomes.
+- Logs must include `command_source`, `detection_mode`, input counts, `adapter_id`, `fallback_used`, `default_watch_root_used`, `filtered_output_count`, `side_effect_profile`, snapshot modes, snapshot entry counts, snapshot capture elapsed time, and rerun suppression outcomes.
 
 ## Build and Test
 - Local validation: `cargo test -p with-watch`

--- a/docs/project-with-watch.md
+++ b/docs/project-with-watch.md
@@ -21,6 +21,7 @@ Provide a Rust-based CLI wrapper that reruns delegated shell utilities and arbit
 - `exec --input` reruns the delegated command unchanged and must not inject changed paths into argv or environment variables.
 - Commands without safe inferred filesystem inputs must fail clearly and direct operators to `with-watch exec --input ...`.
 - Passthrough and shell modes must use adapter-driven input inference that excludes known outputs, scripts, and pattern operands from the watch set.
+- `ls`, `dir`, and `vdir` must use metadata listing snapshots instead of recursive file-content hashing: the default watch scope is immediate children, `-R` stays recursive, and `-d` watches only the named path.
 - Shell redirects must treat `<` and `<>` targets as watched inputs and `>`, `>>`, `&>`, `&>>`, and `>|` targets as filtered outputs.
 - Shell parsing support is limited to command-line expressions plus `&&`, `||`, and `|`; broader shell control-flow stays out of scope until documented otherwise.
 - Safe pathless default watch roots are limited to the built-in allowlist (`ls`, `dir`, `vdir`, `du`, and `find`).


### PR DESCRIPTION
## Summary
- switch `ls`/`dir`/`vdir` to metadata-based listing snapshots so the first run does not recurse through large trees before spawning
- keep `ls -R` recursive, keep `ls -d` scoped to the named path, and add snapshot timing/mode debug logs
- add regression coverage for ls listing behavior and update with-watch docs/contracts

## Testing
- cargo test
- manual check in `/Users/kdy1/projects/cloud`: `with-watch ls` now prints immediately with `snapshot_modes="metadata-children"`