### PR TITLE
chore: bump cargo-mono to 0.6.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-mono"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "assert_cmd",
  "cargo_metadata",

--- a/crates/cargo-mono/Cargo.toml
+++ b/crates/cargo-mono/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-mono"
-version = "0.6.8"
+version = "0.6.9"
 edition = "2021"
 license = "MIT"
 description = "Cargo subcommand for Rust monorepo management"


### PR DESCRIPTION
## Summary
- Bump the `cargo-mono` crate patch version from `0.6.8` to `0.6.9`.
- Refresh the workspace lockfile entry for `cargo-mono`.

## Validation
- `cargo test -p cargo-mono`
- `git diff --check`