### PR TITLE
chore(with-watch): bump patch version to 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3596,7 +3596,7 @@ dependencies = [
 
 [[package]]
 name = "with-watch"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "assert_cmd",
  "blake3",

--- a/crates/with-watch/Cargo.toml
+++ b/crates/with-watch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "with-watch"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "MIT"
 description = "Watch command inputs and rerun commands when they change"


### PR DESCRIPTION
## Summary
- bump `with-watch` from `0.1.4` to `0.1.5` via `cargo mono bump`
- sync `Cargo.lock` after workspace validation refreshed the package entry

## Testing
- `cargo test`