### PR TITLE
chore(nodeup): bump version to 0.1.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "nodeup"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/crates/nodeup/Cargo.toml
+++ b/crates/nodeup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nodeup"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 license = "MIT"
 description = "Rustup-like Node.js version manager"


### PR DESCRIPTION
## Summary
- bump the `nodeup` crate version from `0.1.11` to `0.1.12`
- keep the workspace `Cargo.lock` package entry aligned with the crate manifest

## Testing
- cargo test
