### PR TITLE
cargo-mono: remove sparse index prefetch timeout

### DIFF
--- a/crates/cargo-mono/src/commands/publish.rs
+++ b/crates/cargo-mono/src/commands/publish.rs
@@ -29,7 +29,6 @@ pub(super) const PUBLISH_MAX_ATTEMPTS_ENV: &str = "CARGO_MONO_PUBLISH_MAX_ATTEMP
 pub(super) const PUBLISH_PREFETCH_CONCURRENCY_ENV: &str = "CARGO_MONO_PUBLISH_PREFETCH_CONCURRENCY";
 const DEFAULT_PREFETCH_CONCURRENCY: usize = 16;
 const MAX_PREFETCH_CONCURRENCY: usize = 64;
-const PREFETCH_HTTP_TIMEOUT: Duration = Duration::from_secs(15);
 const PUBLISH_NO_VERIFY: bool = true;
 const INITIAL_RETRY_DELAY_SECONDS: u64 = 2;
 const MAX_RETRY_DELAY_SECONDS: u64 = 60;
@@ -869,10 +868,7 @@ fn run_parallel_sparse_index_lookup(
         return Vec::new();
     }
 
-    let http_client = match reqwest::blocking::Client::builder()
-        .timeout(PREFETCH_HTTP_TIMEOUT)
-        .build()
-    {
+    let http_client = match reqwest::blocking::Client::builder().build() {
         Ok(client) => client,
         Err(error) => {
             return candidates

--- a/docs/crates-cargo-mono-foundation.md
+++ b/docs/crates-cargo-mono-foundation.md
@@ -23,6 +23,7 @@
 - `publish` must treat only index propagation lag and registry rate limiting as retryable failures; other publish failures must still fail immediately.
 - Retryable `publish` failures must retry indefinitely by default with capped exponential backoff (`2s`, `4s`, `8s`, `16s`, `32s`, then `60s`), and rate-limit retries must honor `Retry-After` when present.
 - Operators must be able to cap retry attempts via `cargo mono publish --max-attempts <count>` or `CARGO_MONO_PUBLISH_MAX_ATTEMPTS`, with precedence `--max-attempts` > env > default unlimited retries.
+- crates.io sparse-index prefetch must not enforce a separate client-side HTTP timeout; sparse index requests must rely on the HTTP client's default timeout behavior.
 - Publish tag creation is opt-in by default (no config means no tags), must remain local-only (`git tag` without push), and must use `<crate>@v<version>` naming.
 - Remote tag publication is owned by CI automation: `.github/workflows/auto-publish.yml` must run `git push --tags` after a successful `publish` command, with checkout credential persistence disabled and authentication bound to `secrets.GH_TOKEN` (non-`GITHUB_TOKEN`) so downstream tag-triggered workflows run.
 - If `publish` tag configuration references unknown workspace packages, command execution must fail with `invalid-input`.

--- a/docs/project-cargo-mono.md
+++ b/docs/project-cargo-mono.md
@@ -19,6 +19,7 @@ Provide a Cargo subcommand for Rust monorepo lifecycle management, including ver
 - `publish` must delegate to `cargo publish --no-verify` for all package uploads and dry-run executions.
 - Retryable `publish` failures remain narrowly scoped to index propagation lag and registry rate limiting, and must retry indefinitely by default with capped exponential backoff (`2s`, `4s`, `8s`, `16s`, `32s`, then `60s`) while honoring `Retry-After` when present.
 - `publish` retry overrides must remain operator-controlled through `--max-attempts <count>` and `CARGO_MONO_PUBLISH_MAX_ATTEMPTS`, with precedence `--max-attempts` > env > default unlimited retries.
+- `publish` crates.io sparse-index prefetch must not enforce a separate client-side HTTP timeout; sparse index requests must rely on the HTTP client's default timeout behavior.
 - Remote tag publication remains CI-owned: `auto-publish` pushes release tags with `git push --tags` after a successful `publish` run, with checkout credential persistence disabled and authentication bound to `secrets.GH_TOKEN` (non-`GITHUB_TOKEN`) so downstream tag-triggered workflows run.
 - Publish tag configuration must be opt-in through `[workspace.metadata.cargo-mono.publish.tag].packages`, and tag naming must remain `<crate>@v<version>`.
 - Tag release automation must detect `cargo-mono@v*` and produce signed prebuilt artifacts for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`, plus Sigstore bundle sidecars (`*.sigstore.json`) without changing CLI command behavior.


### PR DESCRIPTION
## Summary
- remove the explicit `15s` reqwest timeout from `cargo-mono` sparse index prefetch during `publish`
- keep existing prefetch concurrency, rate-limit retry, and already-published skip behavior unchanged
- document that crates.io sparse-index prefetch relies on the HTTP client's default timeout behavior

## Why
`cargo-mono publish` prefetch could fail early on slower registry responses because it enforced a separate client-side timeout for sparse index lookups. Removing that override avoids premature lookup failures without changing the existing publish retry and backoff behavior.

## Impact
- sparse-index prefetch no longer imposes its own client-side HTTP timeout
- operator-facing CLI and environment-variable interfaces stay unchanged
- project and crate contracts now describe the intended timeout behavior

## Validation
- `cargo fmt --all --check`
- `cargo test`