### PR TITLE
[codex] bump cargo-mono to 0.6.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-mono"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "assert_cmd",
  "cargo_metadata",

--- a/crates/cargo-mono/Cargo.toml
+++ b/crates/cargo-mono/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-mono"
-version = "0.6.7"
+version = "0.6.8"
 edition = "2021"
 license = "MIT"
 description = "Cargo subcommand for Rust monorepo management"


### PR DESCRIPTION
## Summary
- bump `cargo-mono` from `0.6.7` to `0.6.8`
- update the workspace lockfile entry to match the crate version

## Why
- prepare the next patch release of `cargo-mono` while keeping crate metadata and the lockfile aligned

## Testing
- `cargo test`