### PR TITLE
docs(public-docs): remove rust install script examples

### DIFF
--- a/apps/public-docs/cargo-mono.mdx
+++ b/apps/public-docs/cargo-mono.mdx
@@ -22,16 +22,6 @@ Tag contract:
 
 - `cargo-mono@v<semver>`
 
-Direct installers:
-
-```bash
-./scripts/install/cargo-mono.sh --version latest --method direct
-```
-
-```powershell
-./scripts/install/cargo-mono.ps1 -Version latest -Method direct
-```
-
 `cargo-binstall`:
 
 ```bash
@@ -46,8 +36,6 @@ GitHub Actions:
     tool: cargo-binstall
 - run: cargo binstall cargo-mono --no-confirm
 ```
-
-Direct installers verify Sigstore bundle sidecars (`*.sigstore.json`) and require `cosign`.
 
 ## Common workflows
 

--- a/apps/public-docs/nodeup.mdx
+++ b/apps/public-docs/nodeup.mdx
@@ -27,21 +27,6 @@ Package manager:
 - macOS/Linux: `brew install delinoio/tap/nodeup`
 - Homebrew installs prebuilt archives on macOS Intel, macOS Apple Silicon, Linux amd64, and Linux arm64
 
-Windows direct install:
-
-- `./scripts/install/nodeup.ps1 -Version latest -Method direct`
-- The PowerShell installer selects the `windows/amd64` or `windows/arm64` archive automatically based on the host architecture
-
-Script installer:
-
-```bash
-./scripts/install/nodeup.sh --version latest --method package-manager
-```
-
-```powershell
-./scripts/install/nodeup.ps1 -Version latest -Method direct
-```
-
 `cargo-binstall`:
 
 ```bash
@@ -57,7 +42,6 @@ GitHub Actions:
 - run: cargo binstall nodeup --no-confirm
 ```
 
-Direct installers verify Sigstore bundle sidecars (`*.sigstore.json`), require `cosign`, and only support bundle-enabled releases.
 `nodeup toolchain install` supports `macOS`, `Linux`, and `Windows` x64/arm64 hosts.
 
 ## Common workflows

--- a/apps/public-docs/with-watch.mdx
+++ b/apps/public-docs/with-watch.mdx
@@ -21,16 +21,6 @@ Package manager:
 - macOS/Linux: `brew install delinoio/tap/with-watch`
 - Homebrew installs prebuilt archives on macOS Intel, macOS Apple Silicon, Linux amd64, and Linux arm64
 
-Direct installers:
-
-```bash
-./scripts/install/with-watch.sh --version latest --method package-manager
-```
-
-```powershell
-./scripts/install/with-watch.ps1 -Version latest -Method direct
-```
-
 `cargo-binstall`:
 
 ```bash
@@ -51,8 +41,6 @@ Cargo:
 ```bash
 cargo install with-watch
 ```
-
-Direct installers verify Sigstore bundle sidecars (`*.sigstore.json`) and require `cosign`.
 
 ## Quick start
 

--- a/docs/apps-public-docs-foundation.md
+++ b/docs/apps-public-docs-foundation.md
@@ -17,6 +17,7 @@
 - Public-facing routes and content groupings must map to canonical docs contracts.
 - Top-level product page IDs currently include `nodeup`, `cargo-mono`, `derun`, `with-watch`, and `dexdex`.
 - The `With Watch` tab must route to the stable page ID `with-watch` and keep the `Command Rerun Watcher` grouping unless contracts are updated together.
+- Rust CLI/crate product pages may omit repo-local installer script flows from public guidance even when those installers remain supported by release/runtime contracts elsewhere in the repository.
 - Breaking navigation changes require explicit migration notes.
 
 ## Storage

--- a/docs/crates-cargo-mono-foundation.md
+++ b/docs/crates-cargo-mono-foundation.md
@@ -70,7 +70,8 @@
 - Release contract checks should align with `.github/workflows/release-cargo-mono.yml`.
 - Release assets must cover `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`.
 - Release signing outputs must use Sigstore bundle sidecars (`SHA256SUMS.sigstore.json` and `<artifact>.sigstore.json`).
-- Install docs must keep Bash, PowerShell, `cargo-binstall`, and GitHub Actions usage aligned with the installer scripts and manifest metadata.
+- Install docs that choose to describe direct-install flows must keep Bash, PowerShell, `cargo-binstall`, and GitHub Actions usage aligned with the installer scripts and manifest metadata.
+- `apps/public-docs` is not required to surface repo-local direct-installer script examples.
 
 ## Dependencies and Integrations
 - Integrates with Cargo workspace metadata and release workflows.

--- a/docs/crates-nodeup-foundation.md
+++ b/docs/crates-nodeup-foundation.md
@@ -61,7 +61,8 @@
 - Release assets must include both standalone prebuilt binaries (`nodeup-<os>-<arch>[.exe]`) and compressed archives (`nodeup-<os>-<arch>.tar.gz|zip`) for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`.
 - Release signing outputs must include `SHA256SUMS.sigstore.json` and `<artifact>.sigstore.json` sidecars; legacy `.sig`/`.pem` sidecars are out of scope for direct installation.
 - Homebrew release automation must render the prebuilt formula from release asset URLs and push tap updates directly to `delinoio/homebrew-tap` `main` with a dedicated tap-write credential.
-- Install docs must keep Bash, PowerShell, `cargo-binstall`, and GitHub Actions usage aligned with the installer scripts and manifest metadata.
+- Install docs that choose to describe direct-install flows must keep Bash, PowerShell, `cargo-binstall`, and GitHub Actions usage aligned with the installer scripts and manifest metadata.
+- `apps/public-docs` is not required to surface repo-local direct-installer script examples.
 - Completion coverage must include successful script generation, invalid shell/scope validation, and JSON-mode raw output behavior.
 - Output color coverage must include flag/env precedence, invalid env fallback, stream-aware auto-mode behavior, and JSON/completion ANSI exclusion.
 - `packageManager` coverage must include strict parsing, mismatch conflicts, yarn v1 vs v2+ mapping, direct-binary preference, and npm-exec fallback behavior.

--- a/docs/crates-with-watch-foundation.md
+++ b/docs/crates-with-watch-foundation.md
@@ -79,7 +79,8 @@
 - Release contract checks should align with `.github/workflows/release-with-watch.yml`.
 - Release assets must include standalone binaries (`with-watch-<os>-<arch>[.exe]`) and compressed archives (`with-watch-<os>-<arch>.tar.gz|zip`) for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`.
 - Release signing outputs must include `SHA256SUMS.sigstore.json` and `<artifact>.sigstore.json` sidecars.
-- Install docs must keep Bash, PowerShell, `cargo-binstall`, and GitHub Actions usage aligned with the installer scripts and manifest metadata.
+- Install docs that choose to describe direct-install flows must keep Bash, PowerShell, `cargo-binstall`, and GitHub Actions usage aligned with the installer scripts and manifest metadata.
+- `apps/public-docs` is not required to surface repo-local direct-installer script examples.
 
 ## Dependencies and Integrations
 - Uses `clap` for CLI parsing.


### PR DESCRIPTION
## Summary
- remove repo-local install script examples from the public-docs pages for cargo-mono, nodeup, and with-watch
- keep public guidance focused on Homebrew, cargo-binstall, and cargo install where applicable
- update public-docs and crate foundation contracts so installer scripts can remain supported without being surfaced in public-docs

## Testing
- pnpm --filter public-docs test
- rg -n "scripts/install/cargo-mono|scripts/install/nodeup|scripts/install/with-watch" apps/public-docs
- rg -n "cargo binstall cargo-mono|cargo binstall nodeup|cargo binstall with-watch|cargo install with-watch" apps/public-docs