### PR TITLE
chore: Add repair-pr skill

### DIFF
--- a/.agents/skills/repair-pr/SKILL.md
+++ b/.agents/skills/repair-pr/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: repair-pr
+description: One-shot pull request repair workflow for this repository. Use when asked to repair the current or specified PR by resolving merge conflicts, applying actionable unresolved review feedback, resolving handled review threads, fixing failing CI, committing coherent repair chunks, and pushing once at the end.
+---
+
+# Repair PR
+
+## Goal
+
+Repair the current or specified GitHub PR once, then stop. Handle merge conflicts, actionable unresolved review feedback, and CI failures in that order. Commit after each coherent repair phase, but push only once after all local changes are complete.
+
+## Workflow
+
+1. Resolve the PR context.
+   - Read the repository `AGENTS.md` before changing code.
+   - List files in `docs/` before starting work, and use `docs/` as the source of truth for project contracts.
+   - Confirm `gh auth status` works.
+   - If the user provided a PR number or URL, use it; otherwise use `gh pr view --json number,url,baseRefName,headRefName`.
+   - Run `node .agents/skills/repair-pr/scripts/repair-pr.mjs status --pr <pr>` to collect merge state, unresolved review threads, and failing checks.
+   - Use `--review-author <login>` only when the user or task scope asks to focus on a specific reviewer or bot.
+
+2. Resolve merge conflicts first.
+   - Treat `mergeStateStatus: DIRTY` or GitHub reporting conflicts as the conflict signal.
+   - Fetch the PR base branch and merge it into the PR branch; do not rebase.
+   - Use `git merge origin/<baseRefName>` or the correct remote-tracking base ref for this repository.
+   - Resolve conflicts by reading source, fixtures, tests, `AGENTS.md`, and relevant `docs/` contracts. Do not choose `--ours` or `--theirs` blindly.
+   - Run focused verification for the resolved area, then `git add` the intended files and commit the merge or conflict repair before moving on.
+
+3. Apply review feedback.
+   - Consider only unresolved, non-outdated review threads from the helper output.
+   - Ignore approvals, resolved threads, outdated threads, duplicates, and non-actionable notes.
+   - Group related actionable threads by behavior or file, implement the smallest correct fix, and update relevant `docs/` or `AGENTS.md` files when contracts, policies, or structure changed.
+   - Run focused tests for each repair group.
+   - Commit each coherent review-fix group.
+   - After the relevant fix is committed, resolve each handled thread with `node .agents/skills/repair-pr/scripts/repair-pr.mjs resolve-thread <thread-id>`.
+   - If a review comment is ambiguous or would cause a regression, leave the thread unresolved and report the blocker.
+
+4. Fix CI failures.
+   - Use `gh pr checks <pr> --json name,state,bucket,link,workflow` to identify failing checks.
+   - For GitHub Actions failures, inspect logs with `gh run view <run-id> --log` or job logs from `gh api` when needed.
+   - Treat external checks as report-only unless their logs are available through `gh`.
+   - Fix the observed root cause, run focused local verification, and commit the CI fix.
+
+5. Finish once.
+   - Run repository-required verification from `AGENTS.md` when feasible. At minimum, run checks for the touched domains: `cargo test` from the root after Rust changes, `pnpm test` from the relevant frontend directory after frontend changes, and the closest focused checks for other domains.
+   - Re-run `node .agents/skills/repair-pr/scripts/repair-pr.mjs status --pr <pr>` once for a final summary.
+   - If any commits were created, push once with `git push` for the current branch. Because this workflow merges instead of rebasing, do not force-push.
+   - Do not start a monitoring loop or keep polling checks after the final status check.
+
+## Helper
+
+Use the helper from the repository root:
+
+```bash
+node .agents/skills/repair-pr/scripts/repair-pr.mjs status
+node .agents/skills/repair-pr/scripts/repair-pr.mjs status --pr 123 --json
+node .agents/skills/repair-pr/scripts/repair-pr.mjs status --pr 123 --review-author chatgpt-codex-connector[bot]
+node .agents/skills/repair-pr/scripts/repair-pr.mjs resolve-thread PRRT_kwDO...
+```
+
+The helper is an inventory and review-thread mutation aid. It does not implement code fixes, stage changes, commit, push, or decide whether a review comment is correct.
+
+## Commit And Push Rules
+
+- Commit after each coherent phase that changes files: merge-conflict repair, review repair group, CI repair group.
+- Stage only files that belong to the current repair.
+- Push exactly once at the end if at least one commit was created.
+- If no local changes were needed, do not create an empty commit and do not push.

--- a/.agents/skills/repair-pr/SKILL.md
+++ b/.agents/skills/repair-pr/SKILL.md
@@ -16,6 +16,8 @@ Repair the current or specified GitHub PR once, then stop. Handle merge conflict
    - List files in `docs/` before starting work, and use `docs/` as the source of truth for project contracts.
    - Confirm `gh auth status` works.
    - If the user provided a PR number or URL, use it; otherwise use `gh pr view --json number,url,baseRefName,headRefName`.
+   - Before making repair commits, confirm the worktree is clean with `git status --short`. If it is dirty, stop and ask how to handle the pre-existing changes.
+   - If the user provided a PR number or URL, check out the PR branch with `gh pr checkout <pr>` before making commits. Otherwise, assert that the current branch matches the PR `headRefName`; if it does not, stop before changing files.
    - Run `node .agents/skills/repair-pr/scripts/repair-pr.mjs status --pr <pr>` to collect merge state, unresolved `chatgpt-codex-connector[bot]` review threads, and failing checks.
 
 2. Resolve merge conflicts first.
@@ -31,7 +33,7 @@ Repair the current or specified GitHub PR once, then stop. Handle merge conflict
    - Group related actionable threads by behavior or file, implement the smallest correct fix, and update relevant `docs/` or `AGENTS.md` files when contracts, policies, or structure changed.
    - Run focused tests for each repair group.
    - Commit each coherent review-fix group.
-   - After the relevant fix is committed, resolve each handled thread with `node .agents/skills/repair-pr/scripts/repair-pr.mjs resolve-thread <thread-id>`.
+   - Record each handled thread id, but do not resolve review threads until the final push succeeds.
    - If a review comment is ambiguous or would cause a regression, leave the thread unresolved and report the blocker.
 
 4. Fix CI failures.
@@ -44,6 +46,7 @@ Repair the current or specified GitHub PR once, then stop. Handle merge conflict
    - Run repository-required verification from `AGENTS.md` when feasible. At minimum, run checks for the touched domains: `cargo test` from the root after Rust changes, `pnpm test` from the relevant frontend directory after frontend changes, and the closest focused checks for other domains.
    - Re-run `node .agents/skills/repair-pr/scripts/repair-pr.mjs status --pr <pr>` once for a final summary.
    - If any commits were created, push once with `git push` for the current branch. Because this workflow merges instead of rebasing, do not force-push.
+   - After the final push succeeds, resolve each handled review thread with `node .agents/skills/repair-pr/scripts/repair-pr.mjs resolve-thread <thread-id>`.
    - Do not start a monitoring loop or keep polling checks after the final status check.
 
 ## Helper

--- a/.agents/skills/repair-pr/SKILL.md
+++ b/.agents/skills/repair-pr/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: repair-pr
-description: One-shot pull request repair workflow for this repository. Use when asked to repair the current or specified PR by resolving merge conflicts, applying actionable unresolved review feedback, resolving handled review threads, fixing failing CI, committing coherent repair chunks, and pushing once at the end.
+description: One-shot pull request repair workflow for this repository. Use when asked to repair the current or specified PR by resolving merge conflicts, applying actionable unresolved review feedback from chatgpt-codex-connector[bot], resolving handled bot review threads, fixing failing CI, committing coherent repair chunks, and pushing once at the end.
 ---
 
 # Repair PR
 
 ## Goal
 
-Repair the current or specified GitHub PR once, then stop. Handle merge conflicts, actionable unresolved review feedback, and CI failures in that order. Commit after each coherent repair phase, but push only once after all local changes are complete.
+Repair the current or specified GitHub PR once, then stop. Handle merge conflicts, actionable unresolved review feedback from `chatgpt-codex-connector[bot]`, and CI failures in that order. Commit after each coherent repair phase, but push only once after all local changes are complete.
 
 ## Workflow
 
@@ -16,8 +16,7 @@ Repair the current or specified GitHub PR once, then stop. Handle merge conflict
    - List files in `docs/` before starting work, and use `docs/` as the source of truth for project contracts.
    - Confirm `gh auth status` works.
    - If the user provided a PR number or URL, use it; otherwise use `gh pr view --json number,url,baseRefName,headRefName`.
-   - Run `node .agents/skills/repair-pr/scripts/repair-pr.mjs status --pr <pr>` to collect merge state, unresolved review threads, and failing checks.
-   - Use `--review-author <login>` only when the user or task scope asks to focus on a specific reviewer or bot.
+   - Run `node .agents/skills/repair-pr/scripts/repair-pr.mjs status --pr <pr>` to collect merge state, unresolved `chatgpt-codex-connector[bot]` review threads, and failing checks.
 
 2. Resolve merge conflicts first.
    - Treat `mergeStateStatus: DIRTY` or GitHub reporting conflicts as the conflict signal.
@@ -26,9 +25,9 @@ Repair the current or specified GitHub PR once, then stop. Handle merge conflict
    - Resolve conflicts by reading source, fixtures, tests, `AGENTS.md`, and relevant `docs/` contracts. Do not choose `--ours` or `--theirs` blindly.
    - Run focused verification for the resolved area, then `git add` the intended files and commit the merge or conflict repair before moving on.
 
-3. Apply review feedback.
-   - Consider only unresolved, non-outdated review threads from the helper output.
-   - Ignore approvals, resolved threads, outdated threads, duplicates, and non-actionable notes.
+3. Apply bot review feedback.
+   - Consider only unresolved, non-outdated review threads with at least one comment authored by `chatgpt-codex-connector[bot]`.
+   - Ignore approvals, resolved threads, outdated threads, duplicates, non-actionable notes, and review threads that do not include `chatgpt-codex-connector[bot]` feedback.
    - Group related actionable threads by behavior or file, implement the smallest correct fix, and update relevant `docs/` or `AGENTS.md` files when contracts, policies, or structure changed.
    - Run focused tests for each repair group.
    - Commit each coherent review-fix group.
@@ -54,7 +53,6 @@ Use the helper from the repository root:
 ```bash
 node .agents/skills/repair-pr/scripts/repair-pr.mjs status
 node .agents/skills/repair-pr/scripts/repair-pr.mjs status --pr 123 --json
-node .agents/skills/repair-pr/scripts/repair-pr.mjs status --pr 123 --review-author chatgpt-codex-connector[bot]
 node .agents/skills/repair-pr/scripts/repair-pr.mjs resolve-thread PRRT_kwDO...
 ```
 

--- a/.agents/skills/repair-pr/agents/openai.yaml
+++ b/.agents/skills/repair-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Repair PR"
+  short_description: "Repair PR conflicts, reviews, and CI"
+  default_prompt: "Use $repair-pr to repair the current PR once, then push the finished fixes."

--- a/.agents/skills/repair-pr/agents/openai.yaml
+++ b/.agents/skills/repair-pr/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Repair PR"
-  short_description: "Repair PR conflicts, reviews, and CI"
+  short_description: "Repair PR conflicts, bot reviews, and CI"
   default_prompt: "Use $repair-pr to repair the current PR once, then push the finished fixes."

--- a/.agents/skills/repair-pr/scripts/repair-pr.mjs
+++ b/.agents/skills/repair-pr/scripts/repair-pr.mjs
@@ -1,0 +1,608 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { exit } from "node:process";
+
+const args = process.argv.slice(2);
+const command = args[0];
+
+if (!command || command === "--help" || command === "-h") {
+  printGlobalHelp();
+  exit(command ? 0 : 1);
+}
+
+if (command === "status") {
+  statusCommand(args.slice(1));
+} else if (command === "resolve-thread") {
+  resolveThreadCommand(args.slice(1));
+} else {
+  fail(`Unknown command: ${command}`);
+}
+
+function statusCommand(rawArgs) {
+  const options = parseStatusArgs(rawArgs);
+
+  if (options.help) {
+    printStatusHelp();
+    exit(0);
+  }
+
+  const pr = readPullRequest(options.pr);
+  const repo = parsePullRequestUrl(pr.url) ?? readCurrentRepo();
+  const reviewThreads = readReviewThreads(repo, pr.number);
+  const unresolvedThreads = reviewThreads.filter((thread) =>
+    isRelevantThread(thread, options.reviewAuthor),
+  );
+  const checks = readChecks(options.pr ?? String(pr.number));
+  const failingChecks = checks.items.filter(isFailingCheck);
+
+  const report = {
+    pullRequest: {
+      number: pr.number,
+      url: pr.url,
+      title: pr.title,
+      baseRefName: pr.baseRefName,
+      headRefName: pr.headRefName,
+      mergeStateStatus: pr.mergeStateStatus,
+      reviewDecision: pr.reviewDecision,
+      isDraft: pr.isDraft,
+    },
+    reviewAuthor: options.reviewAuthor,
+    unresolvedReviewThreads: unresolvedThreads.map((thread) =>
+      formatThread(thread, options.reviewAuthor),
+    ),
+    checks: {
+      error: checks.error,
+      failing: failingChecks.map(formatCheck),
+      total: checks.items.length,
+    },
+  };
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } else {
+    printStatusReport(report);
+  }
+}
+
+function resolveThreadCommand(rawArgs) {
+  const options = parseResolveThreadArgs(rawArgs);
+
+  if (options.help) {
+    printResolveThreadHelp();
+    exit(0);
+  }
+
+  if (!options.threadId) {
+    fail("Missing review thread id.");
+  }
+
+  const query = `
+mutation($threadId: ID!) {
+  resolveReviewThread(input: { threadId: $threadId }) {
+    thread {
+      id
+      isResolved
+    }
+  }
+}`;
+  const result = runJson("gh", [
+    "api",
+    "graphql",
+    "-f",
+    `query=${query}`,
+    "-F",
+    `threadId=${options.threadId}`,
+  ]);
+  failOnGraphQLErrors(result, "resolve review thread");
+
+  const thread = result?.data?.resolveReviewThread?.thread;
+
+  if (!thread?.isResolved) {
+    fail(`GitHub did not report thread ${options.threadId} as resolved.`);
+  }
+
+  process.stdout.write(`Resolved review thread ${thread.id}\n`);
+}
+
+function parseStatusArgs(rawArgs) {
+  const parsed = {
+    help: false,
+    json: false,
+    pr: null,
+    reviewAuthor: null,
+  };
+
+  for (let i = 0; i < rawArgs.length; i += 1) {
+    const arg = rawArgs[i];
+
+    if (arg === "--help" || arg === "-h") {
+      parsed.help = true;
+    } else if (arg === "--json") {
+      parsed.json = true;
+    } else if (arg === "--pr") {
+      parsed.pr = requireValue(rawArgs, ++i, arg);
+    } else if (arg.startsWith("--pr=")) {
+      parsed.pr = arg.slice("--pr=".length);
+    } else if (arg === "--review-author") {
+      parsed.reviewAuthor = requireValue(rawArgs, ++i, arg);
+    } else if (arg.startsWith("--review-author=")) {
+      parsed.reviewAuthor = arg.slice("--review-author=".length);
+    } else {
+      fail(`Unknown status argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function parseResolveThreadArgs(rawArgs) {
+  const parsed = {
+    help: false,
+    threadId: null,
+  };
+
+  for (const arg of rawArgs) {
+    if (arg === "--help" || arg === "-h") {
+      parsed.help = true;
+    } else if (arg.startsWith("--")) {
+      fail(`Unknown resolve-thread argument: ${arg}`);
+    } else if (!parsed.threadId) {
+      parsed.threadId = arg;
+    } else {
+      fail(`Unexpected resolve-thread argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function requireValue(rawArgs, index, flag) {
+  const value = rawArgs[index];
+
+  if (!value || value.startsWith("--")) {
+    fail(`Missing value for ${flag}`);
+  }
+
+  return value;
+}
+
+function readPullRequest(prArg) {
+  const ghArgs = ["pr", "view"];
+
+  if (prArg) {
+    ghArgs.push(prArg);
+  }
+
+  ghArgs.push(
+    "--json",
+    [
+      "baseRefName",
+      "headRefName",
+      "isDraft",
+      "mergeStateStatus",
+      "number",
+      "reviewDecision",
+      "title",
+      "url",
+    ].join(","),
+  );
+
+  return runJson("gh", ghArgs);
+}
+
+function readCurrentRepo() {
+  const repo = runJson("gh", ["repo", "view", "--json", "nameWithOwner"]);
+  const [owner, name] = String(repo.nameWithOwner ?? "").split("/");
+
+  if (!owner || !name) {
+    fail("Could not determine the current GitHub repository.");
+  }
+
+  return { owner, name };
+}
+
+function parsePullRequestUrl(url) {
+  const match = String(url).match(
+    /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/[0-9]+/,
+  );
+
+  if (!match) {
+    return null;
+  }
+
+  return {
+    owner: match[1],
+    name: match[2],
+  };
+}
+
+function readReviewThreads(repo, number) {
+  const query = `
+query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          originalLine
+          startLine
+          originalStartLine
+          comments(first: 100) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+            nodes {
+              id
+              author {
+                login
+              }
+              body
+              createdAt
+              url
+              isMinimized
+              minimizedReason
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+  const threads = [];
+  let cursor = null;
+
+  for (;;) {
+    const args = [
+      "api",
+      "graphql",
+      "-f",
+      `query=${query}`,
+      "-F",
+      `owner=${repo.owner}`,
+      "-F",
+      `name=${repo.name}`,
+      "-F",
+      `number=${number}`,
+    ];
+
+    if (cursor) {
+      args.push("-F", `cursor=${cursor}`);
+    }
+
+    const result = runJson("gh", args);
+    failOnGraphQLErrors(result, "read review threads");
+
+    const connection = result?.data?.repository?.pullRequest?.reviewThreads;
+
+    if (!connection) {
+      fail("GitHub did not return review thread data for this PR.");
+    }
+
+    threads.push(...(connection.nodes ?? []));
+
+    if (!connection.pageInfo?.hasNextPage) {
+      break;
+    }
+
+    cursor = connection.pageInfo.endCursor;
+  }
+
+  return threads.map(readAllThreadComments);
+}
+
+function readAllThreadComments(thread) {
+  const comments = thread.comments?.nodes ?? [];
+  let pageInfo = thread.comments?.pageInfo;
+
+  while (pageInfo?.hasNextPage) {
+    const page = readThreadCommentsPage(thread.id, pageInfo.endCursor);
+    comments.push(...(page.nodes ?? []));
+    pageInfo = page.pageInfo;
+  }
+
+  return {
+    ...thread,
+    comments: {
+      nodes: comments,
+    },
+  };
+}
+
+function readThreadCommentsPage(threadId, cursor) {
+  const query = `
+query($threadId: ID!, $cursor: String) {
+  node(id: $threadId) {
+    ... on PullRequestReviewThread {
+      comments(first: 100, after: $cursor) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          author {
+            login
+          }
+          body
+          createdAt
+          url
+          isMinimized
+          minimizedReason
+        }
+      }
+    }
+  }
+}`;
+  const result = runJson("gh", [
+    "api",
+    "graphql",
+    "-f",
+    `query=${query}`,
+    "-F",
+    `threadId=${threadId}`,
+    "-F",
+    `cursor=${cursor}`,
+  ]);
+  failOnGraphQLErrors(result, `read comments for review thread ${threadId}`);
+
+  const comments = result?.data?.node?.comments;
+
+  if (!comments) {
+    fail(`GitHub did not return comments for review thread ${threadId}.`);
+  }
+
+  return comments;
+}
+
+function readChecks(prArg) {
+  const result = run(
+    "gh",
+    [
+      "pr",
+      "checks",
+      prArg,
+      "--json",
+      "bucket,completedAt,description,link,name,startedAt,state,workflow",
+    ],
+    { allowFailure: true },
+  );
+
+  if (!result.ok) {
+    return {
+      error: result.stderr.trim() || result.stdout.trim(),
+      items: [],
+    };
+  }
+
+  try {
+    return {
+      error: null,
+      items: JSON.parse(result.stdout),
+    };
+  } catch (error) {
+    return {
+      error: `Could not parse gh pr checks JSON: ${error.message}`,
+      items: [],
+    };
+  }
+}
+
+function isRelevantThread(thread, reviewAuthor) {
+  if (thread.isResolved || thread.isOutdated) {
+    return false;
+  }
+
+  if (!reviewAuthor) {
+    return true;
+  }
+
+  return (thread.comments?.nodes ?? []).some((comment) =>
+    authorLoginMatches(comment.author?.login, reviewAuthor),
+  );
+}
+
+function authorLoginMatches(actual, expected) {
+  if (actual === expected) {
+    return true;
+  }
+
+  return stripBotSuffix(actual) === stripBotSuffix(expected);
+}
+
+function stripBotSuffix(login) {
+  return String(login ?? "").replace(/\[bot\]$/, "");
+}
+
+function isFailingCheck(check) {
+  const bucket = String(check.bucket ?? "").toLowerCase();
+  const state = String(check.state ?? "").toLowerCase();
+
+  return (
+    bucket === "fail" ||
+    bucket === "failing" ||
+    state === "failure" ||
+    state === "failed" ||
+    state === "error" ||
+    state === "cancelled" ||
+    state === "timed_out"
+  );
+}
+
+function formatThread(thread, reviewAuthor) {
+  const comments = thread.comments?.nodes ?? [];
+  const selectedComment = reviewAuthor
+    ? comments.find((comment) =>
+        authorLoginMatches(comment.author?.login, reviewAuthor),
+      )
+    : comments[0];
+
+  return {
+    id: thread.id,
+    path: thread.path,
+    line: thread.line ?? thread.originalLine ?? null,
+    startLine: thread.startLine ?? thread.originalStartLine ?? null,
+    url: selectedComment?.url ?? comments[0]?.url ?? null,
+    comments: comments.map((comment) => ({
+      author: comment.author?.login ?? null,
+      body: comment.body,
+      createdAt: comment.createdAt,
+      url: comment.url,
+      isMinimized: comment.isMinimized,
+      minimizedReason: comment.minimizedReason,
+    })),
+  };
+}
+
+function formatCheck(check) {
+  return {
+    name: check.name,
+    workflow: check.workflow,
+    state: check.state,
+    bucket: check.bucket,
+    link: check.link,
+    description: check.description,
+    startedAt: check.startedAt,
+    completedAt: check.completedAt,
+  };
+}
+
+function printStatusReport(report) {
+  const pr = report.pullRequest;
+  const reviewLabel = report.reviewAuthor
+    ? `Unresolved ${report.reviewAuthor} review threads`
+    : "Unresolved review threads";
+
+  process.stdout.write(`PR #${pr.number}: ${pr.title}\n`);
+  process.stdout.write(`${pr.url}\n`);
+  process.stdout.write(`Base: ${pr.baseRefName}\n`);
+  process.stdout.write(`Head: ${pr.headRefName}\n`);
+  process.stdout.write(`Merge state: ${pr.mergeStateStatus ?? "unknown"}\n`);
+  process.stdout.write(`Review decision: ${pr.reviewDecision ?? "unknown"}\n`);
+  process.stdout.write(`Draft: ${pr.isDraft ? "yes" : "no"}\n\n`);
+
+  process.stdout.write(`${reviewLabel}: ${report.unresolvedReviewThreads.length}\n`);
+  for (const thread of report.unresolvedReviewThreads) {
+    const location = thread.line ? `${thread.path}:${thread.line}` : thread.path;
+    const firstComment = thread.comments[0]?.body
+      ?.replace(/\s+/g, " ")
+      .trim()
+      .slice(0, 160);
+
+    process.stdout.write(`- ${thread.id} ${location}\n`);
+    if (thread.url) {
+      process.stdout.write(`  ${thread.url}\n`);
+    }
+    if (firstComment) {
+      process.stdout.write(`  ${firstComment}\n`);
+    }
+  }
+
+  process.stdout.write(`\nFailing checks: ${report.checks.failing.length}\n`);
+  if (report.checks.error) {
+    process.stdout.write(`Checks error: ${report.checks.error}\n`);
+  }
+  for (const check of report.checks.failing) {
+    process.stdout.write(`- ${check.name} [${check.state ?? check.bucket}]\n`);
+    if (check.link) {
+      process.stdout.write(`  ${check.link}\n`);
+    }
+    if (check.description) {
+      process.stdout.write(`  ${check.description}\n`);
+    }
+  }
+}
+
+function printGlobalHelp() {
+  process.stdout.write(`Usage: repair-pr.mjs <command> [options]
+
+Commands:
+  status          Show PR merge state, unresolved review threads, and failing checks.
+  resolve-thread  Resolve a GitHub review thread by node id.
+
+Run "repair-pr.mjs <command> --help" for command-specific options.
+`);
+}
+
+function printStatusHelp() {
+  process.stdout.write(`Usage: repair-pr.mjs status [options]
+
+Options:
+  --pr <number-or-url>           PR to inspect. Defaults to the current branch PR.
+  --review-author <login>        Limit review threads to a specific author.
+  --json                         Print machine-readable JSON.
+  -h, --help                     Show this help.
+`);
+}
+
+function printResolveThreadHelp() {
+  process.stdout.write(`Usage: repair-pr.mjs resolve-thread <thread-id>
+
+Arguments:
+  thread-id                      GitHub review thread GraphQL node id.
+
+Options:
+  -h, --help                     Show this help.
+`);
+}
+
+function runJson(commandName, commandArgs) {
+  const result = run(commandName, commandArgs);
+
+  try {
+    return JSON.parse(result.stdout);
+  } catch (error) {
+    fail(
+      `Could not parse JSON from ${commandName} ${commandArgs.join(" ")}: ${error.message}`,
+    );
+  }
+}
+
+function failOnGraphQLErrors(result, operation) {
+  if (Array.isArray(result?.errors) && result.errors.length > 0) {
+    fail(`GraphQL errors while trying to ${operation}: ${JSON.stringify(result.errors)}`);
+  }
+}
+
+function run(commandName, commandArgs, options = {}) {
+  const result = spawnSync(commandName, commandArgs, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  if (result.error) {
+    fail(result.error.message);
+  }
+
+  const ok = result.status === 0;
+
+  if (!ok && !options.allowFailure) {
+    const detail = result.stderr.trim() || result.stdout.trim();
+    fail(
+      detail
+        ? `${commandName} ${commandArgs.join(" ")} failed:\n${detail}`
+        : `${commandName} ${commandArgs.join(" ")} failed with status ${result.status}`,
+    );
+  }
+
+  return {
+    ok,
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function fail(message) {
+  process.stderr.write(`repair-pr: ${message}\n`);
+  exit(1);
+}

--- a/.agents/skills/repair-pr/scripts/repair-pr.mjs
+++ b/.agents/skills/repair-pr/scripts/repair-pr.mjs
@@ -3,6 +3,8 @@
 import { spawnSync } from "node:child_process";
 import { exit } from "node:process";
 
+const REVIEW_AUTHOR = "chatgpt-codex-connector[bot]";
+
 const args = process.argv.slice(2);
 const command = args[0];
 
@@ -31,7 +33,7 @@ function statusCommand(rawArgs) {
   const repo = parsePullRequestUrl(pr.url) ?? readCurrentRepo();
   const reviewThreads = readReviewThreads(repo, pr.number);
   const unresolvedThreads = reviewThreads.filter((thread) =>
-    isRelevantThread(thread, options.reviewAuthor),
+    isRelevantBotThread(thread),
   );
   const checks = readChecks(options.pr ?? String(pr.number));
   const failingChecks = checks.items.filter(isFailingCheck);
@@ -47,9 +49,9 @@ function statusCommand(rawArgs) {
       reviewDecision: pr.reviewDecision,
       isDraft: pr.isDraft,
     },
-    reviewAuthor: options.reviewAuthor,
+    reviewAuthor: REVIEW_AUTHOR,
     unresolvedReviewThreads: unresolvedThreads.map((thread) =>
-      formatThread(thread, options.reviewAuthor),
+      formatThread(thread),
     ),
     checks: {
       error: checks.error,
@@ -110,7 +112,6 @@ function parseStatusArgs(rawArgs) {
     help: false,
     json: false,
     pr: null,
-    reviewAuthor: null,
   };
 
   for (let i = 0; i < rawArgs.length; i += 1) {
@@ -124,10 +125,6 @@ function parseStatusArgs(rawArgs) {
       parsed.pr = requireValue(rawArgs, ++i, arg);
     } else if (arg.startsWith("--pr=")) {
       parsed.pr = arg.slice("--pr=".length);
-    } else if (arg === "--review-author") {
-      parsed.reviewAuthor = requireValue(rawArgs, ++i, arg);
-    } else if (arg.startsWith("--review-author=")) {
-      parsed.reviewAuthor = arg.slice("--review-author=".length);
     } else {
       fail(`Unknown status argument: ${arg}`);
     }
@@ -397,17 +394,13 @@ function readChecks(prArg) {
   }
 }
 
-function isRelevantThread(thread, reviewAuthor) {
+function isRelevantBotThread(thread) {
   if (thread.isResolved || thread.isOutdated) {
     return false;
   }
 
-  if (!reviewAuthor) {
-    return true;
-  }
-
   return (thread.comments?.nodes ?? []).some((comment) =>
-    authorLoginMatches(comment.author?.login, reviewAuthor),
+    authorLoginMatches(comment.author?.login, REVIEW_AUTHOR),
   );
 }
 
@@ -438,13 +431,11 @@ function isFailingCheck(check) {
   );
 }
 
-function formatThread(thread, reviewAuthor) {
+function formatThread(thread) {
   const comments = thread.comments?.nodes ?? [];
-  const selectedComment = reviewAuthor
-    ? comments.find((comment) =>
-        authorLoginMatches(comment.author?.login, reviewAuthor),
-      )
-    : comments[0];
+  const selectedComment = comments.find((comment) =>
+    authorLoginMatches(comment.author?.login, REVIEW_AUTHOR),
+  );
 
   return {
     id: thread.id,
@@ -478,9 +469,6 @@ function formatCheck(check) {
 
 function printStatusReport(report) {
   const pr = report.pullRequest;
-  const reviewLabel = report.reviewAuthor
-    ? `Unresolved ${report.reviewAuthor} review threads`
-    : "Unresolved review threads";
 
   process.stdout.write(`PR #${pr.number}: ${pr.title}\n`);
   process.stdout.write(`${pr.url}\n`);
@@ -490,7 +478,9 @@ function printStatusReport(report) {
   process.stdout.write(`Review decision: ${pr.reviewDecision ?? "unknown"}\n`);
   process.stdout.write(`Draft: ${pr.isDraft ? "yes" : "no"}\n\n`);
 
-  process.stdout.write(`${reviewLabel}: ${report.unresolvedReviewThreads.length}\n`);
+  process.stdout.write(
+    `Unresolved ${report.reviewAuthor} review threads: ${report.unresolvedReviewThreads.length}\n`,
+  );
   for (const thread of report.unresolvedReviewThreads) {
     const location = thread.line ? `${thread.path}:${thread.line}` : thread.path;
     const firstComment = thread.comments[0]?.body
@@ -526,7 +516,7 @@ function printGlobalHelp() {
   process.stdout.write(`Usage: repair-pr.mjs <command> [options]
 
 Commands:
-  status          Show PR merge state, unresolved review threads, and failing checks.
+  status          Show PR merge state, unresolved bot review threads, and failing checks.
   resolve-thread  Resolve a GitHub review thread by node id.
 
 Run "repair-pr.mjs <command> --help" for command-specific options.
@@ -538,7 +528,6 @@ function printStatusHelp() {
 
 Options:
   --pr <number-or-url>           PR to inspect. Defaults to the current branch PR.
-  --review-author <login>        Limit review threads to a specific author.
   --json                         Print machine-readable JSON.
   -h, --help                     Show this help.
 `);


### PR DESCRIPTION
## Summary
- Add a workspace-local `repair-pr` Codex skill adapted for this repository.
- Add a GitHub CLI helper that reports PR merge state, unresolved `chatgpt-codex-connector[bot]` review threads, and failing checks.
- Restrict review repair handling to `chatgpt-codex-connector[bot]` threads only.

## Validation
- Listed `docs/` before the task.
- Ran skill validation with `quick_validate.py` in a temporary Python environment with PyYAML.
- Ran `node --check .agents/skills/repair-pr/scripts/repair-pr.mjs`.
- Ran helper smoke checks for `--help`, `status --help`, and `resolve-thread --help`.
- Confirmed `--review-author` is rejected.
