### PR TITLE
chore: bump cargo-mono to 0.6.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-mono"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "assert_cmd",
  "cargo_metadata",

--- a/crates/cargo-mono/Cargo.toml
+++ b/crates/cargo-mono/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-mono"
-version = "0.6.6"
+version = "0.6.7"
 edition = "2021"
 license = "MIT"
 description = "Cargo subcommand for Rust monorepo management"


### PR DESCRIPTION
## Summary
- bump `cargo-mono` from `0.6.6` to `0.6.7`
- update the workspace lockfile package entry to match the crate version

## Testing
- `cargo test`
