### PR TITLE
chore(with-watch): add --clear terminal refresh mode

### DIFF
--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -44,6 +44,7 @@
 
 - Keep passthrough, shell, and `exec --input` command shapes stable and documented in `docs/project-with-watch.md` and `docs/crates-with-watch-foundation.md`.
 - Keep default rerun filtering content-hash-based, with `--no-hash` as the documented metadata-only override.
+- Keep `--clear` as a best-effort TTY-only output refresh flag; redirected or piped stdout must stay byte-for-byte clean.
 - Keep shell support scoped to command-line expressions and do not silently broaden into shell-script control-flow without updating docs first.
 - Keep logs sufficient to explain inferred inputs, watcher anchors, snapshot counts, and rerun causes.
 - Keep public release contracts aligned across root publish-tag allowlist, `.github/workflows/release-with-watch.yml`, and Homebrew packaging assets.

--- a/crates/with-watch/README.md
+++ b/crates/with-watch/README.md
@@ -19,9 +19,11 @@ brew install delinoio/tap/with-watch
 
 ## Command modes
 
-- Passthrough mode: `with-watch [--no-hash] <utility> [args...]`
-- Shell mode: `with-watch [--no-hash] --shell '<expr>'`
-- Explicit-input mode: `with-watch exec [--no-hash] --input <glob>... -- <command> [args...]`
+- Passthrough mode: `with-watch [--no-hash] [--clear] <utility> [args...]`
+- Shell mode: `with-watch [--no-hash] [--clear] --shell '<expr>'`
+- Explicit-input mode: `with-watch exec [--no-hash] [--clear] --input <glob>... -- <command> [args...]`
+
+All modes also accept `--clear`, which clears the terminal before the initial run and each rerun when stdout is an interactive terminal.
 
 Use passthrough mode for a single delegated command, shell mode for simple command-line expressions that need `&&`, `||`, or `|`, and `exec --input` when you want to declare the watched files yourself.
 
@@ -29,6 +31,7 @@ Use passthrough mode for a single delegated command, shell mode for simple comma
 
 ```sh
 with-watch cat input.txt
+with-watch --clear cat input.txt
 with-watch cp src.txt dest.txt
 with-watch ls -l
 with-watch --shell 'cat src.txt | grep hello'
@@ -104,6 +107,7 @@ with-watch exec --input 'src/**/*.rs' -- cargo test -p with-watch
 ## Rerun behavior
 
 - `with-watch` always performs one initial run after it has inferred inputs and armed the watcher, even before any external filesystem change occurs.
+- `--clear` clears stdout before the initial run and each rerun only when stdout is a terminal; redirected and piped output remain unchanged.
 - The default rerun filter compares content hashes, which avoids reruns from metadata churn alone.
 - `ls`, `dir`, and `vdir` use metadata-based listing snapshots instead of hashing every file under the watched directory before the first run.
 - `--no-hash` switches the filter to metadata-only comparison.

--- a/crates/with-watch/src/analysis.rs
+++ b/crates/with-watch/src/analysis.rs
@@ -494,15 +494,15 @@ pub fn render_after_long_help() -> String {
     let inventory = help_inventory();
 
     format!(
-        "Command modes:\n  Passthrough: with-watch [--no-hash] <utility> [args...]\n  Shell: \
-         with-watch [--no-hash] --shell '<expr>'\n  Explicit inputs: with-watch exec [--no-hash] \
-         --input <glob>... -- <command> [args...]\n\nWrapper commands:\n  {}\n\nDedicated \
-         built-in adapters and aliases:\n  {}\n\nGeneric read-path commands:\n  {}\n\nSafe \
-         current-directory defaults:\n  {}\n\nRecognized but not auto-watchable commands:\n  {}\n  \
-         These commands are recognized, but they do not expose stable filesystem inputs on their \
-         own.\n\nexec --input escape hatch:\n  Use `with-watch exec --input <glob>... -- \
-         <command> [args...]` when inference is ambiguous, when a command has no stable \
-         filesystem inputs, or when you want an explicit watch set.",
+        "Command modes:\n  Passthrough: with-watch [--no-hash] [--clear] <utility> [args...]\n  \
+         Shell: with-watch [--no-hash] [--clear] --shell '<expr>'\n  Explicit inputs: with-watch \
+         exec [--no-hash] [--clear] --input <glob>... -- <command> [args...]\n\nWrapper \
+         commands:\n  {}\n\nDedicated built-in adapters and aliases:\n  {}\n\nGeneric read-path \
+         commands:\n  {}\n\nSafe current-directory defaults:\n  {}\n\nRecognized but not \
+         auto-watchable commands:\n  {}\n  These commands are recognized, but they do not expose \
+         stable filesystem inputs on their own.\n\nexec --input escape hatch:\n  Use `with-watch \
+         exec --input <glob>... -- <command> [args...]` when inference is ambiguous, when a \
+         command has no stable filesystem inputs, or when you want an explicit watch set.",
         join_command_names(&inventory.wrapper_commands),
         join_command_names(&inventory.dedicated_built_ins),
         join_command_names(inventory.generic_read_path_commands),

--- a/crates/with-watch/src/cli.rs
+++ b/crates/with-watch/src/cli.rs
@@ -5,6 +5,7 @@ use clap::{Args, CommandFactory, FromArgMatches, Parser, Subcommand};
 use crate::{
     analysis::render_after_long_help,
     error::{Result, WithWatchError},
+    runner::OutputRefreshMode,
     snapshot::ChangeDetectionMode,
 };
 
@@ -18,6 +19,10 @@ pub struct Cli {
     /// Disable content hashing and compare only file metadata.
     #[arg(long, global = true)]
     pub no_hash: bool,
+
+    /// Clear the terminal before the initial run and each rerun.
+    #[arg(long, global = true)]
+    pub clear: bool,
 
     /// Run a quoted shell command line that may contain `&&`, `||`, or `|`.
     #[arg(long, global = true, value_name = "EXPR")]
@@ -78,6 +83,14 @@ impl Cli {
         }
     }
 
+    pub fn output_refresh_mode(&self) -> OutputRefreshMode {
+        if self.clear {
+            OutputRefreshMode::ClearTerminal
+        } else {
+            OutputRefreshMode::Preserve
+        }
+    }
+
     pub fn command_mode(&self) -> Result<CommandMode> {
         match (&self.shell, &self.command) {
             (Some(_), Some(_)) => Err(WithWatchError::ConflictingModes),
@@ -115,7 +128,7 @@ mod tests {
     use clap::Parser;
 
     use super::{Cli, CommandMode};
-    use crate::{error::WithWatchError, snapshot::ChangeDetectionMode};
+    use crate::{error::WithWatchError, runner::OutputRefreshMode, snapshot::ChangeDetectionMode};
 
     #[test]
     fn passthrough_mode_preserves_external_subcommand_arguments() {
@@ -140,6 +153,42 @@ mod tests {
             .expect_err("expected error");
 
         assert!(matches!(error, WithWatchError::ConflictingModes));
+    }
+
+    #[test]
+    fn passthrough_mode_accepts_clear_flag() {
+        let cli = Cli::parse_from(["with-watch", "--clear", "cat", "input.txt"]);
+        let mode = cli.command_mode().expect("command mode");
+
+        assert_eq!(cli.output_refresh_mode(), OutputRefreshMode::ClearTerminal);
+        assert!(matches!(mode, CommandMode::Passthrough { .. }));
+    }
+
+    #[test]
+    fn shell_mode_accepts_clear_flag() {
+        let cli = Cli::parse_from(["with-watch", "--clear", "--shell", "cat input.txt"]);
+        let mode = cli.command_mode().expect("command mode");
+
+        assert_eq!(cli.output_refresh_mode(), OutputRefreshMode::ClearTerminal);
+        assert!(matches!(mode, CommandMode::Shell { .. }));
+    }
+
+    #[test]
+    fn exec_mode_accepts_clear_flag() {
+        let cli = Cli::parse_from([
+            "with-watch",
+            "exec",
+            "--clear",
+            "--input",
+            "src/**/*.rs",
+            "--",
+            "cargo",
+            "test",
+        ]);
+        let mode = cli.command_mode().expect("command mode");
+
+        assert_eq!(cli.output_refresh_mode(), OutputRefreshMode::ClearTerminal);
+        assert!(matches!(mode, CommandMode::Exec { .. }));
     }
 
     #[test]
@@ -177,7 +226,9 @@ mod tests {
 
         assert!(!short_help.contains("Wrapper commands:"));
         assert!(!short_help.contains("Recognized but not auto-watchable commands:"));
+        assert!(short_help.contains("--clear"));
         assert!(long_help.contains("Wrapper commands:"));
         assert!(long_help.contains("Recognized but not auto-watchable commands:"));
+        assert!(long_help.contains("--clear"));
     }
 }

--- a/crates/with-watch/src/error.rs
+++ b/crates/with-watch/src/error.rs
@@ -64,6 +64,8 @@ pub enum WithWatchError {
         #[source]
         source: io::Error,
     },
+    #[error("Failed to refresh stdout before running the delegated command: {0}")]
+    StdoutRefresh(#[source] io::Error),
     #[error("`--shell` execution is only supported on Unix-like platforms.")]
     UnsupportedShellPlatform,
 }
@@ -87,7 +89,8 @@ impl WithWatchError {
             | Self::WatcherCreate(_)
             | Self::WatchPath { .. }
             | Self::Spawn { .. }
-            | Self::Wait { .. } => 1,
+            | Self::Wait { .. }
+            | Self::StdoutRefresh(_) => 1,
         }
     }
 }

--- a/crates/with-watch/src/lib.rs
+++ b/crates/with-watch/src/lib.rs
@@ -13,7 +13,7 @@ use analysis::{analyze_argv, analyze_shell_expression, CommandAnalysis, CommandA
 use cli::{Cli, CommandMode};
 use error::{Result, WithWatchError};
 use parser::parse_shell_expression;
-use runner::{ExecutionMetadata, ExecutionPlan, RunnerOptions};
+use runner::{ExecutionMetadata, ExecutionPlan, OutputRefreshMode, RunnerOptions};
 use snapshot::{ChangeDetectionMode, WatchInput, WatchInputKind};
 use tracing::debug;
 
@@ -21,13 +21,15 @@ pub fn run_cli(cli: Cli, options: RunnerOptions) -> Result<i32> {
     let mode = cli.command_mode()?;
     let cwd = std::env::current_dir().map_err(WithWatchError::CurrentDirectory)?;
     let detection_mode = cli.change_detection_mode();
-    let plan = build_execution_plan(mode, detection_mode, &cwd)?;
+    let output_refresh_mode = cli.output_refresh_mode();
+    let plan = build_execution_plan(mode, detection_mode, output_refresh_mode, &cwd)?;
     runner::run(plan, options)
 }
 
 fn build_execution_plan(
     mode: CommandMode,
     detection_mode: ChangeDetectionMode,
+    output_refresh_mode: OutputRefreshMode,
     cwd: &Path,
 ) -> Result<ExecutionPlan> {
     match mode {
@@ -39,6 +41,7 @@ fn build_execution_plan(
                 argv,
                 inputs,
                 detection_mode,
+                output_refresh_mode,
                 execution_metadata(&analysis),
             ))
         }
@@ -51,6 +54,7 @@ fn build_execution_plan(
                 expression,
                 inputs,
                 detection_mode,
+                output_refresh_mode,
                 execution_metadata(&analysis),
             ))
         }
@@ -62,6 +66,7 @@ fn build_execution_plan(
                 argv,
                 planned_inputs,
                 detection_mode,
+                output_refresh_mode,
                 execution_metadata(&analysis),
             ))
         }

--- a/crates/with-watch/src/runner.rs
+++ b/crates/with-watch/src/runner.rs
@@ -1,6 +1,7 @@
 use std::{
     ffi::OsString,
     fs,
+    io::{self, IsTerminal, Write},
     path::PathBuf,
     process::{Child, Command, ExitStatus, Stdio},
     thread,
@@ -18,12 +19,29 @@ use crate::{
 
 const DEFAULT_POLL_TIMEOUT: Duration = Duration::from_millis(50);
 const DEFAULT_DEBOUNCE_WINDOW: Duration = Duration::from_millis(200);
+const CLEAR_TERMINAL_SEQUENCE: &str = "\x1b[2J\x1b[H";
 const WITH_WATCH_TEST_RUN_MARKER_DIR_ENV: &str = "WITH_WATCH_TEST_RUN_MARKER_DIR";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputRefreshMode {
+    Preserve,
+    ClearTerminal,
+}
+
+impl OutputRefreshMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Preserve => "preserve",
+            Self::ClearTerminal => "clear-terminal",
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct ExecutionPlan {
     pub source: CommandSource,
     pub detection_mode: ChangeDetectionMode,
+    pub output_refresh_mode: OutputRefreshMode,
     pub inputs: Vec<WatchInput>,
     pub delegated_command: DelegatedCommand,
     pub metadata: ExecutionMetadata,
@@ -34,11 +52,13 @@ impl ExecutionPlan {
         argv: Vec<OsString>,
         inputs: Vec<WatchInput>,
         detection_mode: ChangeDetectionMode,
+        output_refresh_mode: OutputRefreshMode,
         metadata: ExecutionMetadata,
     ) -> Self {
         Self {
             source: CommandSource::Argv,
             detection_mode,
+            output_refresh_mode,
             inputs,
             delegated_command: DelegatedCommand::Argv(argv),
             metadata,
@@ -49,11 +69,13 @@ impl ExecutionPlan {
         expression: String,
         inputs: Vec<WatchInput>,
         detection_mode: ChangeDetectionMode,
+        output_refresh_mode: OutputRefreshMode,
         metadata: ExecutionMetadata,
     ) -> Self {
         Self {
             source: CommandSource::Shell,
             detection_mode,
+            output_refresh_mode,
             inputs,
             delegated_command: DelegatedCommand::Shell(expression),
             metadata,
@@ -64,11 +86,13 @@ impl ExecutionPlan {
         argv: Vec<OsString>,
         inputs: Vec<WatchInput>,
         detection_mode: ChangeDetectionMode,
+        output_refresh_mode: OutputRefreshMode,
         metadata: ExecutionMetadata,
     ) -> Self {
         Self {
             source: CommandSource::Exec,
             detection_mode,
+            output_refresh_mode,
             inputs,
             delegated_command: DelegatedCommand::Argv(argv),
             metadata,
@@ -191,7 +215,10 @@ pub fn run(plan: ExecutionPlan, options: RunnerOptions) -> Result<i32> {
     // v1 contract: after inference, watcher setup, and baseline capture succeed,
     // the delegated command must run immediately once before waiting for any
     // filesystem change events.
-    let mut child = Some(spawn_command(&plan.delegated_command)?);
+    let mut child = Some(spawn_command(
+        &plan.delegated_command,
+        plan.output_refresh_mode,
+    )?);
     let mut completed_runs = 0usize;
     let mut pending_rerun = false;
     let mut suppressed_self_change_snapshot = None::<SnapshotState>;
@@ -199,6 +226,7 @@ pub fn run(plan: ExecutionPlan, options: RunnerOptions) -> Result<i32> {
     info!(
         command_source = plan.source.as_str(),
         detection_mode = plan.detection_mode.as_str(),
+        output_refresh_mode = plan.output_refresh_mode.as_str(),
         input_count = plan.inputs.len(),
         adapter_id = plan.metadata.adapter_field(),
         fallback_used = plan.metadata.fallback_used,
@@ -289,7 +317,10 @@ pub fn run(plan: ExecutionPlan, options: RunnerOptions) -> Result<i32> {
                 }
 
                 if should_rerun {
-                    child = Some(spawn_command(&plan.delegated_command)?);
+                    child = Some(spawn_command(
+                        &plan.delegated_command,
+                        plan.output_refresh_mode,
+                    )?);
                     continue;
                 }
             }
@@ -336,7 +367,10 @@ pub fn run(plan: ExecutionPlan, options: RunnerOptions) -> Result<i32> {
                     }
                 } else {
                     baseline = current_snapshot;
-                    child = Some(spawn_command(&plan.delegated_command)?);
+                    child = Some(spawn_command(
+                        &plan.delegated_command,
+                        plan.output_refresh_mode,
+                    )?);
                 }
             } else if child.is_some() {
                 debug!(
@@ -401,12 +435,45 @@ fn handle_watch_events(events: &CollectedEvents) {
     }
 }
 
-fn spawn_command(command: &DelegatedCommand) -> Result<Child> {
+fn spawn_command(
+    command: &DelegatedCommand,
+    output_refresh_mode: OutputRefreshMode,
+) -> Result<Child> {
+    prepare_output_for_run(output_refresh_mode)?;
     log_delegated_command_spawn(command);
     match command {
         DelegatedCommand::Argv(argv) => spawn_argv(argv),
         DelegatedCommand::Shell(expression) => spawn_shell(expression),
     }
+}
+
+fn prepare_output_for_run(output_refresh_mode: OutputRefreshMode) -> Result<()> {
+    let mut stdout = std::io::stdout();
+    let stdout_is_terminal = stdout.is_terminal();
+    let terminal_cleared =
+        refresh_output_before_run(output_refresh_mode, stdout_is_terminal, &mut stdout)
+            .map_err(WithWatchError::StdoutRefresh)?;
+
+    debug!(
+        output_refresh_mode = output_refresh_mode.as_str(),
+        stdout_is_terminal, terminal_cleared, "Prepared stdout for delegated command"
+    );
+
+    Ok(())
+}
+
+fn refresh_output_before_run<W: Write>(
+    output_refresh_mode: OutputRefreshMode,
+    stdout_is_terminal: bool,
+    output: &mut W,
+) -> io::Result<bool> {
+    if output_refresh_mode != OutputRefreshMode::ClearTerminal || !stdout_is_terminal {
+        return Ok(false);
+    }
+
+    output.write_all(CLEAR_TERMINAL_SEQUENCE.as_bytes())?;
+    output.flush()?;
+    Ok(true)
 }
 
 fn log_delegated_command_spawn(command: &DelegatedCommand) {
@@ -508,7 +575,10 @@ mod tests {
 
     use tracing::Level;
 
-    use super::{log_delegated_command_spawn, DelegatedCommand};
+    use super::{
+        log_delegated_command_spawn, refresh_output_before_run, DelegatedCommand,
+        OutputRefreshMode, CLEAR_TERMINAL_SEQUENCE,
+    };
 
     #[test]
     fn argv_spawn_logging_omits_argument_values() {
@@ -542,6 +612,44 @@ mod tests {
         assert!(!output.contains("patterns.txt"));
     }
 
+    #[test]
+    fn clear_refresh_mode_writes_escape_sequence_and_flushes_for_terminals() {
+        let mut writer = FlushTrackingWriter::default();
+
+        let cleared =
+            refresh_output_before_run(OutputRefreshMode::ClearTerminal, true, &mut writer)
+                .expect("clear terminal output");
+
+        assert!(cleared);
+        assert_eq!(writer.buffer, CLEAR_TERMINAL_SEQUENCE.as_bytes());
+        assert_eq!(writer.flush_count, 1);
+    }
+
+    #[test]
+    fn preserve_refresh_mode_does_not_write_escape_sequence() {
+        let mut writer = FlushTrackingWriter::default();
+
+        let cleared = refresh_output_before_run(OutputRefreshMode::Preserve, true, &mut writer)
+            .expect("skip refresh");
+
+        assert!(!cleared);
+        assert!(writer.buffer.is_empty());
+        assert_eq!(writer.flush_count, 0);
+    }
+
+    #[test]
+    fn clear_refresh_mode_skips_non_terminal_outputs() {
+        let mut writer = FlushTrackingWriter::default();
+
+        let cleared =
+            refresh_output_before_run(OutputRefreshMode::ClearTerminal, false, &mut writer)
+                .expect("skip non-terminal refresh");
+
+        assert!(!cleared);
+        assert!(writer.buffer.is_empty());
+        assert_eq!(writer.flush_count, 0);
+    }
+
     fn capture_logs(callback: impl FnOnce()) -> String {
         let buffer = Arc::new(Mutex::new(Vec::new()));
         let writer = SharedWriter(buffer.clone());
@@ -573,6 +681,24 @@ mod tests {
         }
 
         fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct FlushTrackingWriter {
+        buffer: Vec<u8>,
+        flush_count: usize,
+    }
+
+    impl Write for FlushTrackingWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.buffer.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            self.flush_count += 1;
             Ok(())
         }
     }

--- a/crates/with-watch/tests/cli.rs
+++ b/crates/with-watch/tests/cli.rs
@@ -22,6 +22,7 @@ fn long_help_lists_command_inventory_sections() {
         .stdout(predicate::str::contains("--shell"))
         .stdout(predicate::str::contains("exec"))
         .stdout(predicate::str::contains("--no-hash"))
+        .stdout(predicate::str::contains("--clear"))
         .stdout(predicate::str::contains("Wrapper commands:"))
         .stdout(predicate::str::contains(
             "env, nice, nohup, stdbuf, timeout",
@@ -47,6 +48,7 @@ fn short_help_stays_compact() {
         .stdout(predicate::str::contains("--shell"))
         .stdout(predicate::str::contains("exec"))
         .stdout(predicate::str::contains("--no-hash"))
+        .stdout(predicate::str::contains("--clear"))
         .stdout(predicate::str::contains("Wrapper commands:").not())
         .stdout(predicate::str::contains("Recognized but not auto-watchable commands:").not());
 }
@@ -154,6 +156,23 @@ fn passthrough_mode_runs_immediately_once_at_startup_with_test_hook() {
         .assert()
         .success()
         .stdout(predicate::str::contains("hello"));
+}
+
+#[cfg(unix)]
+#[test]
+fn clear_flag_keeps_non_terminal_output_clean_during_initial_run() {
+    let temp_dir = tempfile::tempdir().expect("create tempdir");
+    let input_path = temp_dir.path().join("input.txt");
+    fs::write(&input_path, "hello\n").expect("write input");
+
+    with_watch_command()
+        .env("WITH_WATCH_TEST_MAX_RUNS", "1")
+        .args(["--clear", "cat", input_path.to_string_lossy().as_ref()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hello"))
+        .stdout(predicate::str::contains("\u{1b}[2J").not())
+        .stdout(predicate::str::contains("\u{1b}[H").not());
 }
 
 #[cfg(unix)]

--- a/docs/crates-with-watch-foundation.md
+++ b/docs/crates-with-watch-foundation.md
@@ -14,14 +14,15 @@
 - Release engineers operating crate publication and binary distribution workflows
 
 ## Interfaces and Contracts
-- Root passthrough mode must remain `with-watch [--no-hash] <utility> [args...]`.
-- Shell mode must remain `with-watch [--no-hash] --shell '<expr>'`.
-- `exec` mode must remain `with-watch exec [--no-hash] --input <glob>... -- <command> [args...]`.
+- Root passthrough mode must remain `with-watch [--no-hash] [--clear] <utility> [args...]`.
+- Shell mode must remain `with-watch [--no-hash] [--clear] --shell '<expr>'`.
+- `exec` mode must remain `with-watch exec [--no-hash] [--clear] --input <glob>... -- <command> [args...]`.
 - The CLI must continue to reject mixed modes and empty delegated-command requests with operator-facing guidance.
 - Passthrough and shell modes must infer watch inputs before the first run; if inference does not produce safe filesystem inputs, the command must fail with `exec --input` guidance instead of guessing.
 - After watch input inference, watcher setup, and baseline snapshot capture succeed, all command modes must execute the delegated command immediately once before waiting for the first filesystem change event.
 - `exec --input` must accept repeatable explicit glob/path values, keep the delegated command unchanged, and remain the canonical fallback for otherwise ambiguous or pathless commands.
 - `--no-hash` must remain a global flag that switches rerun filtering from content hashes to metadata-only comparison.
+- `--clear` must remain a global flag that clears stdout before the initial run and each rerun only when stdout is a terminal.
 - `WW_LOG` must remain the only supported environment variable for configuring `with-watch` diagnostic `tracing` filters.
 - The default diagnostic log filter must remain `with_watch=off`, and `RUST_LOG` must not affect `with-watch` logging behavior.
 - Public crate installation must remain `cargo install with-watch`.
@@ -29,6 +30,7 @@
 - Stable internal enums must remain aligned with the current v1 contract:
   - `ChangeDetectionMode::{ContentHash, MtimeOnly}`
   - `CommandSource::{Argv, Shell, Exec}`
+  - `OutputRefreshMode::{Preserve, ClearTerminal}`
   - `CommandAnalysisStatus::{Resolved, NoInputs, AmbiguousFallback}`
   - `CommandAdapterId` adapter categories used for built-in inference
   - `SideEffectProfile::{ReadOnly, WritesExcludedOutputs, WritesWatchedInputs}`
@@ -64,12 +66,12 @@
 ## Logging
 - Use structured `tracing` logs for command planning, watcher setup, snapshot capture, debounce decisions, and rerun causes.
 - Diagnostic `tracing` logs are operator opt-in: they are disabled by default and enabled via `WW_LOG`.
-- Logs must include `command_source`, `detection_mode`, input counts, `adapter_id`, `fallback_used`, `default_watch_root_used`, `filtered_output_count`, `side_effect_profile`, snapshot modes, snapshot entry counts, snapshot capture elapsed time, and rerun suppression outcomes.
+- Logs must include `command_source`, `detection_mode`, `output_refresh_mode`, input counts, `adapter_id`, `fallback_used`, `default_watch_root_used`, `filtered_output_count`, `side_effect_profile`, snapshot modes, snapshot entry counts, snapshot capture elapsed time, and rerun suppression outcomes.
 
 ## Build and Test
 - Local validation: `cargo test -p with-watch`
 - Workspace validation baseline: `cargo test --workspace --all-targets`
-- Tests must cover CLI modes, immediate startup execution, shell parsing, adapter classification, fallback ambiguity handling, snapshot diffing, self-write suppression, and representative rerun flows.
+- Tests must cover CLI modes, immediate startup execution, shell parsing, adapter classification, fallback ambiguity handling, snapshot diffing, self-write suppression, TTY-only output clearing, and representative rerun flows.
 - Documentation changes should be checked against `cargo run -p with-watch -- --help` and the integration scenarios in `crates/with-watch/tests/cli.rs`.
 - Publishability validation: `cargo publish -p with-watch --dry-run`
 - Release contract checks should align with `.github/workflows/release-with-watch.yml`.

--- a/docs/project-with-watch.md
+++ b/docs/project-with-watch.md
@@ -13,13 +13,14 @@ Provide a Rust-based CLI wrapper that reruns delegated shell utilities and arbit
 - `docs/crates-with-watch-foundation.md`
 
 ## Cross-Domain Invariants
-- Root passthrough mode must remain `with-watch [--no-hash] <utility> [args...]`.
-- Shell mode must remain `with-watch [--no-hash] --shell '<expr>'` and is the supported entrypoint for `&&`, `||`, and `|`.
-- Arbitrary command mode must remain `with-watch exec [--no-hash] --input <glob>... -- <command> [args...]`.
+- Root passthrough mode must remain `with-watch [--no-hash] [--clear] <utility> [args...]`.
+- Shell mode must remain `with-watch [--no-hash] [--clear] --shell '<expr>'` and is the supported entrypoint for `&&`, `||`, and `|`.
+- Arbitrary command mode must remain `with-watch exec [--no-hash] [--clear] --input <glob>... -- <command> [args...]`.
 - `with-watch --help` must include a long-help appendix that documents command modes, the recognized delegated-command inventory, safe current-directory defaults, and recognized-but-not-auto-watchable commands.
 - The public CLI surface must keep exactly one delegated-command entrypoint per invocation: passthrough argv, `--shell`, or `exec --input`.
 - After watch input inference, watcher setup, and baseline snapshot capture succeed, `with-watch` must execute the delegated command immediately once before waiting for the first filesystem change event.
 - Default change detection must prefer content hashing, while `--no-hash` must switch the rerun filter to metadata-only comparison.
+- `--clear` must remain a global flag that clears stdout before the initial run and each rerun only when stdout is a terminal.
 - `WW_LOG` must remain the only supported environment variable for configuring `with-watch` diagnostic `tracing` logs, and the default diagnostic filter must remain `with_watch=off`.
 - `RUST_LOG` must not affect `with-watch` diagnostic logging.
 - `exec --input` reruns the delegated command unchanged and must not inject changed paths into argv or environment variables.


### PR DESCRIPTION
## Summary
- add a global `--clear` flag across passthrough, `--shell`, and `exec --input` modes
- clear the terminal before the initial run and each rerun only when stdout is a TTY
- document the new contract in the with-watch README and project docs

## Testing
- cargo test -p with-watch
- cargo test
- cargo run -p with-watch -- --help