### PR TITLE
docs: define binpm global cache contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@
 - `docs/project-public-docs.md`: Public docs app project index.
 - `docs/project-serde-feather.md`: Serde Feather multi-crate project index.
 - `docs/project-rustia.md`: Rustia multi-crate project index.
-- `docs/crates-binpm-foundation.md`: binpm Rust CLI and GitHub Release binary selection contract.
+- `docs/crates-binpm-foundation.md`: binpm Rust CLI, GitHub Release binary selection, and global cache contract.
 - `docs/crates-with-watch-foundation.md`: with-watch CLI and watcher foundation contract.
 - `docs/crates-rustia-core-foundation.md`: Rustia core runtime LLM data contract.
 - `docs/crates-rustia-llm-foundation.md`: Rustia aisdk tool adapter contract.
@@ -110,6 +110,13 @@ enum ProjectId {
 - `cmds/ttlc` command identifiers are `build`, `check`, `explain`, and `run`.
 - `ttlc run` requires `--task` and accepts optional `--args <json>` with default `{}`.
 - `ttlc run` response payload includes `result`, `run_trace`, and root-task `cache_analysis`.
+
+### binpm Cache Contract
+
+- `~/.binpm/cache` is the user-level global asset cache shared by all `binpm` installs for the same account.
+- `binpm` cache reuse must be validated with the strongest available integrity source: GitHub asset digest, upstream checksum or signature material, or locally recorded SHA-256 metadata.
+- Cache management command identifiers are `list`, `prune`, and `clean` under `binpm cache`.
+- `binpm cache prune` and `binpm cache clean` must not remove installed package records or executable links/copies under `~/.binpm/bin`.
 
 ### Devkit Mini-App Identifier Contract
 

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -37,7 +37,11 @@
 ### binpm-Specific Rules
 
 - Keep `binpm` documentation-only until `crates/binpm` is intentionally scaffolded in an implementation change.
-- Preserve `~/.binpm` as the canonical home directory for binpm-managed binaries, package records, cache entries, and temporary extraction state.
+- Preserve `~/.binpm` as the canonical home directory for binpm-managed binaries, package records, global cache entries, and temporary extraction state.
+- Treat `~/.binpm/cache` as the user-level global GitHub Release asset cache shared by all binpm installs for the same account.
+- Keep cache management command identifiers stable as `binpm cache list`, `binpm cache prune`, and `binpm cache clean`.
+- Ensure cache reuse is always verified against GitHub asset digests, upstream checksum/signature material, or locally recorded SHA-256 metadata before extraction or install finalization.
+- Keep cache cleanup behavior separate from uninstall behavior: cache pruning and cleaning must not remove package records or executable links/copies under `~/.binpm/bin`.
 - Keep GitHub Release asset selection deterministic and documented by OS, CPU architecture, and libc/ABI environment.
 - Keep checksum/signature fallback behavior aligned with `docs/project-binpm.md` and `docs/crates-binpm-foundation.md`.
 

--- a/docs/crates-binpm-foundation.md
+++ b/docs/crates-binpm-foundation.md
@@ -19,6 +19,10 @@
 - `github:owner/repo` is the canonical v1 package spec. Direct URLs, registries, and non-GitHub hosts are out of scope until documented separately.
 - When `@version` is omitted, `binpm` must select the latest stable GitHub Release by ignoring draft and prerelease releases.
 - Explicit versions may be written with or without a leading `v`; release tag matching must try the exact input first, then the opposite `v` prefix form.
+- Cache management commands for v1:
+  - `binpm cache list` must report cached assets with digest, byte size when known, source owner/repo, release tag, asset name, last-used timestamp when known, and whether installed package manifests currently reference the entry.
+  - `binpm cache prune` must remove only cache entries that are not referenced by installed package manifests.
+  - `binpm cache clean` must remove all cache entries while preserving installed package records and executable links or copies under `~/.binpm/bin`.
 - The host target model must be enum-driven and include:
   - OS: `linux`, `darwin`, `windows`, `freebsd`
   - CPU architecture: `x86_64`, `aarch64`, `i686`, `armv7`
@@ -78,10 +82,17 @@
 - Home directory: `~/.binpm`
 - Executable link or copy directory: `~/.binpm/bin`
 - Installed package records: `~/.binpm/packages`
-- Download cache: `~/.binpm/cache`
+- User-level global asset cache: `~/.binpm/cache`
 - Temporary downloads and extraction roots: `~/.binpm/tmp`
-- Local install manifests must record package spec, resolved owner/repo, release tag, asset name, asset URL, target OS, target architecture, target libc/ABI, archive format, selected binary path inside the archive, installed binary path, SHA-256 digest, checksum source (`github-digest`, `sidecar`, `manifest`, `local`), install timestamp, and whether upstream signature material was available.
-- Temporary extraction must be atomic: incomplete downloads and extraction directories stay under `~/.binpm/tmp` and must not update package records or `~/.binpm/bin`.
+- The global cache stores GitHub Release asset original bytes, not extracted package directories or installed binaries.
+- Cache entries must be content-addressed by `sha256:<hex>` when GitHub Release asset metadata exposes a SHA-256 `digest`.
+- When GitHub asset metadata does not expose a digest, `binpm` must compute SHA-256 after download and use the local digest as both the cache key and the install manifest verification value.
+- Cache lookup for assets without GitHub-provided digests may use source metadata to find a prior local digest, but source owner/repo, release tag, asset name, or URL alone must not make bytes reusable without SHA-256 revalidation.
+- Cache metadata must preserve the source owner/repo, release tag, asset name, asset URL, byte size when known, checksum source, creation timestamp, and last-used timestamp when known.
+- Local install manifests must record package spec, resolved owner/repo, release tag, asset name, asset URL, target OS, target architecture, target libc/ABI, archive format, selected binary path inside the archive, installed binary path, cache key, cache path, SHA-256 digest, checksum source (`github-digest`, `sidecar`, `manifest`, `local`), install timestamp, and whether upstream signature material was available.
+- The global cache is separate from installed package records and executable links or copies. Removing cache entries must not remove package manifests or files under `~/.binpm/bin`.
+- Temporary extraction and cache population must be atomic: incomplete downloads and extraction directories stay under `~/.binpm/tmp` and must not update cache entries, package records, or `~/.binpm/bin`.
+- Concurrent installs for the same asset must use temporary files plus atomic rename or a cache lock so partial downloads are never visible as reusable cache entries.
 
 ## Security
 - `binpm` must use HTTPS GitHub API and release asset URLs.
@@ -89,6 +100,8 @@
 - If the GitHub Release asset metadata exposes a SHA-256 `digest`, `binpm` must verify the downloaded asset against that digest before considering checksum sidecars or local fallback hashes.
 - If an upstream checksum manifest or sidecar exists, `binpm` must verify the selected asset before installation.
 - If no GitHub asset digest, checksum sidecar, checksum manifest, or signature exists, `binpm` must warn, compute SHA-256 locally, store it in the install manifest, and verify future reinstalls or cache reuse against that recorded digest.
+- Cache hits must be revalidated before extraction or install finalization using the strongest available integrity source: GitHub asset digest, upstream checksum material, signature verification, or the locally recorded install manifest digest.
+- If cache revalidation fails, `binpm` must discard the corrupted cache entry and redownload the asset. If the redownloaded bytes fail the trusted integrity source, installation must fail.
 - Checksum, signature, SBOM, and provenance files are metadata inputs only; they must not be installed as binaries.
 - URL diagnostics in errors and logs must omit query strings and fragments.
 - Archive extraction must reject absolute paths, parent-directory traversal, unsafe symlinks, and files that would escape the package extraction root.
@@ -96,15 +109,16 @@
 ## Logging
 - Use structured `tracing` logs for release lookup, target normalization, asset candidate scoring, checksum discovery, download, extraction, binary discovery, and install finalization.
 - Candidate scoring logs must include normalized package spec, release tag, asset name, detected OS, detected architecture, detected libc/ABI, artifact kind, score, and rejection reason when applicable.
-- Download logs must include sanitized URL origin, asset name, byte count when known, cache hit or miss state, retry attempt, and final outcome.
+- Download and cache logs must include sanitized URL origin, asset name, byte count when known, cache hit or miss state, cache key, cache path, cache action, cache validation source, cache reused state, cache eviction state, retry attempt, and final outcome.
 - Install logs must include package spec, release tag, selected asset, selected archive member or bare executable, installed path, and manifest path.
+- Stable cache log keys include `cache_key`, `cache_path`, `cache_action`, `cache_validation_source`, `cache_reused`, `cache_evicted`, and `cache_bytes`.
 - Human CLI output may be concise, but debug logs must be sufficient to reconstruct why a candidate won or lost.
 
 ## Build and Test
 - No Rust validation command is required while `binpm` remains documentation-only.
 - When runtime code is introduced, local validation must include `cargo test -p binpm` and the repository Rust baseline `cargo test --workspace --all-targets`.
 - Heuristic tests must cover OS aliases, architecture aliases, libc aliases, exact libc preference, Linux glibc missing-libc fallback, Linux musl missing-libc rejection, source archive rejection, sidecar rejection, desktop installer de-prioritization, cargo-binstall candidates, cargo-dist candidates, GoReleaser candidates, Bun/Deno candidates, and ambiguous archive contents.
-- Storage tests must cover atomic install behavior, cache digest verification, manifest updates, and unsafe archive path rejection.
+- Storage tests must cover atomic install behavior, cache miss download and digest recording, cache hit reuse after verification, digest mismatch eviction and redownload, concurrent partial download isolation, manifest updates, cache command behavior for `list`, `prune`, and `clean`, and unsafe archive path rejection.
 
 ## Dependencies and Integrations
 - Integrates with GitHub Releases through the GitHub API and release asset downloads.
@@ -113,14 +127,15 @@
 - Does not integrate with npm, pnpm, yarn, Bun, Cargo install, cargo-binstall, Homebrew, apt, rpm, or system package managers as install backends in v1.
 
 ## Change Triggers
-- Update `docs/project-binpm.md` with this file when CLI shape, storage layout, security policy, target model, or asset selection heuristics change.
+- Update `docs/project-binpm.md` with this file when CLI shape, storage layout, cache behavior, security policy, target model, or asset selection heuristics change.
 - Update root `AGENTS.md` and `crates/AGENTS.md` when `binpm` project ownership, planned path status, or Rust-domain policy changes.
 - Update implementation tests in the same change set when heuristic scoring rules are implemented or changed.
 
 ## References
 - `docs/project-binpm.md`
 - `docs/domain-template.md`
-- GitHub Release asset API: https://docs.github.com/en/rest/releases/releases
+- GitHub Release asset API: https://docs.github.com/en/rest/releases/assets
+- GitHub Release asset digest changelog: https://github.blog/changelog/2025-06-03-releases-now-expose-digests-for-release-assets/
 - GoReleaser archives: https://goreleaser.com/customization/package/archives/
 - GoReleaser Go builder: https://goreleaser.com/customization/builds/builders/go/
 - cargo-binstall support metadata: https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md

--- a/docs/project-binpm.md
+++ b/docs/project-binpm.md
@@ -20,11 +20,14 @@ Provide a Rust-based, Node-free binary package manager for installing command-li
 - Binary selection must be deterministic and target-aware across operating system, CPU architecture, and libc or ABI environment.
 - The asset selection heuristic must remain fully documented in `docs/crates-binpm-foundation.md` before implementation changes alter scoring behavior.
 - `~/.binpm` is the canonical home directory for installed binaries, package records, cache entries, and temporary extraction state.
+- `~/.binpm/cache` is the user-level global asset cache shared by all `binpm` installs for the same account.
+- Global cache reuse must never bypass GitHub asset digest, upstream checksum, signature, or locally recorded SHA-256 verification.
+- Cache management commands must preserve installed package records and `~/.binpm/bin` entries unless a separate uninstall contract explicitly changes that behavior.
 - `binpm` must not require Node.js, npm, pnpm, yarn, or Bun to install native binary tools.
 - Installs without upstream checksum or signature material are allowed in v1 only with an explicit warning and locally recorded SHA-256 metadata.
 
 ## Change Policy
-- Update this index and `docs/crates-binpm-foundation.md` together when CLI shape, target selection, storage layout, security behavior, or heuristic scoring changes.
+- Update this index and `docs/crates-binpm-foundation.md` together when CLI shape, target selection, storage layout, cache behavior, security behavior, or heuristic scoring changes.
 - Update root `AGENTS.md` and `crates/AGENTS.md` when `binpm` ownership, planned path status, or repository policy boundaries change.
 - Create the planned `crates/binpm` path and add it to the Rust workspace in the same change set where runtime implementation begins.
 


### PR DESCRIPTION
## Summary
- Defines `~/.binpm/cache` as the user-level global binpm asset cache.
- Documents `binpm cache list`, `binpm cache prune`, and `binpm cache clean` for v1.
- Aligns the binpm project docs and AGENTS policy files around cache verification and cleanup semantics.

## Validation
- `git diff --check`
- Documentation-only change; `cargo test` and `pnpm test` were not required.
