### PR TITLE
Add prebuilt installers and cargo-binstall metadata

### DIFF
--- a/apps/public-docs/cargo-mono.mdx
+++ b/apps/public-docs/cargo-mono.mdx
@@ -16,6 +16,39 @@
 - Dependency-aware publish flow with optional release tag creation: `publish`
 - Stable output contract: `--output human|json`
 
+## Install
+
+Tag contract:
+
+- `cargo-mono@v<semver>`
+
+Direct installers:
+
+```bash
+./scripts/install/cargo-mono.sh --version latest --method direct
+```
+
+```powershell
+./scripts/install/cargo-mono.ps1 -Version latest -Method direct
+```
+
+`cargo-binstall`:
+
+```bash
+cargo binstall cargo-mono --no-confirm
+```
+
+GitHub Actions:
+
+```yaml
+- uses: taiki-e/install-action@v2
+  with:
+    tool: cargo-binstall
+- run: cargo binstall cargo-mono --no-confirm
+```
+
+Direct installers verify Sigstore bundle sidecars (`*.sigstore.json`) and require `cosign`.
+
 ## Common workflows
 
 List publishable workspace crates:

--- a/apps/public-docs/nodeup.mdx
+++ b/apps/public-docs/nodeup.mdx
@@ -42,7 +42,22 @@ Script installer:
 ./scripts/install/nodeup.ps1 -Version latest -Method direct
 ```
 
-Direct installers verify Sigstore bundle sidecars (`*.sigstore.json`) and only support bundle-enabled releases.
+`cargo-binstall`:
+
+```bash
+cargo binstall nodeup --no-confirm
+```
+
+GitHub Actions:
+
+```yaml
+- uses: taiki-e/install-action@v2
+  with:
+    tool: cargo-binstall
+- run: cargo binstall nodeup --no-confirm
+```
+
+Direct installers verify Sigstore bundle sidecars (`*.sigstore.json`), require `cosign`, and only support bundle-enabled releases.
 `nodeup toolchain install` supports `macOS`, `Linux`, and `Windows` x64/arm64 hosts.
 
 ## Common workflows

--- a/apps/public-docs/with-watch.mdx
+++ b/apps/public-docs/with-watch.mdx
@@ -21,11 +21,38 @@ Package manager:
 - macOS/Linux: `brew install delinoio/tap/with-watch`
 - Homebrew installs prebuilt archives on macOS Intel, macOS Apple Silicon, Linux amd64, and Linux arm64
 
+Direct installers:
+
+```bash
+./scripts/install/with-watch.sh --version latest --method package-manager
+```
+
+```powershell
+./scripts/install/with-watch.ps1 -Version latest -Method direct
+```
+
+`cargo-binstall`:
+
+```bash
+cargo binstall with-watch --no-confirm
+```
+
+GitHub Actions:
+
+```yaml
+- uses: taiki-e/install-action@v2
+  with:
+    tool: cargo-binstall
+- run: cargo binstall with-watch --no-confirm
+```
+
 Cargo:
 
 ```bash
 cargo install with-watch
 ```
+
+Direct installers verify Sigstore bundle sidecars (`*.sigstore.json`) and require `cosign`.
 
 ## Quick start
 

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -30,6 +30,7 @@
 - Preserve rustup-like shim behavior: symlink strategy plus executable-name dispatch.
 - Keep channel and command identifiers stable and documented.
 - Record storage and download behavior in project docs whenever changed.
+- Keep direct installers and `cargo-binstall` metadata aligned with release asset names, signing contracts, and install docs.
 
 ### cargo-mono-Specific Rules
 
@@ -39,6 +40,7 @@
 - Keep `publish` delegation aligned with the documented contract: `cargo mono publish` must invoke `cargo publish --no-verify` in both execute and dry-run modes.
 - Ensure release automation (`bump`, `publish`) logs include structured operational context.
 - Keep runtime error output on the fixed `Summary/Context/Hint` three-line contract and include only safe debugging context values.
+- Keep direct installers and `cargo-binstall` metadata aligned with release asset names, signing contracts, and install docs.
 
 ### with-watch-Specific Rules
 
@@ -48,6 +50,7 @@
 - Keep shell support scoped to command-line expressions and do not silently broaden into shell-script control-flow without updating docs first.
 - Keep logs sufficient to explain inferred inputs, watcher anchors, snapshot counts, and rerun causes.
 - Keep public release contracts aligned across root publish-tag allowlist, `.github/workflows/release-with-watch.yml`, and Homebrew packaging assets.
+- Keep direct installers and `cargo-binstall` metadata aligned with release asset names, signing contracts, and install docs.
 
 ### serde-feather-Specific Rules
 

--- a/crates/cargo-mono/Cargo.toml
+++ b/crates/cargo-mono/Cargo.toml
@@ -4,6 +4,40 @@ version = "0.6.6"
 edition = "2021"
 license = "MIT"
 description = "Cargo subcommand for Rust monorepo management"
+repository = "https://github.com/delinoio/oss"
+
+[package.metadata.binstall]
+disabled-strategies = ["quick-install", "compile"]
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/cargo-mono@v{ version }/cargo-mono-linux-amd64.tar.gz"
+pkg-fmt = "tgz"
+bin-dir = "cargo-mono"
+
+[package.metadata.binstall.overrides.aarch64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/cargo-mono@v{ version }/cargo-mono-linux-arm64.tar.gz"
+pkg-fmt = "tgz"
+bin-dir = "cargo-mono"
+
+[package.metadata.binstall.overrides.x86_64-apple-darwin]
+pkg-url = "{ repo }/releases/download/cargo-mono@v{ version }/cargo-mono-darwin-amd64.tar.gz"
+pkg-fmt = "tgz"
+bin-dir = "cargo-mono"
+
+[package.metadata.binstall.overrides.aarch64-apple-darwin]
+pkg-url = "{ repo }/releases/download/cargo-mono@v{ version }/cargo-mono-darwin-arm64.tar.gz"
+pkg-fmt = "tgz"
+bin-dir = "cargo-mono"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/cargo-mono@v{ version }/cargo-mono-windows-amd64.zip"
+pkg-fmt = "zip"
+bin-dir = "cargo-mono.exe"
+
+[package.metadata.binstall.overrides.aarch64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/cargo-mono@v{ version }/cargo-mono-windows-arm64.zip"
+pkg-fmt = "zip"
+bin-dir = "cargo-mono.exe"
 
 [dependencies]
 cargo_metadata = "0.19.2"

--- a/crates/cargo-mono/README.md
+++ b/crates/cargo-mono/README.md
@@ -2,6 +2,39 @@
 
 `cargo-mono` is the external Cargo subcommand that powers `cargo mono` for Rust monorepo workflows.
 
+## Install
+
+Tag contract:
+
+- `cargo-mono@v<semver>`
+
+Direct installers:
+
+```bash
+./scripts/install/cargo-mono.sh --version latest --method direct
+```
+
+```powershell
+./scripts/install/cargo-mono.ps1 -Version latest -Method direct
+```
+
+`cargo-binstall`:
+
+```bash
+cargo binstall cargo-mono --no-confirm
+```
+
+GitHub Actions:
+
+```yaml
+- uses: taiki-e/install-action@v2
+  with:
+    tool: cargo-binstall
+- run: cargo binstall cargo-mono --no-confirm
+```
+
+Direct installers verify Sigstore bundle sidecars (`*.sigstore.json`) and require `cosign`.
+
 ## Commands
 
 ```bash

--- a/crates/nodeup/Cargo.toml
+++ b/crates/nodeup/Cargo.toml
@@ -5,6 +5,40 @@ edition = "2021"
 license = "MIT"
 description = "Rustup-like Node.js version manager"
 readme = "README.md"
+repository = "https://github.com/delinoio/oss"
+
+[package.metadata.binstall]
+disabled-strategies = ["quick-install", "compile"]
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/nodeup@v{ version }/nodeup-linux-amd64.tar.gz"
+pkg-fmt = "tgz"
+bin-dir = "nodeup"
+
+[package.metadata.binstall.overrides.aarch64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/nodeup@v{ version }/nodeup-linux-arm64.tar.gz"
+pkg-fmt = "tgz"
+bin-dir = "nodeup"
+
+[package.metadata.binstall.overrides.x86_64-apple-darwin]
+pkg-url = "{ repo }/releases/download/nodeup@v{ version }/nodeup-darwin-amd64.tar.gz"
+pkg-fmt = "tgz"
+bin-dir = "nodeup"
+
+[package.metadata.binstall.overrides.aarch64-apple-darwin]
+pkg-url = "{ repo }/releases/download/nodeup@v{ version }/nodeup-darwin-arm64.tar.gz"
+pkg-fmt = "tgz"
+bin-dir = "nodeup"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/nodeup@v{ version }/nodeup-windows-amd64.zip"
+pkg-fmt = "zip"
+bin-dir = "nodeup-windows-amd64.exe"
+
+[package.metadata.binstall.overrides.aarch64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/nodeup@v{ version }/nodeup-windows-arm64.zip"
+pkg-fmt = "zip"
+bin-dir = "nodeup-windows-arm64.exe"
 
 [dependencies]
 clap = { version = "4.5.32", features = ["derive"] }

--- a/crates/nodeup/README.md
+++ b/crates/nodeup/README.md
@@ -9,6 +9,43 @@
 - Use human-friendly output for operators and JSON output for automation.
 - Run `node`, `npm`, `npx`, `yarn`, and `pnpm` through one binary by executable-name dispatch.
 
+## Install
+
+Tag contract:
+
+- `nodeup@v<semver>`
+
+Package manager:
+
+- macOS/Linux: `brew install delinoio/tap/nodeup`
+
+Direct installers:
+
+```bash
+./scripts/install/nodeup.sh --version latest --method package-manager
+```
+
+```powershell
+./scripts/install/nodeup.ps1 -Version latest -Method direct
+```
+
+`cargo-binstall`:
+
+```bash
+cargo binstall nodeup --no-confirm
+```
+
+GitHub Actions:
+
+```yaml
+- uses: taiki-e/install-action@v2
+  with:
+    tool: cargo-binstall
+- run: cargo binstall nodeup --no-confirm
+```
+
+Direct installers verify Sigstore bundle sidecars (`*.sigstore.json`) and require `cosign`.
+
 ## Quick Command Reference
 
 - `nodeup toolchain list [--quiet|--verbose]`

--- a/crates/with-watch/Cargo.toml
+++ b/crates/with-watch/Cargo.toml
@@ -7,6 +7,39 @@ description = "Watch command inputs and rerun commands when they change"
 readme = "README.md"
 repository = "https://github.com/delinoio/oss"
 
+[package.metadata.binstall]
+disabled-strategies = ["quick-install", "compile"]
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/with-watch@v{ version }/with-watch-linux-amd64.tar.gz"
+pkg-fmt = "tgz"
+bin-dir = "with-watch"
+
+[package.metadata.binstall.overrides.aarch64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/with-watch@v{ version }/with-watch-linux-arm64.tar.gz"
+pkg-fmt = "tgz"
+bin-dir = "with-watch"
+
+[package.metadata.binstall.overrides.x86_64-apple-darwin]
+pkg-url = "{ repo }/releases/download/with-watch@v{ version }/with-watch-darwin-amd64.tar.gz"
+pkg-fmt = "tgz"
+bin-dir = "with-watch"
+
+[package.metadata.binstall.overrides.aarch64-apple-darwin]
+pkg-url = "{ repo }/releases/download/with-watch@v{ version }/with-watch-darwin-arm64.tar.gz"
+pkg-fmt = "tgz"
+bin-dir = "with-watch"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/with-watch@v{ version }/with-watch-windows-amd64.zip"
+pkg-fmt = "zip"
+bin-dir = "with-watch.exe"
+
+[package.metadata.binstall.overrides.aarch64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/with-watch@v{ version }/with-watch-windows-arm64.zip"
+pkg-fmt = "zip"
+bin-dir = "with-watch.exe"
+
 [dependencies]
 blake3 = "1.8.4"
 clap = { version = "4.5.32", features = ["derive"] }

--- a/crates/with-watch/README.md
+++ b/crates/with-watch/README.md
@@ -17,6 +17,29 @@ cargo install with-watch
 brew install delinoio/tap/with-watch
 ```
 
+```sh
+./scripts/install/with-watch.sh --version latest --method package-manager
+```
+
+```powershell
+./scripts/install/with-watch.ps1 -Version latest -Method direct
+```
+
+```sh
+cargo binstall with-watch --no-confirm
+```
+
+GitHub Actions:
+
+```yaml
+- uses: taiki-e/install-action@v2
+  with:
+    tool: cargo-binstall
+- run: cargo binstall with-watch --no-confirm
+```
+
+Direct installers verify Sigstore bundle sidecars (`*.sigstore.json`) and require `cosign`.
+
 ## Command modes
 
 - Passthrough mode: `with-watch [--no-hash] [--clear] <utility> [args...]`

--- a/docs/crates-cargo-mono-foundation.md
+++ b/docs/crates-cargo-mono-foundation.md
@@ -26,6 +26,8 @@
 - Publish tag creation is opt-in by default (no config means no tags), must remain local-only (`git tag` without push), and must use `<crate>@v<version>` naming.
 - Remote tag publication is owned by CI automation: `.github/workflows/auto-publish.yml` must run `git push --tags` after a successful `publish` command, with checkout credential persistence disabled and authentication bound to `secrets.GH_TOKEN` (non-`GITHUB_TOKEN`) so downstream tag-triggered workflows run.
 - If `publish` tag configuration references unknown workspace packages, command execution must fail with `invalid-input`.
+- Direct installers must remain available at `scripts/install/cargo-mono.sh` and `scripts/install/cargo-mono.ps1`, and direct installs must verify `SHA256SUMS` plus Sigstore bundle sidecars via `cosign verify-blob --bundle`.
+- `cargo-binstall` metadata must resolve only first-party GitHub Release assets and disable `quick-install` and `compile` strategies.
 - Human-output color contract:
   - Global CLI flag: `--color <auto|always|never>`.
   - Environment override: `CARGO_MONO_OUTPUT_COLOR=auto|always|never`.
@@ -68,11 +70,13 @@
 - Release contract checks should align with `.github/workflows/release-cargo-mono.yml`.
 - Release assets must cover `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`.
 - Release signing outputs must use Sigstore bundle sidecars (`SHA256SUMS.sigstore.json` and `<artifact>.sigstore.json`).
+- Install docs must keep Bash, PowerShell, `cargo-binstall`, and GitHub Actions usage aligned with the installer scripts and manifest metadata.
 
 ## Dependencies and Integrations
 - Integrates with Cargo workspace metadata and release workflows.
 - Integrates with root automation (`auto-publish`) through stable command contracts, including CI-driven tag publication.
 - Integrates with tag-based binary distribution automation (`release-cargo-mono`) through stable artifact naming and bundle-signing contracts.
+- Integrates with direct installer scripts and `cargo-binstall` metadata for prebuilt binary distribution.
 
 ## Change Triggers
 - Update `docs/project-cargo-mono.md` with this file when command identifiers or ownership changes.

--- a/docs/crates-nodeup-foundation.md
+++ b/docs/crates-nodeup-foundation.md
@@ -20,6 +20,8 @@
 - Host support must include `macOS`, `Linux`, and `Windows` x64/arm64, while x86 hosts remain unsupported.
 - Homebrew installation must consume prebuilt release archives for `darwin/amd64`, `darwin/arm64`, `linux/amd64`, and `linux/arm64`.
 - Direct install scripts must verify release artifacts with `SHA256SUMS` and Sigstore bundle sidecars (`<artifact>.sigstore.json`) via `cosign verify-blob --bundle`.
+- Direct installers must remain available at `scripts/install/nodeup.sh` and `scripts/install/nodeup.ps1`.
+- `cargo-binstall` metadata must resolve only first-party GitHub Release assets and disable `quick-install` and `compile` strategies.
 - Runtime archive selection must remain enum-driven: `tar.xz` for `darwin/*` and `linux/*`, `zip` for `windows/*`.
 - Windows runtime archives that unpack without a top-level directory must be normalized into the stable `bin/` runtime layout used by nodeup execution and linking flows.
 - `yarn`/`pnpm` delegated execution must honor nearest `package.json` `packageManager` when present.
@@ -59,6 +61,7 @@
 - Release assets must include both standalone prebuilt binaries (`nodeup-<os>-<arch>[.exe]`) and compressed archives (`nodeup-<os>-<arch>.tar.gz|zip`) for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`.
 - Release signing outputs must include `SHA256SUMS.sigstore.json` and `<artifact>.sigstore.json` sidecars; legacy `.sig`/`.pem` sidecars are out of scope for direct installation.
 - Homebrew release automation must render the prebuilt formula from release asset URLs and push tap updates directly to `delinoio/homebrew-tap` `main` with a dedicated tap-write credential.
+- Install docs must keep Bash, PowerShell, `cargo-binstall`, and GitHub Actions usage aligned with the installer scripts and manifest metadata.
 - Completion coverage must include successful script generation, invalid shell/scope validation, and JSON-mode raw output behavior.
 - Output color coverage must include flag/env precedence, invalid env fallback, stream-aware auto-mode behavior, and JSON/completion ANSI exclusion.
 - `packageManager` coverage must include strict parsing, mismatch conflicts, yarn v1 vs v2+ mapping, direct-binary preference, and npm-exec fallback behavior.

--- a/docs/crates-with-watch-foundation.md
+++ b/docs/crates-with-watch-foundation.md
@@ -25,7 +25,9 @@
 - `--clear` must remain a global flag that clears stdout before the initial run and each rerun only when stdout is a terminal.
 - `WW_LOG` must remain the only supported environment variable for configuring `with-watch` diagnostic `tracing` filters.
 - The default diagnostic log filter must remain `with_watch=off`, and `RUST_LOG` must not affect `with-watch` logging behavior.
-- Public crate installation must remain `cargo install with-watch`.
+- Public crate installation must remain available via `cargo install with-watch`.
+- Direct installers must remain available at `scripts/install/with-watch.sh` and `scripts/install/with-watch.ps1`, and direct installs must verify `SHA256SUMS` plus Sigstore bundle sidecars via `cosign verify-blob --bundle`.
+- `cargo-binstall` metadata must resolve only first-party GitHub Release assets and disable `quick-install` and `compile` strategies.
 - Publish tag naming must remain `with-watch@v<version>`.
 - Stable internal enums must remain aligned with the current v1 contract:
   - `ChangeDetectionMode::{ContentHash, MtimeOnly}`
@@ -77,6 +79,7 @@
 - Release contract checks should align with `.github/workflows/release-with-watch.yml`.
 - Release assets must include standalone binaries (`with-watch-<os>-<arch>[.exe]`) and compressed archives (`with-watch-<os>-<arch>.tar.gz|zip`) for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`.
 - Release signing outputs must include `SHA256SUMS.sigstore.json` and `<artifact>.sigstore.json` sidecars.
+- Install docs must keep Bash, PowerShell, `cargo-binstall`, and GitHub Actions usage aligned with the installer scripts and manifest metadata.
 
 ## Dependencies and Integrations
 - Uses `clap` for CLI parsing.
@@ -85,6 +88,7 @@
 - Uses `blake3` for content-hash-based rerun filtering.
 - Integrates with root `auto-publish` tag publication and `.github/workflows/release-with-watch.yml`.
 - Integrates with Homebrew tap automation through `scripts/release/update-homebrew.sh` and `packaging/homebrew/templates/with-watch.rb.tmpl`.
+- Integrates with direct installer scripts and `cargo-binstall` metadata for prebuilt binary distribution.
 
 ## Change Triggers
 - Update `docs/project-with-watch.md` with this file when command shape, detection behavior, release distribution, or ownership changes.

--- a/docs/project-cargo-mono.md
+++ b/docs/project-cargo-mono.md
@@ -22,6 +22,8 @@ Provide a Cargo subcommand for Rust monorepo lifecycle management, including ver
 - Remote tag publication remains CI-owned: `auto-publish` pushes release tags with `git push --tags` after a successful `publish` run, with checkout credential persistence disabled and authentication bound to `secrets.GH_TOKEN` (non-`GITHUB_TOKEN`) so downstream tag-triggered workflows run.
 - Publish tag configuration must be opt-in through `[workspace.metadata.cargo-mono.publish.tag].packages`, and tag naming must remain `<crate>@v<version>`.
 - Tag release automation must detect `cargo-mono@v*` and produce signed prebuilt artifacts for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`, plus Sigstore bundle sidecars (`*.sigstore.json`) without changing CLI command behavior.
+- Direct installers must remain available at `scripts/install/cargo-mono.sh` and `scripts/install/cargo-mono.ps1`; direct installs must verify `SHA256SUMS` entries and Sigstore bundle sidecars and require `cosign`.
+- `cargo-binstall` metadata must resolve only first-party GitHub Release assets and disable third-party quick-install and compile fallback strategies.
 - Runtime failure messaging must follow the `Summary/Context/Hint` three-line contract while command behavior, output schema, and exit code semantics remain stable.
 - Dependency-cycle conflicts in package ordering must identify cycle package names and dependency scope in `Context` without changing CLI flags, command behavior, or JSON output schema.
 - Human output color controls must remain stable: global `--color <auto|always|never>`, `CARGO_MONO_OUTPUT_COLOR`, and `NO_COLOR` with precedence `--color` > `CARGO_MONO_OUTPUT_COLOR` > `NO_COLOR` > auto-detection.
@@ -29,6 +31,7 @@ Provide a Cargo subcommand for Rust monorepo lifecycle management, including ver
 
 ## Change Policy
 - Update this index and `docs/crates-cargo-mono-foundation.md` together when command shape, release workflow, or ownership changes.
+- Keep `scripts/install/cargo-mono.sh`, `scripts/install/cargo-mono.ps1`, and `crates/cargo-mono/Cargo.toml` synchronized with release asset names and signing contracts.
 - Keep `crates/AGENTS.md` and root `AGENTS.md` aligned with structural changes.
 
 ## References

--- a/docs/project-nodeup.md
+++ b/docs/project-nodeup.md
@@ -19,12 +19,15 @@ Provide a Rust-based Node.js version manager with predictable channel resolution
 - Shell completion generation must remain deterministic for supported shells and top-level command scopes.
 - Human output styling controls (`--color`, `NODEUP_COLOR`, and `NO_COLOR` precedence) must remain stable across CLI and public documentation.
 - Release automation must publish both standalone prebuilt binaries and archive assets for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`, plus Sigstore bundle sidecars (`*.sigstore.json`) for each artifact and `SHA256SUMS`.
-- Direct installers must verify `SHA256SUMS` entries and Sigstore bundle sidecars, and only support bundle-enabled releases.
+- Direct installers must verify `SHA256SUMS` entries and Sigstore bundle sidecars, require `cosign`, and only support bundle-enabled releases.
+- Direct installers must remain available at `scripts/install/nodeup.sh` and `scripts/install/nodeup.ps1`.
+- `cargo-binstall` metadata must resolve only first-party GitHub Release assets and disable third-party quick-install and compile fallback strategies.
 - Homebrew installation must use prebuilt `nodeup` release archives for `darwin/amd64`, `darwin/arm64`, `linux/amd64`, and `linux/arm64`.
 - `nodeup` runtime installation and shim dispatch must support `macOS`, `Linux`, and `Windows` x64/arm64 hosts while leaving x86 hosts out of scope.
 
 ## Change Policy
 - Update this index and `docs/crates-nodeup-foundation.md` in the same change for behavior or storage contract updates.
+- Keep `scripts/install/nodeup.sh`, `scripts/install/nodeup.ps1`, and `crates/nodeup/Cargo.toml` synchronized with release asset names and signing contracts.
 - Keep release and install contracts synchronized with root and `crates/AGENTS.md` rules.
 
 ## References

--- a/docs/project-with-watch.md
+++ b/docs/project-with-watch.md
@@ -32,7 +32,9 @@ Provide a Rust-based CLI wrapper that reruns delegated shell utilities and arbit
 - Safe pathless default watch roots are limited to the built-in allowlist (`ls`, `dir`, `vdir`, `du`, and `find`).
 - Commands that mutate watched inputs directly must refresh the baseline snapshot after each run and suppress self-triggered reruns caused by their own writes.
 - Path-based watch inputs must anchor watcher subscriptions at the nearest existing directory so replace-style writers keep emitting later external changes.
-- Public crate distribution must remain `cargo install with-watch`.
+- Public crate installation must continue to support `cargo install with-watch`.
+- Direct installers must remain available at `scripts/install/with-watch.sh` and `scripts/install/with-watch.ps1`; direct installs must verify `SHA256SUMS` entries and Sigstore bundle sidecars and require `cosign`.
+- `cargo-binstall` metadata must resolve only first-party GitHub Release assets and disable third-party quick-install and compile fallback strategies.
 - Publish tag eligibility must remain enabled through root `[workspace.metadata.cargo-mono.publish.tag].packages`, and release tag naming must remain `with-watch@v<version>`.
 - Release automation must publish signed GitHub Release assets for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`, including standalone binaries (`with-watch-<os>-<arch>[.exe]`) and archives (`with-watch-<os>-<arch>.tar.gz|zip`).
 - Homebrew installation must consume prebuilt `with-watch` release archives for `darwin/amd64`, `darwin/arm64`, `linux/amd64`, and `linux/arm64`.
@@ -40,6 +42,7 @@ Provide a Rust-based CLI wrapper that reruns delegated shell utilities and arbit
 ## Change Policy
 - Update this index and `docs/crates-with-watch-foundation.md` together when CLI shape, watch inference behavior, operator guidance, release automation, side-effect suppression, or storage/logging contracts change.
 - Update root `Cargo.toml`, `.github/workflows/release-with-watch.yml`, `scripts/release/update-homebrew.sh`, and `packaging/homebrew/templates/with-watch.rb.tmpl` in the same change when with-watch release tags, artifact names, or package-manager distribution contracts change.
+- Keep `scripts/install/with-watch.sh`, `scripts/install/with-watch.ps1`, and `crates/with-watch/Cargo.toml` synchronized with release asset names and signing contracts.
 - Keep root `AGENTS.md` and `crates/AGENTS.md` aligned with ownership and project-ID changes.
 
 ## References

--- a/scripts/install/README.md
+++ b/scripts/install/README.md
@@ -5,10 +5,15 @@ Cross-platform install scripts with the shared interface:
 - `--version <semver|latest>`
 - `--method package-manager|direct`
 - `direct` verifies `SHA256SUMS` plus Sigstore bundle sidecars (`*.sigstore.json`)
+- `direct` requires `cosign` for Sigstore bundle verification
 - Older releases that only published legacy `.sig`/`.pem` files are not supported in direct mode
+- PowerShell installers default to `-Method direct` on Windows hosts
+- `cargo-mono` accepts `package-manager` only as a compatibility alias and maps it to `direct`
 
 Scripts:
 
+- `cargo-mono.sh` / `cargo-mono.ps1`
 - `nodeup.sh` / `nodeup.ps1`
+- `with-watch.sh` / `with-watch.ps1`
 - `derun.sh` / `derun.ps1`
 - `dexdex-stack.sh` / `dexdex-stack.ps1`

--- a/scripts/install/cargo-mono.ps1
+++ b/scripts/install/cargo-mono.ps1
@@ -1,0 +1,133 @@
+param(
+  [string]$Version = "latest",
+  [ValidateSet("package-manager", "direct")]
+  [string]$Method = "direct",
+  [string]$InstallDir = "$HOME\\.local\\bin"
+)
+
+$ErrorActionPreference = "Stop"
+
+$Repo = "delinoio/oss"
+$TagPrefix = "cargo-mono@v"
+$WorkflowIdentityPattern = "^https://github.com/delinoio/oss/.github/workflows/release-cargo-mono.yml@"
+
+function Resolve-LatestTag {
+  $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases?per_page=200"
+  $match = $releases | Where-Object { $_.tag_name -like "$TagPrefix*" } | Select-Object -First 1
+  if (-not $match) {
+    throw "[install.cargo-mono] failed to resolve latest tag"
+  }
+
+  return $match.tag_name
+}
+
+function Resolve-Tag {
+  if ($Version -eq "latest") {
+    return Resolve-LatestTag
+  }
+
+  return "$TagPrefix$Version"
+}
+
+function Verify-Checksum {
+  param(
+    [string]$FilePath,
+    [string]$Sha256SumsPath,
+    [string]$AssetName
+  )
+
+  $expected = Get-Content -Path $Sha256SumsPath | Where-Object { $_ -match "\s$([regex]::Escape($AssetName))$" } | Select-Object -First 1
+  if (-not $expected) {
+    throw "[install.cargo-mono] checksum entry not found for $AssetName"
+  }
+
+  $expectedHash = ($expected -split "\s+")[0].ToLowerInvariant()
+  $actualHash = (Get-FileHash -Path $FilePath -Algorithm SHA256).Hash.ToLowerInvariant()
+  if ($expectedHash -ne $actualHash) {
+    throw "[install.cargo-mono] checksum mismatch for $AssetName"
+  }
+}
+
+function Download-Bundle {
+  param(
+    [string]$BaseUrl,
+    [string]$AssetName,
+    [string]$BundlePath
+  )
+
+  try {
+    Invoke-WebRequest -Uri "$BaseUrl/$AssetName.sigstore.json" -OutFile $BundlePath
+  }
+  catch {
+    throw "[install.cargo-mono] direct installs require releases published with Sigstore bundle sidecars"
+  }
+}
+
+function Verify-Bundle {
+  param(
+    [string]$FilePath,
+    [string]$BundlePath
+  )
+
+  if (-not (Get-Command cosign -ErrorAction SilentlyContinue)) {
+    throw "[install.cargo-mono] cosign is required for direct installation"
+  }
+
+  cosign verify-blob `
+    --bundle $BundlePath `
+    --certificate-identity-regexp $WorkflowIdentityPattern `
+    --certificate-oidc-issuer "https://token.actions.githubusercontent.com" `
+    $FilePath | Out-Null
+}
+
+function Install-Direct {
+  $tag = Resolve-Tag
+  $baseUrl = "https://github.com/$Repo/releases/download/$tag"
+  $architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
+  $assetArch = switch ($architecture) {
+    "x64" { "amd64" }
+    "arm64" { "arm64" }
+    default { throw "[install.cargo-mono] unsupported Windows architecture: $architecture" }
+  }
+  $assetName = "cargo-mono-windows-$assetArch.zip"
+
+  $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ("cargo-mono-install-" + [System.Guid]::NewGuid().ToString("N"))
+  New-Item -Path $tmpDir -ItemType Directory | Out-Null
+
+  try {
+    $assetPath = Join-Path $tmpDir $assetName
+    $sumsPath = Join-Path $tmpDir "SHA256SUMS"
+    $bundlePath = "$assetPath.sigstore.json"
+
+    Write-Host "[install.cargo-mono] downloading $assetName"
+    Invoke-WebRequest -Uri "$baseUrl/$assetName" -OutFile $assetPath
+    Invoke-WebRequest -Uri "$baseUrl/SHA256SUMS" -OutFile $sumsPath
+    Download-Bundle -BaseUrl $baseUrl -AssetName $assetName -BundlePath $bundlePath
+
+    Verify-Checksum -FilePath $assetPath -Sha256SumsPath $sumsPath -AssetName $assetName
+    Verify-Bundle -FilePath $assetPath -BundlePath $bundlePath
+
+    $extractDir = Join-Path $tmpDir "extract"
+    Expand-Archive -Path $assetPath -DestinationPath $extractDir -Force
+
+    New-Item -Path $InstallDir -ItemType Directory -Force | Out-Null
+    Copy-Item -Path (Join-Path $extractDir "cargo-mono.exe") -Destination (Join-Path $InstallDir "cargo-mono.exe") -Force
+
+    Write-Host "[install.cargo-mono] installed cargo-mono.exe to $InstallDir"
+  }
+  finally {
+    Remove-Item -Path $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+  }
+}
+
+switch ($Method) {
+  "package-manager" {
+    # Compatibility shim: keep accepting package-manager until downstream automation
+    # moves to the documented direct-install path for cargo-mono.
+    Write-Warning "[install.cargo-mono] method=package-manager is not available and now maps to direct installation."
+    Install-Direct
+  }
+  "direct" {
+    Install-Direct
+  }
+}

--- a/scripts/install/cargo-mono.sh
+++ b/scripts/install/cargo-mono.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Install cargo-mono with direct release artifacts.
+
+Usage:
+  ./scripts/install/cargo-mono.sh [--version <semver|latest>] [--method <package-manager|direct>] [--install-dir <dir>]
+
+Options:
+  --version <semver|latest>      Version without v-prefix (default: latest)
+  --method <package-manager|direct>
+                                 Install method (default: direct)
+  --install-dir <dir>            Binary install directory for direct mode (default: ~/.local/bin)
+USAGE
+}
+
+repo="delinoio/oss"
+tag_prefix="cargo-mono@v"
+workflow_identity="https://github.com/delinoio/oss/.github/workflows/release-cargo-mono.yml@"
+
+version="latest"
+method="direct"
+install_dir="${HOME}/.local/bin"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    --method)
+      method="${2:-}"
+      shift 2
+      ;;
+    --install-dir)
+      install_dir="${2:-}"
+      shift 2
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[install.cargo-mono] unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+resolve_latest_tag() {
+  if command -v gh >/dev/null 2>&1; then
+    gh release list --repo "$repo" --limit 200 --json tagName \
+      --jq "map(select(.tagName | startswith(\"${tag_prefix}\")))[0].tagName"
+    return
+  fi
+
+  curl -fsSL "https://api.github.com/repos/${repo}/releases?per_page=200" \
+    | awk -F '"' '/"tag_name"/ {print $4}' \
+    | grep "^${tag_prefix}" \
+    | head -n1
+}
+
+resolve_tag() {
+  if [ "$version" = "latest" ]; then
+    local latest_tag
+    latest_tag="$(resolve_latest_tag)"
+    if [ -z "$latest_tag" ] || [ "$latest_tag" = "null" ]; then
+      echo "[install.cargo-mono] failed to resolve latest cargo-mono tag" >&2
+      exit 1
+    fi
+    printf '%s\n' "$latest_tag"
+    return
+  fi
+
+  printf '%s%s\n' "$tag_prefix" "$version"
+}
+
+download_bundle() {
+  local base_url="$1"
+  local artifact="$2"
+  local bundle_name="${artifact}.sigstore.json"
+
+  if ! curl -fsSLO "${base_url}/${bundle_name}"; then
+    echo "[install.cargo-mono] missing bundle sidecar: ${bundle_name}" >&2
+    echo "[install.cargo-mono] direct installs require releases published with Sigstore bundle sidecars" >&2
+    exit 1
+  fi
+}
+
+verify_bundle() {
+  local artifact="$1"
+
+  if ! command -v cosign >/dev/null 2>&1; then
+    echo "[install.cargo-mono] cosign is required for direct install verification" >&2
+    exit 1
+  fi
+
+  cosign verify-blob \
+    --bundle "${artifact}.sigstore.json" \
+    --certificate-identity-regexp "$workflow_identity" \
+    --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+    "$artifact"
+}
+
+install_direct() {
+  local tag
+  tag="$(resolve_tag)"
+
+  local uname_os
+  uname_os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+
+  local os=""
+  case "$uname_os" in
+    linux*)
+      os="linux"
+      ;;
+    darwin*)
+      os="darwin"
+      ;;
+    *)
+      echo "[install.cargo-mono] unsupported OS for this installer: $uname_os" >&2
+      exit 1
+      ;;
+  esac
+
+  local uname_arch
+  uname_arch="$(uname -m)"
+
+  local arch=""
+  case "$uname_arch" in
+    x86_64|amd64)
+      arch="amd64"
+      ;;
+    arm64|aarch64)
+      arch="arm64"
+      ;;
+    *)
+      echo "[install.cargo-mono] unsupported architecture: $uname_arch" >&2
+      exit 1
+      ;;
+  esac
+
+  local asset_name="cargo-mono-${os}-${arch}.tar.gz"
+  local base_url="https://github.com/${repo}/releases/download/${tag}"
+
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "$tmp_dir"' EXIT
+
+  pushd "$tmp_dir" >/dev/null
+
+  echo "[install.cargo-mono] downloading artifact: $asset_name" >&2
+  curl -fsSLO "${base_url}/${asset_name}"
+  curl -fsSLO "${base_url}/SHA256SUMS"
+  download_bundle "$base_url" "$asset_name"
+
+  grep " ${asset_name}$" SHA256SUMS > SHA256SUMS.cargo-mono
+  shasum -a 256 -c SHA256SUMS.cargo-mono
+  verify_bundle "$asset_name"
+
+  tar -xzf "$asset_name"
+
+  mkdir -p "$install_dir"
+  install -m 0755 cargo-mono "$install_dir/cargo-mono"
+
+  popd >/dev/null
+
+  echo "[install.cargo-mono] installed cargo-mono to $install_dir/cargo-mono" >&2
+}
+
+case "$method" in
+  package-manager)
+    echo "[install.cargo-mono] package-manager mode is not available yet; using direct installation instead" >&2
+    install_direct
+    ;;
+  direct)
+    install_direct
+    ;;
+  *)
+    echo "[install.cargo-mono] unsupported method: $method" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/install/with-watch.ps1
+++ b/scripts/install/with-watch.ps1
@@ -1,0 +1,133 @@
+param(
+  [string]$Version = "latest",
+  [ValidateSet("package-manager", "direct")]
+  [string]$Method = "direct",
+  [string]$InstallDir = "$HOME\\.local\\bin"
+)
+
+$ErrorActionPreference = "Stop"
+
+$Repo = "delinoio/oss"
+$TagPrefix = "with-watch@v"
+$WorkflowIdentityPattern = "^https://github.com/delinoio/oss/.github/workflows/release-with-watch.yml@"
+
+function Resolve-LatestTag {
+  $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases?per_page=200"
+  $match = $releases | Where-Object { $_.tag_name -like "$TagPrefix*" } | Select-Object -First 1
+  if (-not $match) {
+    throw "[install.with-watch] failed to resolve latest tag"
+  }
+
+  return $match.tag_name
+}
+
+function Resolve-Tag {
+  if ($Version -eq "latest") {
+    return Resolve-LatestTag
+  }
+
+  return "$TagPrefix$Version"
+}
+
+function Verify-Checksum {
+  param(
+    [string]$FilePath,
+    [string]$Sha256SumsPath,
+    [string]$AssetName
+  )
+
+  $expected = Get-Content -Path $Sha256SumsPath | Where-Object { $_ -match "\s$([regex]::Escape($AssetName))$" } | Select-Object -First 1
+  if (-not $expected) {
+    throw "[install.with-watch] checksum entry not found for $AssetName"
+  }
+
+  $expectedHash = ($expected -split "\s+")[0].ToLowerInvariant()
+  $actualHash = (Get-FileHash -Path $FilePath -Algorithm SHA256).Hash.ToLowerInvariant()
+  if ($expectedHash -ne $actualHash) {
+    throw "[install.with-watch] checksum mismatch for $AssetName"
+  }
+}
+
+function Download-Bundle {
+  param(
+    [string]$BaseUrl,
+    [string]$AssetName,
+    [string]$BundlePath
+  )
+
+  try {
+    Invoke-WebRequest -Uri "$BaseUrl/$AssetName.sigstore.json" -OutFile $BundlePath
+  }
+  catch {
+    throw "[install.with-watch] direct installs require releases published with Sigstore bundle sidecars"
+  }
+}
+
+function Verify-Bundle {
+  param(
+    [string]$FilePath,
+    [string]$BundlePath
+  )
+
+  if (-not (Get-Command cosign -ErrorAction SilentlyContinue)) {
+    throw "[install.with-watch] cosign is required for direct installation"
+  }
+
+  cosign verify-blob `
+    --bundle $BundlePath `
+    --certificate-identity-regexp $WorkflowIdentityPattern `
+    --certificate-oidc-issuer "https://token.actions.githubusercontent.com" `
+    $FilePath | Out-Null
+}
+
+function Install-Direct {
+  $tag = Resolve-Tag
+  $baseUrl = "https://github.com/$Repo/releases/download/$tag"
+  $architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
+  $assetArch = switch ($architecture) {
+    "x64" { "amd64" }
+    "arm64" { "arm64" }
+    default { throw "[install.with-watch] unsupported Windows architecture: $architecture" }
+  }
+  $assetName = "with-watch-windows-$assetArch.zip"
+
+  $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ("with-watch-install-" + [System.Guid]::NewGuid().ToString("N"))
+  New-Item -Path $tmpDir -ItemType Directory | Out-Null
+
+  try {
+    $assetPath = Join-Path $tmpDir $assetName
+    $sumsPath = Join-Path $tmpDir "SHA256SUMS"
+    $bundlePath = "$assetPath.sigstore.json"
+
+    Write-Host "[install.with-watch] downloading $assetName"
+    Invoke-WebRequest -Uri "$baseUrl/$assetName" -OutFile $assetPath
+    Invoke-WebRequest -Uri "$baseUrl/SHA256SUMS" -OutFile $sumsPath
+    Download-Bundle -BaseUrl $baseUrl -AssetName $assetName -BundlePath $bundlePath
+
+    Verify-Checksum -FilePath $assetPath -Sha256SumsPath $sumsPath -AssetName $assetName
+    Verify-Bundle -FilePath $assetPath -BundlePath $bundlePath
+
+    $extractDir = Join-Path $tmpDir "extract"
+    Expand-Archive -Path $assetPath -DestinationPath $extractDir -Force
+
+    New-Item -Path $InstallDir -ItemType Directory -Force | Out-Null
+    Copy-Item -Path (Join-Path $extractDir "with-watch.exe") -Destination (Join-Path $InstallDir "with-watch.exe") -Force
+
+    Write-Host "[install.with-watch] installed with-watch.exe to $InstallDir"
+  }
+  finally {
+    Remove-Item -Path $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+  }
+}
+
+switch ($Method) {
+  "package-manager" {
+    # Compatibility shim: keep accepting the legacy package-manager flag until downstream
+    # automation and docs stop sending it for Windows installs.
+    Write-Warning "[install.with-watch] method=package-manager is deprecated on Windows and now maps to direct installation."
+    Install-Direct
+  }
+  "direct" {
+    Install-Direct
+  }
+}

--- a/scripts/install/with-watch.sh
+++ b/scripts/install/with-watch.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Install with-watch with package manager or direct release artifact.
+
+Usage:
+  ./scripts/install/with-watch.sh [--version <semver|latest>] [--method <package-manager|direct>] [--install-dir <dir>]
+
+Options:
+  --version <semver|latest>      Version without v-prefix (default: latest)
+  --method <package-manager|direct>
+                                 Install method (default: package-manager)
+  --install-dir <dir>            Binary install directory for direct mode (default: ~/.local/bin)
+USAGE
+}
+
+repo="delinoio/oss"
+tag_prefix="with-watch@v"
+workflow_identity="https://github.com/delinoio/oss/.github/workflows/release-with-watch.yml@"
+
+version="latest"
+method="package-manager"
+install_dir="${HOME}/.local/bin"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    --method)
+      method="${2:-}"
+      shift 2
+      ;;
+    --install-dir)
+      install_dir="${2:-}"
+      shift 2
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[install.with-watch] unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+resolve_latest_tag() {
+  if command -v gh >/dev/null 2>&1; then
+    gh release list --repo "$repo" --limit 200 --json tagName \
+      --jq "map(select(.tagName | startswith(\"${tag_prefix}\")))[0].tagName"
+    return
+  fi
+
+  curl -fsSL "https://api.github.com/repos/${repo}/releases?per_page=200" \
+    | awk -F '"' '/"tag_name"/ {print $4}' \
+    | grep "^${tag_prefix}" \
+    | head -n1
+}
+
+resolve_tag() {
+  if [ "$version" = "latest" ]; then
+    local latest_tag
+    latest_tag="$(resolve_latest_tag)"
+    if [ -z "$latest_tag" ] || [ "$latest_tag" = "null" ]; then
+      echo "[install.with-watch] failed to resolve latest with-watch tag" >&2
+      exit 1
+    fi
+    printf '%s\n' "$latest_tag"
+    return
+  fi
+
+  printf '%s%s\n' "$tag_prefix" "$version"
+}
+
+install_via_package_manager() {
+  if command -v brew >/dev/null 2>&1; then
+    echo "[install.with-watch] installing via Homebrew" >&2
+    brew install delinoio/tap/with-watch
+    return 0
+  fi
+
+  echo "[install.with-watch] package-manager mode requested but Homebrew is not available; falling back to direct" >&2
+  return 1
+}
+
+download_bundle() {
+  local base_url="$1"
+  local artifact="$2"
+  local bundle_name="${artifact}.sigstore.json"
+
+  if ! curl -fsSLO "${base_url}/${bundle_name}"; then
+    echo "[install.with-watch] missing bundle sidecar: ${bundle_name}" >&2
+    echo "[install.with-watch] direct installs require releases published with Sigstore bundle sidecars" >&2
+    exit 1
+  fi
+}
+
+verify_bundle() {
+  local artifact="$1"
+
+  if ! command -v cosign >/dev/null 2>&1; then
+    echo "[install.with-watch] cosign is required for direct install verification" >&2
+    exit 1
+  fi
+
+  cosign verify-blob \
+    --bundle "${artifact}.sigstore.json" \
+    --certificate-identity-regexp "$workflow_identity" \
+    --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+    "$artifact"
+}
+
+install_direct() {
+  local tag
+  tag="$(resolve_tag)"
+
+  local uname_os
+  uname_os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+
+  local os=""
+  case "$uname_os" in
+    linux*)
+      os="linux"
+      ;;
+    darwin*)
+      os="darwin"
+      ;;
+    *)
+      echo "[install.with-watch] unsupported OS for this installer: $uname_os" >&2
+      exit 1
+      ;;
+  esac
+
+  local uname_arch
+  uname_arch="$(uname -m)"
+
+  local arch=""
+  case "$uname_arch" in
+    x86_64|amd64)
+      arch="amd64"
+      ;;
+    arm64|aarch64)
+      arch="arm64"
+      ;;
+    *)
+      echo "[install.with-watch] unsupported architecture: $uname_arch" >&2
+      exit 1
+      ;;
+  esac
+
+  local asset_name="with-watch-${os}-${arch}.tar.gz"
+  local base_url="https://github.com/${repo}/releases/download/${tag}"
+
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "$tmp_dir"' EXIT
+
+  pushd "$tmp_dir" >/dev/null
+
+  echo "[install.with-watch] downloading artifact: $asset_name" >&2
+  curl -fsSLO "${base_url}/${asset_name}"
+  curl -fsSLO "${base_url}/SHA256SUMS"
+  download_bundle "$base_url" "$asset_name"
+
+  grep " ${asset_name}$" SHA256SUMS > SHA256SUMS.with-watch
+  shasum -a 256 -c SHA256SUMS.with-watch
+  verify_bundle "$asset_name"
+
+  tar -xzf "$asset_name"
+
+  mkdir -p "$install_dir"
+  install -m 0755 with-watch "$install_dir/with-watch"
+
+  popd >/dev/null
+
+  echo "[install.with-watch] installed with-watch to $install_dir/with-watch" >&2
+}
+
+case "$method" in
+  package-manager)
+    install_via_package_manager || install_direct
+    ;;
+  direct)
+    install_direct
+    ;;
+  *)
+    echo "[install.with-watch] unsupported method: $method" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add verified prebuilt installers for `cargo-mono` and `with-watch` on Bash and PowerShell
- add first-party-only `cargo-binstall` metadata for `cargo-mono`, `with-watch`, and `nodeup`
- update internal contracts, crate READMEs, and public docs for direct install and CI usage

## Testing
- `cargo test`
- `pnpm --filter public-docs test`
- `git diff --check`
- smoke-tested `scripts/install/cargo-mono.sh --help`
- smoke-tested `scripts/install/with-watch.sh --help`

## Notes
- `pwsh`, `cosign`, and `cargo-binstall` were not available in the local environment, so their smoke tests were not run here.