### PR TITLE
fix cargo-mono publish dependency ordering

### DIFF
--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -38,6 +38,7 @@
 - Preserve `cargo mono` subcommand compatibility (`cargo-mono` binary naming contract).
 - Keep release-tag responsibility split: `bump` must not create tags, and `publish` may create tags only for packages listed in `[workspace.metadata.cargo-mono.publish.tag].packages`.
 - Keep `publish` delegation aligned with the documented contract: `cargo mono publish` must invoke `cargo publish --no-verify` in both execute and dry-run modes.
+- Keep `publish` package ordering based on manifest-declared workspace path dependencies, including optional feature-gated dependencies; do not rely only on Cargo's default-feature resolve graph.
 - Ensure release automation (`bump`, `publish`) logs include structured operational context.
 - Keep runtime error output on the fixed `Summary/Context/Hint` three-line contract and include only safe debugging context values.
 - Keep direct installers and `cargo-binstall` metadata aligned with release asset names, signing contracts, and install docs.

--- a/crates/cargo-mono/src/commands/publish.rs
+++ b/crates/cargo-mono/src/commands/publish.rs
@@ -385,6 +385,15 @@ pub fn execute(args: &PublishArgs, output: OutputSettings, app: &CargoMonoApp) -
     }
 
     let order = app.workspace.topological_order(&publishable_targets)?;
+    info!(
+        command_path = "cargo-mono.publish",
+        workspace_root = %app.workspace.root.display(),
+        action = "resolve-publish-order",
+        outcome = "resolved",
+        package_count = order.len(),
+        order_sample = %format_publish_order_sample(&order, 8),
+        "Resolved publish package order"
+    );
     let prefetch_result = prefetch_published_versions(
         &app.workspace,
         &order,
@@ -1307,6 +1316,26 @@ fn indent_multiline(raw: &str, prefix: &str) -> String {
         .map(|line| format!("{prefix}{line}"))
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn format_publish_order_sample(order: &[String], limit: usize) -> String {
+    if order.is_empty() {
+        return "none".to_string();
+    }
+
+    let visible_count = order.len().min(limit);
+    let mut sample = order
+        .iter()
+        .take(visible_count)
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("|");
+
+    if order.len() > visible_count {
+        sample.push_str(&format!("|...(+{} more)", order.len() - visible_count));
+    }
+
+    sample
 }
 
 fn retry_delay(attempt: usize) -> Duration {

--- a/crates/cargo-mono/src/workspace.rs
+++ b/crates/cargo-mono/src/workspace.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use cargo_metadata::{MetadataCommand, PackageId};
+use cargo_metadata::MetadataCommand;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use semver::Version;
 use serde::Serialize;
@@ -52,7 +52,6 @@ impl Workspace {
             .cloned()
             .collect::<BTreeSet<_>>();
 
-        let mut id_to_name = HashMap::<PackageId, String>::new();
         let mut packages = BTreeMap::<String, WorkspacePackage>::new();
 
         for package in metadata
@@ -125,7 +124,6 @@ impl Workspace {
                 publishable,
             };
 
-            id_to_name.insert(package.id.clone(), package.name.clone());
             packages.insert(package.name.clone(), entry);
         }
 
@@ -138,26 +136,35 @@ impl Workspace {
             .map(|name| (name.clone(), BTreeSet::new()))
             .collect::<BTreeMap<_, _>>();
 
-        if let Some(resolve) = metadata.resolve {
-            for node in resolve.nodes {
-                let Some(node_name) = id_to_name.get(&node.id) else {
+        let package_name_by_directory = packages
+            .values()
+            .map(|package| (package.directory.clone(), package.name.clone()))
+            .collect::<BTreeMap<_, _>>();
+
+        for package in metadata
+            .packages
+            .iter()
+            .filter(|pkg| workspace_members.contains(&pkg.id))
+        {
+            let package_name = package.name.clone();
+            for dependency in &package.dependencies {
+                let Some(dependency_path) = dependency.path.as_ref() else {
+                    continue;
+                };
+                let dependency_path =
+                    normalize_dependency_path(&root, dependency_path.as_std_path());
+                let Some(dependency_name) = package_name_by_directory.get(&dependency_path) else {
                     continue;
                 };
 
-                for dependency in node.deps {
-                    let Some(dependency_name) = id_to_name.get(&dependency.pkg) else {
-                        continue;
-                    };
-
-                    dependencies
-                        .entry(node_name.clone())
-                        .or_default()
-                        .insert(dependency_name.clone());
-                    dependents
-                        .entry(dependency_name.clone())
-                        .or_default()
-                        .insert(node_name.clone());
-                }
+                dependencies
+                    .entry(package_name.clone())
+                    .or_default()
+                    .insert(dependency_name.clone());
+                dependents
+                    .entry(dependency_name.clone())
+                    .or_default()
+                    .insert(package_name.clone());
             }
         }
         let workspace_package_names = packages.keys().cloned().collect::<BTreeSet<_>>();
@@ -578,6 +585,14 @@ fn path_is_excluded_by_filters(
         include_path_globset.is_some_and(|globset| globset.is_match(&normalized_path));
     let excluded = exclude_path_globset.is_some_and(|globset| globset.is_match(&normalized_path));
     excluded && !include_override
+}
+
+fn normalize_dependency_path(root: &Path, dependency_path: &Path) -> PathBuf {
+    if dependency_path.is_absolute() {
+        dependency_path.to_path_buf()
+    } else {
+        root.join(dependency_path)
+    }
 }
 
 fn format_string_sample(values: &[String], limit: usize) -> String {

--- a/crates/cargo-mono/tests/cli.rs
+++ b/crates/cargo-mono/tests/cli.rs
@@ -830,6 +830,38 @@ fn publish_dry_run_forwards_no_verify_to_cargo_publish() {
 }
 
 #[test]
+fn publish_orders_optional_workspace_dependency_before_dependent() {
+    let temp_dir = init_optional_dependency_workspace();
+
+    let mut command = cargo_mono_command_with_fake_publish(temp_dir.path());
+    let output = run_success(command.current_dir(temp_dir.path()).args([
+        "--output",
+        "json",
+        "publish",
+        "--allow-dirty",
+        "--registry",
+        "internal",
+        "--package",
+        "app",
+        "--package",
+        "compat",
+    ]));
+
+    let result = parse_stdout_json(&output);
+    assert_eq!(
+        result["published"],
+        json!([
+            { "name": "compat", "attempts": 1 },
+            { "name": "app", "attempts": 1 }
+        ])
+    );
+    assert_eq!(
+        read_fake_publish_packages(temp_dir.path()),
+        vec!["compat".to_string(), "app".to_string()]
+    );
+}
+
+#[test]
 fn publish_retries_index_not_ready_past_three_attempts_by_default() {
     let temp_dir = init_mixed_publishability_workspace();
     write_fake_publish_sequence(
@@ -1058,12 +1090,31 @@ set -euo pipefail
 if [ "${1-}" = "publish" ]; then
   : "${FAKE_CARGO_PUBLISH_ARGS_FILE:?}"
   : "${FAKE_CARGO_PUBLISH_ATTEMPT_FILE:?}"
+  : "${FAKE_CARGO_PUBLISH_LOG_FILE:?}"
   attempt=1
   if [ -f "${FAKE_CARGO_PUBLISH_ATTEMPT_FILE}" ]; then
     attempt=$(( $(cat "${FAKE_CARGO_PUBLISH_ATTEMPT_FILE}") + 1 ))
   fi
   printf '%s\n' "${attempt}" > "${FAKE_CARGO_PUBLISH_ATTEMPT_FILE}"
   printf '%s\n' "$@" > "${FAKE_CARGO_PUBLISH_ARGS_FILE}"
+
+  published_package=""
+  while [ "$#" -gt 0 ]; do
+    arg="$1"
+    shift
+    case "${arg}" in
+      -p | --package)
+        published_package="${1-}"
+        if [ "$#" -gt 0 ]; then
+          shift
+        fi
+        ;;
+      --package=*)
+        published_package="${arg#--package=}"
+        ;;
+    esac
+  done
+  printf '%s\n' "${published_package}" >> "${FAKE_CARGO_PUBLISH_LOG_FILE}"
 
   scenario="success"
   if [ -n "${FAKE_CARGO_PUBLISH_SCENARIO_FILE-}" ] && [ -f "${FAKE_CARGO_PUBLISH_SCENARIO_FILE}" ]; then
@@ -1120,6 +1171,10 @@ exec "${REAL_CARGO:?}" "$@"
         fake_publish_attempts_path(working_dir),
     );
     command.env(
+        "FAKE_CARGO_PUBLISH_LOG_FILE",
+        fake_publish_log_path(working_dir),
+    );
+    command.env(
         "FAKE_CARGO_PUBLISH_SCENARIO_FILE",
         fake_publish_scenario_path(working_dir),
     );
@@ -1133,6 +1188,10 @@ fn fake_publish_args_path(working_dir: &Path) -> PathBuf {
 
 fn fake_publish_attempts_path(working_dir: &Path) -> PathBuf {
     working_dir.join(".fake-publish-attempts")
+}
+
+fn fake_publish_log_path(working_dir: &Path) -> PathBuf {
+    working_dir.join(".fake-publish-log")
 }
 
 fn fake_publish_scenario_path(working_dir: &Path) -> PathBuf {
@@ -1151,6 +1210,12 @@ fn read_fake_publish_attempt_count(working_dir: &Path) -> usize {
         .trim()
         .parse::<usize>()
         .expect("fake cargo publish attempt count should be numeric")
+}
+
+fn read_fake_publish_packages(working_dir: &Path) -> Vec<String> {
+    let raw = fs::read_to_string(fake_publish_log_path(working_dir))
+        .expect("failed to read fake cargo publish package log");
+    raw.lines().map(str::to_string).collect()
 }
 
 fn write_fake_publish_sequence(working_dir: &Path, scenarios: &[&str]) {
@@ -1299,6 +1364,76 @@ alpha = { path = "../alpha", version = "0.1.0" }
         "pub fn gamma() -> &'static str { \"gamma\" }\n",
     )
     .expect("failed to write gamma source");
+
+    run_git(root, &["init", "-q"]);
+    run_git(root, &["config", "user.name", "test"]);
+    run_git(root, &["config", "user.email", "test@example.com"]);
+    run_git(root, &["add", "."]);
+    run_git(
+        root,
+        &[
+            "-c",
+            "user.name=test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-q",
+            "-m",
+            "init",
+        ],
+    );
+
+    temp_dir
+}
+
+fn init_optional_dependency_workspace() -> tempfile::TempDir {
+    let temp_dir = tempfile::tempdir().expect("failed to create tempdir");
+    let root = temp_dir.path();
+
+    fs::create_dir_all(root.join("crates/app/src")).expect("failed to create app directory");
+    fs::create_dir_all(root.join("crates/compat/src")).expect("failed to create compat directory");
+
+    fs::write(
+        root.join("Cargo.toml"),
+        r#"[workspace]
+members = ["crates/app", "crates/compat"]
+resolver = "2"
+"#,
+    )
+    .expect("failed to write workspace manifest");
+    fs::write(
+        root.join("crates/app/Cargo.toml"),
+        r#"[package]
+name = "app"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[features]
+compat = ["dep:compat"]
+
+[dependencies]
+compat = { path = "../compat", version = "0.1.0", optional = true }
+"#,
+    )
+    .expect("failed to write app manifest");
+    fs::write(
+        root.join("crates/compat/Cargo.toml"),
+        r#"[package]
+name = "compat"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+"#,
+    )
+    .expect("failed to write compat manifest");
+    fs::write(root.join("crates/app/src/lib.rs"), "pub fn app() {}\n")
+        .expect("failed to write app source");
+    fs::write(
+        root.join("crates/compat/src/lib.rs"),
+        "pub fn compat() {}\n",
+    )
+    .expect("failed to write compat source");
 
     run_git(root, &["init", "-q"]);
     run_git(root, &["config", "user.name", "test"]);

--- a/docs/crates-cargo-mono-foundation.md
+++ b/docs/crates-cargo-mono-foundation.md
@@ -20,6 +20,7 @@
 - `bump` must not create Git tags.
 - `publish` is the only command allowed to create release tags, and only for packages listed in `[workspace.metadata.cargo-mono.publish.tag].packages`.
 - `publish` must always delegate to `cargo publish --no-verify`, including when `cargo mono publish --dry-run` is used.
+- `publish` package ordering must be derived from manifest-declared workspace path dependencies, including optional feature-gated dependencies and normal, build, dev, and target-specific dependency declarations.
 - `publish` must treat only index propagation lag and registry rate limiting as retryable failures; other publish failures must still fail immediately.
 - Retryable `publish` failures must retry indefinitely by default with capped exponential backoff (`2s`, `4s`, `8s`, `16s`, `32s`, then `60s`), and rate-limit retries must honor `Retry-After` when present.
 - Operators must be able to cap retry attempts via `cargo mono publish --max-attempts <count>` or `CARGO_MONO_PUBLISH_MAX_ATTEMPTS`, with precedence `--max-attempts` > env > default unlimited retries.
@@ -76,6 +77,7 @@
 
 ## Dependencies and Integrations
 - Integrates with Cargo workspace metadata and release workflows.
+- Publish ordering uses workspace package manifest dependency declarations rather than only Cargo's default-feature resolve graph, so optional workspace path dependencies are published before dependents that expose them behind features.
 - Integrates with root automation (`auto-publish`) through stable command contracts, including CI-driven tag publication.
 - Integrates with tag-based binary distribution automation (`release-cargo-mono`) through stable artifact naming and bundle-signing contracts.
 - Integrates with direct installer scripts and `cargo-binstall` metadata for prebuilt binary distribution.

--- a/docs/project-cargo-mono.md
+++ b/docs/project-cargo-mono.md
@@ -17,6 +17,7 @@ Provide a Cargo subcommand for Rust monorepo lifecycle management, including ver
 - Release automation integration must keep stable command semantics.
 - Release tagging responsibility is split by command: `bump` must not create Git tags, while `publish` may create local Git tags for configured packages.
 - `publish` must delegate to `cargo publish --no-verify` for all package uploads and dry-run executions.
+- `publish` package ordering must include all manifest-declared workspace path dependencies, including optional feature-gated dependencies that are absent from Cargo's default-feature resolve graph.
 - Retryable `publish` failures remain narrowly scoped to index propagation lag and registry rate limiting, and must retry indefinitely by default with capped exponential backoff (`2s`, `4s`, `8s`, `16s`, `32s`, then `60s`) while honoring `Retry-After` when present.
 - `publish` retry overrides must remain operator-controlled through `--max-attempts <count>` and `CARGO_MONO_PUBLISH_MAX_ATTEMPTS`, with precedence `--max-attempts` > env > default unlimited retries.
 - `publish` crates.io sparse-index prefetch must not enforce a separate client-side HTTP timeout; sparse index requests must rely on the HTTP client's default timeout behavior.


### PR DESCRIPTION
## Summary
- Build cargo-mono publish ordering from manifest-declared workspace path dependencies instead of Cargo's default-feature resolve graph.
- Include optional feature-gated workspace dependencies so packages like `swc_css_compat` publish before dependents such as `swc_css`.
- Add structured logging for the resolved publish order and document the contract in the cargo-mono docs and crates AGENTS rules.

## Root Cause
`cargo metadata`'s resolved graph omits inactive optional dependencies, so `cargo-mono publish` could skip an unpublished optional workspace dependency and retry the dependent forever while waiting for an index version that had never been published.

## Validation
- `cargo test -p cargo-mono`
- `cargo test`
- `git diff --check`