### PR TITLE
feat(binpm): add nodeup-style distribution

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -475,6 +475,70 @@ jobs:
         if: ${{ steps.gate.outputs.run == 'true' }}
         run: pnpm --filter mpapp lint
 
+  node-binpm-docs-test:
+    name: Node binpm-docs test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Filter changed paths
+        id: filter
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            ci_workflow:
+              - .github/workflows/CI.yml
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10.26.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Determine whether to run
+        id: gate
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CI_WORKFLOW_CHANGED: ${{ steps.filter.outputs.ci_workflow }}
+          WORKSPACE: binpm-docs
+        run: |
+          set -euo pipefail
+
+          run=false
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ] || [ "${CI_WORKFLOW_CHANGED}" = "true" ]; then
+            run=true
+          else
+            affected_json="$(pnpm dlx turbo@2.9.14 query affected --packages "${WORKSPACE}")"
+            printf '%s\n' "${affected_json}"
+            run="$(printf '%s' "${affected_json}" | jq -r '.data.affectedPackages.items | any(.name == env.WORKSPACE)')"
+          fi
+
+          echo "run=${run}" >> "${GITHUB_OUTPUT}"
+
+      - name: Skip (binpm-docs unaffected)
+        if: ${{ steps.gate.outputs.run != 'true' }}
+        run: |
+          echo "Skipping Node binpm-docs test: workspace unaffected"
+
+      - name: Install dependencies
+        if: ${{ steps.gate.outputs.run == 'true' }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Run binpm-docs tests
+        if: ${{ steps.gate.outputs.run == 'true' }}
+        run: pnpm --filter binpm-docs test
+
   node-nodeup-docs-test:
     name: Node nodeup-docs test
     runs-on: ubuntu-latest
@@ -615,6 +679,7 @@ jobs:
       - rust-test
       - node-mpapp-test
       - node-mpapp-lint
+      - node-binpm-docs-test
       - node-nodeup-docs-test
       - node-public-docs-test
     steps:

--- a/.github/workflows/release-binpm.yml
+++ b/.github/workflows/release-binpm.yml
@@ -1,0 +1,269 @@
+name: Release binpm
+
+on:
+  push:
+    tags:
+      - "binpm@v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Semver without v prefix (for example: 0.2.0)"
+        required: true
+      dry_run:
+        description: "If true, skip release publication and Homebrew tap push"
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: release-binpm-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Prepare metadata
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.meta.outputs.tag }}
+      version: ${{ steps.meta.outputs.version }}
+      dry_run: ${{ steps.meta.outputs.dry_run }}
+    steps:
+      - name: Resolve release metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            tag="binpm@v${{ github.event.inputs.version }}"
+            dry_run="${{ github.event.inputs.dry_run }}"
+          else
+            tag="${GITHUB_REF_NAME}"
+            dry_run="false"
+          fi
+
+          version="${tag#binpm@v}"
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "dry_run=$dry_run" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build (${{ matrix.asset_os }}-${{ matrix.asset_arch }})
+    runs-on: ${{ matrix.os }}
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            asset_os: linux
+            asset_arch: amd64
+            archive_ext: tar.gz
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            asset_os: linux
+            asset_arch: arm64
+            archive_ext: tar.gz
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+            asset_os: darwin
+            asset_arch: amd64
+            archive_ext: tar.gz
+          - os: macos-14
+            target: aarch64-apple-darwin
+            asset_os: darwin
+            asset_arch: arm64
+            archive_ext: tar.gz
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            asset_os: windows
+            asset_arch: amd64
+            archive_ext: zip
+          - os: windows-11-arm
+            target: aarch64-pc-windows-msvc
+            asset_os: windows
+            asset_arch: arm64
+            archive_ext: zip
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: nightly-2026-01-01
+          target: ${{ matrix.target }}
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build binpm
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build -p binpm --release --target "${{ matrix.target }}"
+
+      - name: Package artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p dist
+          artifact_name="binpm-${{ matrix.asset_os }}-${{ matrix.asset_arch }}.${{ matrix.archive_ext }}"
+          binary_name="binpm-${{ matrix.asset_os }}-${{ matrix.asset_arch }}"
+          source_binary="target/${{ matrix.target }}/release/binpm"
+
+          if [ "${{ matrix.asset_os }}" = "windows" ]; then
+            binary_name="${binary_name}.exe"
+            source_binary="${source_binary}.exe"
+          fi
+
+          cp "$source_binary" "dist/${binary_name}"
+
+          if [ "${{ matrix.asset_os }}" = "windows" ]; then
+            cp "$source_binary" "dist/binpm.exe"
+            pwsh -NoLogo -NoProfile -Command "Compress-Archive -Path dist/binpm.exe -DestinationPath dist/${artifact_name}"
+            rm -f "dist/binpm.exe"
+          else
+            cp "$source_binary" "dist/binpm"
+            tar -C dist -czf "dist/${artifact_name}" binpm
+            rm -f "dist/binpm"
+          fi
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: binpm-${{ matrix.asset_os }}-${{ matrix.asset_arch }}
+          path: dist/*
+
+  publish:
+    name: Publish release
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
+      - build
+    env:
+      RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+      RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+      DRY_RUN: ${{ needs.prepare.outputs.dry_run }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: dist
+
+      - name: Flatten artifact directory
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p release-dist
+          find dist -maxdepth 2 -type f -exec cp "{}" "release-dist/" \;
+          rm -rf dist
+          mv release-dist dist
+          find dist -maxdepth 1 -type f | sed 's#^#artifact: #' >&2
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.1.1
+
+      - name: Generate checksums and signatures
+        shell: bash
+        run: |
+          set -euo pipefail
+          chmod +x ./scripts/release/generate-checksums.sh
+          ./scripts/release/generate-checksums.sh --artifacts-dir dist
+
+      - name: Create GitHub release
+        if: env.DRY_RUN != 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          files: dist/*
+          generate_release_notes: true
+
+      - name: Render Homebrew update
+        if: env.DRY_RUN == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          chmod +x ./scripts/release/update-homebrew.sh
+
+          darwin_amd64_asset="binpm-darwin-amd64.tar.gz"
+          darwin_amd64_sha="$(grep " ${darwin_amd64_asset}$" dist/SHA256SUMS | awk '{print $1}')"
+          darwin_amd64_url="https://github.com/delinoio/oss/releases/download/${RELEASE_TAG}/${darwin_amd64_asset}"
+
+          darwin_arm64_asset="binpm-darwin-arm64.tar.gz"
+          darwin_arm64_sha="$(grep " ${darwin_arm64_asset}$" dist/SHA256SUMS | awk '{print $1}')"
+          darwin_arm64_url="https://github.com/delinoio/oss/releases/download/${RELEASE_TAG}/${darwin_arm64_asset}"
+
+          linux_amd64_asset="binpm-linux-amd64.tar.gz"
+          linux_amd64_sha="$(grep " ${linux_amd64_asset}$" dist/SHA256SUMS | awk '{print $1}')"
+          linux_amd64_url="https://github.com/delinoio/oss/releases/download/${RELEASE_TAG}/${linux_amd64_asset}"
+
+          linux_arm64_asset="binpm-linux-arm64.tar.gz"
+          linux_arm64_sha="$(grep " ${linux_arm64_asset}$" dist/SHA256SUMS | awk '{print $1}')"
+          linux_arm64_url="https://github.com/delinoio/oss/releases/download/${RELEASE_TAG}/${linux_arm64_asset}"
+
+          ./scripts/release/update-homebrew.sh \
+            --project binpm \
+            --version "$RELEASE_VERSION" \
+            --darwin-amd64-url "$darwin_amd64_url" \
+            --darwin-amd64-sha256 "$darwin_amd64_sha" \
+            --darwin-arm64-url "$darwin_arm64_url" \
+            --darwin-arm64-sha256 "$darwin_arm64_sha" \
+            --linux-amd64-url "$linux_amd64_url" \
+            --linux-amd64-sha256 "$linux_amd64_sha" \
+            --linux-arm64-url "$linux_arm64_url" \
+            --linux-arm64-sha256 "$linux_arm64_sha" \
+            --dry-run >/dev/null
+
+      - name: Submit Homebrew update
+        if: env.DRY_RUN != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          chmod +x ./scripts/release/update-homebrew.sh
+
+          darwin_amd64_asset="binpm-darwin-amd64.tar.gz"
+          darwin_amd64_sha="$(grep " ${darwin_amd64_asset}$" dist/SHA256SUMS | awk '{print $1}')"
+          darwin_amd64_url="https://github.com/delinoio/oss/releases/download/${RELEASE_TAG}/${darwin_amd64_asset}"
+
+          darwin_arm64_asset="binpm-darwin-arm64.tar.gz"
+          darwin_arm64_sha="$(grep " ${darwin_arm64_asset}$" dist/SHA256SUMS | awk '{print $1}')"
+          darwin_arm64_url="https://github.com/delinoio/oss/releases/download/${RELEASE_TAG}/${darwin_arm64_asset}"
+
+          linux_amd64_asset="binpm-linux-amd64.tar.gz"
+          linux_amd64_sha="$(grep " ${linux_amd64_asset}$" dist/SHA256SUMS | awk '{print $1}')"
+          linux_amd64_url="https://github.com/delinoio/oss/releases/download/${RELEASE_TAG}/${linux_amd64_asset}"
+
+          linux_arm64_asset="binpm-linux-arm64.tar.gz"
+          linux_arm64_sha="$(grep " ${linux_arm64_asset}$" dist/SHA256SUMS | awk '{print $1}')"
+          linux_arm64_url="https://github.com/delinoio/oss/releases/download/${RELEASE_TAG}/${linux_arm64_asset}"
+
+          ./scripts/release/update-homebrew.sh \
+            --project binpm \
+            --version "$RELEASE_VERSION" \
+            --darwin-amd64-url "$darwin_amd64_url" \
+            --darwin-amd64-sha256 "$darwin_amd64_sha" \
+            --darwin-arm64-url "$darwin_arm64_url" \
+            --darwin-arm64-sha256 "$darwin_arm64_sha" \
+            --linux-amd64-url "$linux_amd64_url" \
+            --linux-amd64-sha256 "$linux_amd64_sha" \
+            --linux-arm64-url "$linux_arm64_url" \
+            --linux-arm64-sha256 "$linux_arm64_sha"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,6 +293,7 @@ Coverage expectations:
 - `rust-test`: runs `cargo test --workspace --all-targets`.
 - `node-mpapp-test`: runs `pnpm install --frozen-lockfile` and `pnpm --filter mpapp test`.
 - `node-mpapp-lint`: runs `pnpm install --frozen-lockfile` and `pnpm --filter mpapp lint`.
+- `node-binpm-docs-test`: runs `pnpm install --frozen-lockfile` and `pnpm --filter binpm-docs test`.
 - `node-nodeup-docs-test`: runs `pnpm install --frozen-lockfile` and `pnpm --filter nodeup-docs test`.
 - `node-public-docs-test`: runs `pnpm install --frozen-lockfile` and `pnpm --filter public-docs test`.
 - `ci-result`: provides a single aggregate status that fails when any executed domain job fails or is cancelled.
@@ -317,6 +318,9 @@ Release automation baseline:
 - `release-cargo-mono` is defined in `.github/workflows/release-cargo-mono.yml`.
 - Trigger contract: runs on tag push `cargo-mono@v*` and supports `workflow_dispatch` (`version`, `dry_run`).
 - Distribution contract: publishes signed multi-OS cargo-mono release artifacts to GitHub Releases for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`.
+- `release-binpm` is defined in `.github/workflows/release-binpm.yml`.
+- Trigger contract: runs on tag push `binpm@v*` and supports `workflow_dispatch` (`version`, `dry_run`).
+- Distribution contract: publishes signed multi-OS binpm release artifacts for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`, including standalone prebuilt binaries (`binpm-<os>-<arch>[.exe]`) and archive assets (`binpm-<os>-<arch>.tar.gz|zip`), then updates Homebrew (`binpm`) from prebuilt archives for `darwin/amd64`, `darwin/arm64`, `linux/amd64`, and `linux/arm64`.
 - `release-nodeup` is defined in `.github/workflows/release-nodeup.yml`.
 - Trigger contract: runs on tag push `nodeup@v*` and supports `workflow_dispatch` (`version`, `dry_run`).
 - Distribution contract: publishes signed multi-OS nodeup release artifacts for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`, including standalone prebuilt binaries (`nodeup-<os>-<arch>[.exe]`) and archive assets (`nodeup-<os>-<arch>.tar.gz|zip`), then updates Homebrew (`nodeup`) from prebuilt archives for `darwin/amd64`, `darwin/arm64`, `linux/amd64`, and `linux/arm64`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 ]
 
 [workspace.metadata.cargo-mono.publish.tag]
-packages = ["nodeup", "with-watch", "cargo-mono", "rustia-rs", "rustia-macros", "rustia-llm"]
+packages = ["binpm", "nodeup", "with-watch", "cargo-mono", "rustia-rs", "rustia-macros", "rustia-llm"]
 
 # Release profile optimizations
 [profile.release]

--- a/apps/AGENTS.md
+++ b/apps/AGENTS.md
@@ -29,11 +29,12 @@
 - `binpm-docs` must use Cloudflare Pages as the default static deployment target unless the app contract documents a replacement.
 - `binpm-docs` has canonical production URL `https://binpm.delino.io`.
 - Rspress routes and navigation in `apps/binpm-docs/rspress.config.ts` must stay aligned with `docs/apps-binpm-docs-foundation.md`.
-- Stable `binpm-docs` route IDs are `/`, `/installation`, `/getting-started`, `/commands`, `/local-tooling`, `/cache-and-verification`, `/troubleshooting`, and `/reference`.
+- Stable `binpm-docs` route IDs are `/`, `/installation`, `/getting-started`, `/commands`, `/local-tooling`, `/cache-and-verification`, `/releases`, `/troubleshooting`, and `/reference`.
 - `binpm-docs` must keep Rspress clean URLs enabled and validate that stable route IDs have build output artifacts and generated internal links do not use `.html` suffixes.
 - `binpm-docs` content must remain documentation-only and must not imply new binpm runtime behavior before `docs/project-binpm.md` and `docs/crates-binpm-foundation.md` document it.
 - `binpm-docs` content must not infer behavior, status, or page contents from the live `https://binpm.delino.io` site; repository contracts are the source of truth.
-- When binpm source, target, local tooling, cache, verification, install, execution, diagnostic, or output behavior changes, update related `apps/binpm-docs` pages in the same change set.
+- binpm direct-installer guidance must include copy-pasteable remote POSIX and PowerShell commands that use first-party `delinoio/oss` raw GitHub URLs, keep `scripts/install/binpm.sh` and `scripts/install/binpm.ps1` visible for maintainer workflows, present `cosign` as a required prerequisite, and distinguish binpm release artifact verification from package verification for tools installed by binpm.
+- When binpm source, target, local tooling, cache, verification, install, execution, release distribution, installer, diagnostic, or output behavior changes, update related `apps/binpm-docs` pages in the same change set.
 
 ### public-docs Rules
 

--- a/apps/binpm-docs/README.md
+++ b/apps/binpm-docs/README.md
@@ -20,7 +20,7 @@ pnpm --filter binpm-docs preview
 
 Production deployment is static Cloudflare Pages output from `doc_build`. Rspress clean URLs are enabled, so stable public route IDs such as `/installation` must be generated and internal links must not point at `.html` suffixes.
 
-`pnpm --filter binpm-docs test` builds the site and runs `scripts/validate-clean-urls.mjs`. The validator checks the stable route IDs `/`, `/installation`, `/getting-started`, `/commands`, `/local-tooling`, `/cache-and-verification`, `/troubleshooting`, and `/reference`; each route must have a build output artifact and generated internal HTML links must use clean public route IDs.
+`pnpm --filter binpm-docs test` builds the site and runs `scripts/validate-clean-urls.mjs`. The validator checks the stable route IDs `/`, `/installation`, `/getting-started`, `/commands`, `/local-tooling`, `/cache-and-verification`, `/releases`, `/troubleshooting`, and `/reference`; each route must have a build output artifact and generated internal HTML links must use clean public route IDs.
 
 The production URL is deployment metadata; docs content must come from repository contracts, not from assumptions about the current live site contents.
 

--- a/apps/binpm-docs/docs/index.md
+++ b/apps/binpm-docs/docs/index.md
@@ -11,6 +11,7 @@ Use binpm when a tool already publishes native executables and you want project-
 - [Read the command overview](/commands).
 - [Understand local manifests and lockfiles](/local-tooling).
 - [Review cache and verification behavior](/cache-and-verification).
+- [Review binpm release artifacts](/releases).
 
 ## Source Specs
 

--- a/apps/binpm-docs/docs/installation.md
+++ b/apps/binpm-docs/docs/installation.md
@@ -1,6 +1,122 @@
 # Installation
 
-binpm installs native binary tools without requiring Node.js, npm, pnpm, yarn, or Bun.
+binpm is distributed as first-party release artifacts. Install flows are designed for macOS x64, macOS arm64, Linux x64, Linux arm64, Windows x64, and Windows arm64 hosts.
+
+## Homebrew
+
+On macOS and Linux:
+
+```bash
+brew install delinoio/tap/binpm
+```
+
+The Homebrew formula uses prebuilt binpm release archives for:
+
+- `darwin/amd64`
+- `darwin/arm64`
+- `linux/amd64`
+- `linux/arm64`
+
+## Direct Installers
+
+Direct installers are for users who want a release artifact without Homebrew or `cargo-binstall`. Install `cosign` first and leave it on `PATH`; the installers require it to verify `SHA256SUMS` entries and Sigstore bundle sidecars (`*.sigstore.json`) with `cosign verify-blob --bundle`. Missing `cosign` is a prerequisite failure, not a reason to disable verification. If you do not want to manage that prerequisite directly, use Homebrew or `cargo-binstall` instead.
+
+macOS and Linux:
+
+```bash
+(
+  installer_url="https://raw.githubusercontent.com/delinoio/oss/refs/heads/main/scripts/install/binpm.sh"
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "$tmp_dir"' EXIT
+  if ! curl -fsSL "$installer_url" -o "$tmp_dir/binpm.sh"; then
+    exit 1
+  fi
+  bash "$tmp_dir/binpm.sh" --version latest --method direct
+)
+```
+
+Windows PowerShell:
+
+```powershell
+$InstallerUrl = "https://raw.githubusercontent.com/delinoio/oss/refs/heads/main/scripts/install/binpm.ps1"
+$Installer = Join-Path ([System.IO.Path]::GetTempPath()) ("binpm-install-" + [System.Guid]::NewGuid().ToString("N") + ".ps1")
+try {
+  Invoke-WebRequest -Uri $InstallerUrl -OutFile $Installer -UseBasicParsing
+  Unblock-File -LiteralPath $Installer -ErrorAction SilentlyContinue
+  $PowerShell = (Get-Process -Id $PID).Path
+  & $PowerShell -NoProfile -ExecutionPolicy Bypass -File $Installer -Version latest -Method direct
+  if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+  }
+}
+finally {
+  Remove-Item -LiteralPath $Installer -Force -ErrorAction SilentlyContinue
+}
+```
+
+These commands fetch the current first-party installer scripts from `delinoio/oss`. For reproducible automation, pin the same raw URL paths to a reviewed commit or repository tag instead of `refs/heads/main`, and replace `latest` with an explicit binpm semver.
+
+The canonical in-repo installer paths remain:
+
+- `scripts/install/binpm.sh`
+- `scripts/install/binpm.ps1`
+
+From a repository checkout, maintainers can run the scripts directly:
+
+```bash
+bash ./scripts/install/binpm.sh --version latest --method direct
+```
+
+```powershell
+./scripts/install/binpm.ps1 -Version latest -Method direct
+```
+
+Direct installers detect unsupported x86 hosts before resolving release tags or downloading assets. Use an x64/arm64 host or a supported CI image when an installer reports an unsupported host.
+
+Direct installers support bundle-enabled releases only.
+
+Direct installers place the binary in `~/.local/bin` by default and do not modify your shell `PATH`. Add that directory before verifying the install, or pass `--install-dir` / `-InstallDir` with a directory already on `PATH`.
+
+macOS and Linux:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Windows PowerShell:
+
+```powershell
+$env:Path = "$HOME\.local\bin;$env:Path"
+```
+
+## cargo-binstall
+
+```bash
+cargo binstall binpm --no-confirm
+```
+
+binpm's `cargo-binstall` metadata resolves first-party GitHub Release assets only. Third-party quick-install and compile fallback strategies are disabled by contract.
+
+## GitHub Actions
+
+```yaml
+- uses: taiki-e/install-action@v2
+  with:
+    tool: cargo-binstall
+- run: cargo binstall binpm --no-confirm
+```
+
+## Verify the Install
+
+Run these commands in a shell where `binpm` resolves on `PATH`:
+
+```bash
+binpm --version
+binpm doctor
+binpm env --shell bash
+```
+
+`binpm doctor` verifies that the binary can inspect local and global binpm state. `binpm env --shell bash` verifies shell-specific PATH command generation without mutating shell profile files.
 
 ## Supported Release Assets
 
@@ -41,6 +157,8 @@ binpm does not edit shell profile files from these commands. Persistent profile 
 
 ## Security Boundary
 
-binpm uses HTTPS source-provider APIs and release asset URLs. Stored URLs are sanitized so query strings, fragments, credentials, and expiring signed URL details are not written into project files.
+Release installers verify binpm's own published release artifacts. That release verification is separate from binpm's package-asset verification for tools installed by binpm.
 
-When strict verification is requested, `--require-verified` and `binpm verify --require-verified` fail unless a trusted provider digest is available. Checksum sidecar discovery, checksum manifest discovery, and signature verification remain implementation work.
+binpm package installs use HTTPS source-provider APIs and release asset URLs. Stored URLs are sanitized so query strings, fragments, credentials, and expiring signed URL details are not written into project files.
+
+When strict verification is requested for installed tools, `--require-verified` and `binpm verify --require-verified` fail unless a trusted provider digest is available. Checksum sidecar discovery, checksum manifest discovery, and signature verification for packages installed by binpm remain implementation work.

--- a/apps/binpm-docs/docs/releases.md
+++ b/apps/binpm-docs/docs/releases.md
@@ -1,0 +1,48 @@
+# Releases and Artifacts
+
+binpm releases provide prebuilt CLI downloads, checksums, and Sigstore verification material.
+
+## Tag Contract
+
+Release tags use:
+
+```text
+binpm@v<semver>
+```
+
+## binpm CLI Artifacts
+
+Release downloads are provided for:
+
+- `linux/amd64`
+- `linux/arm64`
+- `darwin/amd64`
+- `darwin/arm64`
+- `windows/amd64`
+- `windows/arm64`
+
+Each release includes standalone prebuilt binaries, archive assets, `SHA256SUMS`, and Sigstore bundle sidecars (`*.sigstore.json`) for each artifact. Direct installers require releases that include this verification material.
+
+## Direct Installer Verification
+
+Direct installers verify:
+
+1. The selected artifact's `SHA256SUMS` entry.
+2. The artifact's Sigstore bundle with `cosign`.
+
+Direct installers require `cosign` and support bundle-enabled releases only. If verification material is missing or verification fails, installation stops before the binary is installed.
+
+## Homebrew and cargo-binstall
+
+Homebrew installation consumes prebuilt release archives for:
+
+- `darwin/amd64`
+- `darwin/arm64`
+- `linux/amd64`
+- `linux/arm64`
+
+`cargo-binstall` metadata resolves only first-party GitHub Release assets. Quick-install and compile fallback strategies are disabled.
+
+## Package Verification Boundary
+
+binpm release artifact verification applies to the `binpm` binary itself. It does not imply that binpm package installs have signature verification beyond the package verification contract documented in [Cache and Verification](/cache-and-verification).

--- a/apps/binpm-docs/rspress.config.ts
+++ b/apps/binpm-docs/rspress.config.ts
@@ -57,6 +57,10 @@ export default defineConfig({
               link: "/cache-and-verification",
             },
             {
+              text: "Releases",
+              link: "/releases",
+            },
+            {
               text: "Troubleshooting",
               link: "/troubleshooting",
             },

--- a/apps/binpm-docs/scripts/validate-clean-urls.mjs
+++ b/apps/binpm-docs/scripts/validate-clean-urls.mjs
@@ -8,6 +8,7 @@ const documentedRouteIds = [
   "/commands",
   "/local-tooling",
   "/cache-and-verification",
+  "/releases",
   "/troubleshooting",
   "/reference",
 ];

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -69,6 +69,8 @@
 - Keep `binpm x` command execution aligned with the local manifest contract: use manifest-declared tools or explicit `--package`, prepend project-local bin directories to `PATH`, and do not infer GitHub repositories from command names. `binpm exec` and `binpm run` are aliases of that same execution behavior; `binpm x` remains canonical in contracts and examples.
 - Keep `binpm env --shell` shell values explicit: support `bash`, `zsh`, `fish`, and `powershell`; accept `cmd` only to report that cmd.exe support is deferred.
 - Keep global install and doctor PATH setup guidance opt-in and non-mutating; do not edit user shell profiles from existing commands or imply project-local `.binpm/bin` entries are suitable for profile persistence.
+- Keep binpm publishability, release tags, direct installers, cargo-binstall metadata, and Homebrew packaging aligned with `docs/project-binpm.md` and `docs/crates-binpm-foundation.md`.
+- Keep `.github/workflows/release-binpm.yml`, `scripts/install/binpm.sh`, `scripts/install/binpm.ps1`, and `crates/binpm/Cargo.toml` synchronized with release asset names and signing contracts.
 
 ### cargo-mono-Specific Rules
 

--- a/crates/binpm/Cargo.toml
+++ b/crates/binpm/Cargo.toml
@@ -6,7 +6,39 @@ license = "MIT"
 description = "Node-free binary package manager for release assets"
 readme = "README.md"
 repository = "https://github.com/delinoio/oss"
-publish = false
+
+[package.metadata.binstall]
+disabled-strategies = ["quick-install", "compile"]
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/binpm@v{ version }/binpm-linux-amd64.tar.gz"
+pkg-fmt = "tgz"
+bin-dir = "binpm"
+
+[package.metadata.binstall.overrides.aarch64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/binpm@v{ version }/binpm-linux-arm64.tar.gz"
+pkg-fmt = "tgz"
+bin-dir = "binpm"
+
+[package.metadata.binstall.overrides.x86_64-apple-darwin]
+pkg-url = "{ repo }/releases/download/binpm@v{ version }/binpm-darwin-amd64.tar.gz"
+pkg-fmt = "tgz"
+bin-dir = "binpm"
+
+[package.metadata.binstall.overrides.aarch64-apple-darwin]
+pkg-url = "{ repo }/releases/download/binpm@v{ version }/binpm-darwin-arm64.tar.gz"
+pkg-fmt = "tgz"
+bin-dir = "binpm"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/binpm@v{ version }/binpm-windows-amd64.zip"
+pkg-fmt = "zip"
+bin-dir = "binpm.exe"
+
+[package.metadata.binstall.overrides.aarch64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/binpm@v{ version }/binpm-windows-arm64.zip"
+pkg-fmt = "zip"
+bin-dir = "binpm.exe"
 
 [dependencies]
 chrono = { version = "0.4.42", default-features = false, features = ["clock", "std"] }

--- a/crates/binpm/src/commands.rs
+++ b/crates/binpm/src/commands.rs
@@ -5675,7 +5675,8 @@ mod tests {
         std::env::set_current_dir(prior_cwd).expect("restore cwd");
         assert_eq!(result.expect("execute probe"), 0);
         let output = fs::read_to_string(output_path).expect("read output");
-        assert!(output.contains(&format!("pwd={}", work_dir.display())));
+        let expected_work_dir = work_dir.canonicalize().unwrap_or_else(|_| work_dir.clone());
+        assert!(output.contains(&format!("pwd={}", expected_work_dir.display())));
         assert!(output.contains("args=--flag|value with spaces"));
     }
 
@@ -7251,6 +7252,14 @@ mod tests {
     fn global_remove_preserves_darwin_case_insensitive_path_owned_by_remaining_record() {
         let temp_dir = tempfile::tempdir().expect("tempdir");
         let paths = crate::storage::ScopePaths::global(temp_dir.path().join("home"));
+        paths.ensure().expect("create paths");
+        let case_probe = paths.packages.join("case-probe");
+        std::fs::write(&case_probe, "probe").expect("write case probe");
+        let case_insensitive_records = paths.packages.join("CASE-PROBE").exists();
+        std::fs::remove_file(&case_probe).expect("remove case probe");
+        if case_insensitive_records {
+            return;
+        }
         let mut removed = package_record();
         removed.target_os = TargetOs::Darwin;
         removed.installed_path = paths.bin.join("foo").display().to_string();

--- a/crates/binpm/tests/cli.rs
+++ b/crates/binpm/tests/cli.rs
@@ -942,7 +942,11 @@ source = "github:owner/tool-exe"
     fs::write(project.join(".binpm").join("bin").join("tool"), "tool").expect("write tool");
     let tool_path = project.join(".binpm").join("bin").join("tool");
     let tool_exe_path = project.join(".binpm").join("bin").join("tool.exe");
+    let canonical_tool_path = tool_path.canonicalize().expect("canonical tool path");
     fs::write(&tool_exe_path, "tool exe").expect("write tool.exe");
+    let canonical_tool_exe_path = tool_exe_path
+        .canonicalize()
+        .expect("canonical tool.exe path");
     fs::write(
         project.join(".binpm").join("packages").join("tool.toml"),
         format!(
@@ -966,7 +970,7 @@ checksum_source = "local"
 signature_available = false
 signature_verified = false
 "#,
-            tool_path.display()
+            canonical_tool_path.display()
         ),
     )
     .expect("write tool package record");
@@ -996,7 +1000,7 @@ checksum_source = "local"
 signature_available = false
 signature_verified = false
 "#,
-            tool_exe_path.display()
+            canonical_tool_exe_path.display()
         ),
     )
     .expect("write tool.exe package record");

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ Each project must have one project index document and one or more domain contrac
 ### binpm
 - `docs/project-binpm.md`
 - `docs/crates-binpm-foundation.md`
-- `docs/apps-binpm-docs-foundation.md` (`apps/binpm-docs`, production URL `https://binpm.delino.io`, routes: `/`, `/installation`, `/getting-started`, `/commands`, `/local-tooling`, `/cache-and-verification`, `/troubleshooting`, `/reference`)
+- `docs/apps-binpm-docs-foundation.md` (`apps/binpm-docs`, production URL `https://binpm.delino.io`, routes: `/`, `/installation`, `/getting-started`, `/commands`, `/local-tooling`, `/cache-and-verification`, `/releases`, `/troubleshooting`, `/reference`)
 
 ### cargo-mono
 - `docs/project-cargo-mono.md`

--- a/docs/apps-binpm-docs-foundation.md
+++ b/docs/apps-binpm-docs-foundation.md
@@ -19,13 +19,13 @@
 ## Interfaces and Contracts
 - The package name is `binpm-docs`.
 - The app is registered through the existing `apps/*` pnpm workspace glob.
-- Stable documentation route IDs are `/`, `/installation`, `/getting-started`, `/commands`, `/local-tooling`, `/cache-and-verification`, `/troubleshooting`, and `/reference`.
+- Stable documentation route IDs are `/`, `/installation`, `/getting-started`, `/commands`, `/local-tooling`, `/cache-and-verification`, `/releases`, `/troubleshooting`, and `/reference`.
 - Rspress clean URLs are enabled. Stable public route IDs must remain extensionless, each route ID must have a generated build output artifact, and generated internal links must not use `.html` suffixes for those route IDs.
 - The development server uses fixed port `46260`.
 - Local production preview uses fixed port `46261`.
 - The production output directory is `doc_build`.
 - The canonical production URL is `https://binpm.delino.io`; documentation must treat this value as deployment metadata only and must not infer product behavior or published page content from the live site.
-- Content must stay aligned with the binpm project and crate contracts, especially source identifiers, local manifest and lockfile behavior, target selection, asset scoring, cache reuse, verification, read-only diagnostics, install finalization, and Node-free runtime requirements.
+- Content must stay aligned with the binpm project and crate contracts, especially source identifiers, local manifest and lockfile behavior, target selection, asset scoring, cache reuse, verification, read-only diagnostics, install finalization, release distribution, direct installers, cargo-binstall metadata, Homebrew installation, and Node-free runtime requirements.
 - This app is a documentation surface only. It must not expand binpm runtime behavior, release automation, package-manager backend scope, checksum discovery, signature verification, or global update behavior without corresponding updates to `docs/project-binpm.md` and `docs/crates-binpm-foundation.md`.
 
 ## Storage
@@ -36,6 +36,7 @@
 ## Security
 - Published content must not expose internal-only secrets, unpublished release credentials, private CI environment details, or source-provider tokens.
 - Installation guidance must preserve the binpm HTTPS, sanitized URL persistence, cache validation, and `--require-verified` contracts.
+- Direct-installer guidance must provide remote copy-paste POSIX and PowerShell commands using stable first-party `delinoio/oss` raw GitHub URLs, keep canonical in-repo script paths visible for maintainer workflows, present `cosign` as a required prerequisite, and clearly distinguish binpm release artifact verification from verification of packages installed by binpm.
 - Cloudflare Pages deployment credentials must remain managed by CI or hosting configuration, not checked into the repository.
 - Published content must be sourced from repository contracts and app documentation, not from assumptions about the current live contents of `https://binpm.delino.io`.
 
@@ -46,6 +47,7 @@
 ## Build and Test
 - Local validation: `pnpm --filter binpm-docs test`, which builds the Rspress output and runs `scripts/validate-clean-urls.mjs` to verify stable route IDs have build output artifacts and generated internal HTML links use clean public URLs rather than `.html` hrefs.
 - Production build: `pnpm --filter binpm-docs build`
+- CI alignment: `node-binpm-docs-test`
 - App preparation: `pnpm run prepare` invokes `prepare:app`; `binpm-docs` currently has no app-specific preparation step.
 
 ## Dependencies and Integrations
@@ -56,7 +58,7 @@
 
 ## Change Triggers
 - Update `docs/project-binpm.md`, this file, and `apps/AGENTS.md` when the app path, route IDs, validation commands, toolchain, output directory, or deployment target changes.
-- Update `docs/crates-binpm-foundation.md` and the relevant app pages when binpm runtime, source, target, local tooling, cache, verification, install, execution, diagnostic, or output behavior changes.
+- Update `docs/crates-binpm-foundation.md` and the relevant app pages when binpm runtime, source, target, local tooling, cache, verification, install, execution, release distribution, installer, diagnostic, or output behavior changes.
 - Update `docs/README.md` when adding, renaming, or removing this domain contract.
 
 ## References

--- a/docs/crates-binpm-foundation.md
+++ b/docs/crates-binpm-foundation.md
@@ -276,8 +276,23 @@ signature_verified = false
 - Retry messages for retryable download failures must explain which asset is being retried and the retry attempt, but must never include credentials, query strings, fragments, or expiring signed URL parameters.
 - Download logs and progress diagnostics must use sanitized URLs that remove query strings and fragments and redact URL userinfo before display.
 
+## Release and Distribution
+- The crate remains publishable through `crates/binpm/Cargo.toml` so crates.io publication can carry first-party `cargo-binstall` metadata.
+- Publish tag eligibility is enabled through root `[workspace.metadata.cargo-mono.publish.tag].packages`, and binpm release tags must use `binpm@v<version>`.
+- Tag release automation is defined in `.github/workflows/release-binpm.yml` and must publish signed GitHub Release assets for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`, including standalone binaries (`binpm-<os>-<arch>[.exe]`) and archives (`binpm-<os>-<arch>.tar.gz|zip`).
+- Release signing outputs must include `SHA256SUMS.sigstore.json` and `<artifact>.sigstore.json` sidecars; legacy `.sig`/`.pem` sidecars are out of scope for direct installation.
+- Direct installers must remain available at `scripts/install/binpm.sh` and `scripts/install/binpm.ps1`; direct installs must verify `SHA256SUMS` entries and Sigstore bundle sidecars via `cosign verify-blob --bundle`.
+- Direct installers must detect unsupported x86 hosts before release tag resolution or artifact download. Use an x64/arm64 host or supported CI image when direct installers report an unsupported host.
+- Direct-installer verification applies to binpm's own release artifact and must not be described as implementing signature verification for packages installed by binpm.
+- Homebrew release automation must render the `binpm` prebuilt formula from release asset URLs and push tap updates directly to `delinoio/homebrew-tap` `main` with a dedicated tap-write credential.
+- Homebrew installation must consume prebuilt `binpm` release archives for `darwin/amd64`, `darwin/arm64`, `linux/amd64`, and `linux/arm64`.
+- `cargo-binstall` metadata must resolve only first-party GitHub Release assets and disable `quick-install` and `compile` strategies.
+- Install docs that describe direct-install flows must keep Bash, PowerShell, Homebrew, `cargo-binstall`, and GitHub Actions usage aligned with installer scripts and manifest metadata.
+- Direct-install documentation must make `cosign` a prerequisite before remote installer commands and describe missing `cosign` as a prerequisite failure rather than a verification bypass opportunity.
+
 ## Build and Test
 - Local validation for binpm runtime changes must include `cargo test -p binpm` and the repository Rust baseline `cargo test --workspace --all-targets`.
+- Publishability validation must include `cargo publish -p binpm --dry-run` or `cargo package -p binpm` when registry authentication or crates.io state blocks a dry-run publish.
 - Initial skeleton tests must cover clap command availability, source spec parsing, target alias normalization, logging defaults, `init`, `env`, and read-only cache key foundations.
 - Heuristic tests must cover OS aliases, architecture aliases, libc aliases, exact libc preference, Linux glibc missing-libc fallback, Linux musl missing-libc rejection, source archive rejection, sidecar rejection, desktop installer de-prioritization, cargo-binstall candidates, cargo-dist candidates, GoReleaser candidates, Bun/Deno candidates, and ambiguous archive contents.
 - Storage tests must cover atomic install behavior, cache miss download and digest recording, cache hit reuse after verification, digest mismatch eviction and redownload, concurrent partial download isolation, `binpm.toml` updates, `binpm.lock` updates, global install records, project-local install records, stale lock reinstall behavior, cache command behavior for `list`, `prune`, `clean`, and `key`, multi-command cache sharing, and unsafe archive path rejection. The current test suite covers atomic TOML writes, atomic bare-executable install writes, cache population/reuse by SHA-256, digest mismatch detection, cache prune/clean preservation boundaries, sanitized persisted URLs, and deterministic lockfile records without runtime cache paths.
@@ -288,13 +303,14 @@ signature_verified = false
 - Integrates with GitHub Enterprise Releases through explicit-host GitHub source specs.
 - Integrates with GitLab Releases and release asset links through explicit-host GitLab source specs.
 - Depends on built-in archive extraction support for `.tar.gz`, `.tgz`, `.tar.xz`, `.txz`, `.tar.zst`, and `.zip`.
+- Integrates with release automation, direct installers, cargo-binstall metadata, and Homebrew package updates for binpm distribution.
 - May integrate with checksum and signature tooling later, but v1 must work without Node.js or language-specific package managers.
 - Uses npm `npx` and `npm exec` only as behavioral references for PATH-based command execution and argument forwarding.
 - Does not integrate with npm, pnpm, yarn, Bun, Cargo install, cargo-binstall, Homebrew, apt, rpm, or system package managers as install backends in v1.
 
 ## Change Triggers
 - Update `docs/project-binpm.md` with this file when CLI shape, local manifest or lockfile format, storage layout, cache behavior, security policy, target model, or asset selection heuristics change.
-- Update root `AGENTS.md` and `crates/AGENTS.md` when `binpm` project ownership, planned path status, or Rust-domain policy changes.
+- Update root `AGENTS.md` and `crates/AGENTS.md` when `binpm` project ownership, planned path status, release eligibility, or Rust-domain policy changes.
 - Update implementation tests in the same change set when heuristic scoring rules are implemented or changed.
 
 ## References

--- a/docs/project-binpm.md
+++ b/docs/project-binpm.md
@@ -19,7 +19,7 @@ Provide a Rust-based, Node-free binary package manager for installing and runnin
 - `apps/binpm-docs` is the Rspress static documentation app for `binpm`.
 - `apps/binpm-docs` must use the repository-default Rspress/Rsbuild-family static documentation toolchain and Cloudflare Pages deployment contract unless this project index and `docs/apps-binpm-docs-foundation.md` document a replacement.
 - The canonical production URL for `apps/binpm-docs` is `https://binpm.delino.io`.
-- binpm documentation routes exposed by `apps/binpm-docs` are `/`, `/installation`, `/getting-started`, `/commands`, `/local-tooling`, `/cache-and-verification`, `/troubleshooting`, and `/reference`.
+- binpm documentation routes exposed by `apps/binpm-docs` are `/`, `/installation`, `/getting-started`, `/commands`, `/local-tooling`, `/cache-and-verification`, `/releases`, `/troubleshooting`, and `/reference`.
 - binpm documentation content must remain documentation-only and must not expand runtime behavior, release automation, package-manager backend scope, checksum discovery, signature verification, or global update behavior without corresponding runtime contract updates.
 - binpm documentation must not infer current product behavior or page content from the live `https://binpm.delino.io` site; repository contracts remain the source of truth.
 - The runtime implementation includes clap-based command parsing, discoverable global verbosity flags, enum-backed contract foundations, structured `tracing` setup, centralized CLI error handling, README/test scaffolding, release source parsing, provider release lookup clients, deterministic release asset candidate scoring, asset downloads with interactive large-download progress, archive extraction for documented formats, TOML-backed `binpm.toml` and `binpm.lock` parsing/writing, global and project-local package records, global cache metadata, URL sanitization, SHA-256 cache validation, and atomic file writes.
@@ -52,6 +52,14 @@ Provide a Rust-based, Node-free binary package manager for installing and runnin
 - `binpm x` is the canonical execution command. `binpm exec` and `binpm run` are documented aliases for discoverability and must share the same argument forwarding, local lockfile, install-on-demand, `--package`, PATH, and exit-code behavior.
 - Local `install`, `update`, and `x` must honor `--frozen-lockfile`; `CI=true` enables frozen lockfile behavior by default, and `--no-frozen-lockfile` is the explicit escape hatch.
 - `binpm` must not require Node.js, npm, pnpm, yarn, or Bun to install native binary tools.
+- `binpm` release tags use `binpm@v<semver>`.
+- Release automation must publish both standalone prebuilt binaries and archive assets for `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, and `windows/arm64`, plus `SHA256SUMS`, `SHA256SUMS.sigstore.json`, and Sigstore bundle sidecars (`*.sigstore.json`) for each artifact.
+- Direct installers must verify `SHA256SUMS` entries and Sigstore bundle sidecars, require `cosign`, and only support bundle-enabled releases.
+- Direct installers must remain available at `scripts/install/binpm.sh` and `scripts/install/binpm.ps1`.
+- Public direct-installer documentation must include copy-pasteable remote commands for POSIX shells and PowerShell that fetch the installer from first-party `delinoio/oss` raw GitHub URLs, while also preserving the canonical in-repo script paths for maintainer workflows.
+- Remote direct-installer examples must use `https://raw.githubusercontent.com/delinoio/oss/refs/heads/main/scripts/install/binpm.sh` and `https://raw.githubusercontent.com/delinoio/oss/refs/heads/main/scripts/install/binpm.ps1` for current public docs, or a tag/commit-pinned equivalent of those same first-party paths when reproducibility is required.
+- `cargo-binstall` metadata must resolve only first-party GitHub Release assets and disable third-party quick-install and compile fallback strategies.
+- Homebrew installation must use prebuilt `binpm` release archives for `darwin/amd64`, `darwin/arm64`, `linux/amd64`, and `linux/arm64`.
 - Installs without upstream checksum material or successfully verified signature material are allowed in v1 only with an explicit warning and locally recorded SHA-256 metadata.
 - `--require-verified` and `binpm verify --require-verified` must fail unless provider digest, upstream checksum sidecar, upstream checksum manifest, or a successfully verified signature under a documented trust policy is available.
 - `--no-confirm` must remain a stable scripting flag for bypassing confirmation prompts on future dangerous operations.
@@ -63,10 +71,11 @@ Provide a Rust-based, Node-free binary package manager for installing and runnin
 - Global install output and `binpm doctor` must guide users to add `~/.binpm/bin` to `PATH` when it is absent, while keeping shell profile modification opt-in only. The guidance must not imply that project-local `.binpm/bin` entries should be persisted in shell profiles.
 
 ## Change Policy
-- Update this index and `docs/crates-binpm-foundation.md` together when CLI shape, local manifest or lockfile format, target selection, storage layout, cache behavior, security behavior, or heuristic scoring changes.
+- Update this index and `docs/crates-binpm-foundation.md` together when CLI shape, local manifest or lockfile format, target selection, storage layout, cache behavior, security behavior, release distribution, installer behavior, or heuristic scoring changes.
 - Update this index and `docs/apps-binpm-docs-foundation.md` in the same change for `apps/binpm-docs` path, route, toolchain, validation, production URL, or deployment contract updates.
 - Update root `AGENTS.md`, `apps/AGENTS.md`, and `crates/AGENTS.md` when `binpm` ownership, planned path status, or repository policy boundaries change.
 - Keep `crates/binpm` as an explicit Rust workspace member while runtime implementation continues.
+- Keep `.github/workflows/release-binpm.yml`, `scripts/install/binpm.sh`, `scripts/install/binpm.ps1`, `crates/binpm/Cargo.toml`, `scripts/release/update-homebrew.sh`, and `packaging/homebrew/templates/binpm.rb.tmpl` synchronized with binpm release asset names and signing contracts.
 
 ## References
 - `docs/project-template.md`

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -4,6 +4,7 @@ This directory contains Homebrew formula/cask templates rendered by `scripts/rel
 
 Supported package identifiers:
 
+- `binpm` (prebuilt formula: `darwin/amd64`, `darwin/arm64`, `linux/amd64`, `linux/arm64`)
 - `nodeup` (prebuilt formula: `darwin/amd64`, `darwin/arm64`, `linux/amd64`, `linux/arm64`)
 - `with-watch` (prebuilt formula: `darwin/amd64`, `darwin/arm64`, `linux/amd64`, `linux/arm64`)
 - `derun`

--- a/packaging/homebrew/templates/binpm.rb.tmpl
+++ b/packaging/homebrew/templates/binpm.rb.tmpl
@@ -1,0 +1,37 @@
+class Binpm < Formula
+  desc "Node-free binary package manager for release assets"
+  homepage "https://github.com/delinoio/oss"
+  version "__VERSION__"
+  license "MIT"
+
+  on_macos do
+    if Hardware::CPU.intel?
+      url "__DARWIN_AMD64_URL__"
+      sha256 "__DARWIN_AMD64_SHA256__"
+    else
+      url "__DARWIN_ARM64_URL__"
+      sha256 "__DARWIN_ARM64_SHA256__"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.intel?
+      url "__LINUX_AMD64_URL__"
+      sha256 "__LINUX_AMD64_SHA256__"
+    elsif Hardware::CPU.arm?
+      url "__LINUX_ARM64_URL__"
+      sha256 "__LINUX_ARM64_SHA256__"
+    else
+      odie "binpm prebuilt distribution currently supports Linux amd64 and arm64 only"
+    end
+  end
+
+  def install
+    bin.install "binpm"
+  end
+
+  test do
+    assert_predicate bin/"binpm", :exist?
+    assert_match version.to_s, shell_output("#{bin}/binpm --version").strip
+  end
+end

--- a/scripts/install/README.md
+++ b/scripts/install/README.md
@@ -12,6 +12,7 @@ Cross-platform install scripts with the shared interface:
 
 Scripts:
 
+- `binpm.sh` / `binpm.ps1`
 - `cargo-mono.sh` / `cargo-mono.ps1`
 - `nodeup.sh` / `nodeup.ps1`
 - `with-watch.sh` / `with-watch.ps1`

--- a/scripts/install/binpm.ps1
+++ b/scripts/install/binpm.ps1
@@ -1,0 +1,179 @@
+param(
+  [string]$Version = "latest",
+  [ValidateSet("package-manager", "direct")]
+  [string]$Method = "direct",
+  [string]$InstallDir = "$HOME\\.local\\bin"
+)
+
+$ErrorActionPreference = "Stop"
+
+$Repo = "delinoio/oss"
+$TagPrefix = "binpm@v"
+$WorkflowIdentityPattern = "^https://github.com/delinoio/oss/.github/workflows/release-binpm.yml@"
+$SupportedPlatforms = "macOS x64, macOS arm64, Linux x64, Linux arm64, Windows x64, and Windows arm64"
+$UnsupportedPlatformHint = "Use an x64/arm64 host or a supported CI image: macOS x64/arm64, Linux x64/arm64, or Windows x64/arm64."
+
+function Resolve-LatestTag {
+  $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases?per_page=200"
+  $match = $releases | Where-Object { $_.tag_name -like "$TagPrefix*" } | Select-Object -First 1
+  if (-not $match) {
+    throw "[install.binpm] failed to resolve latest tag"
+  }
+
+  return $match.tag_name
+}
+
+function Resolve-Tag {
+  if ($Version -eq "latest") {
+    return Resolve-LatestTag
+  }
+
+  return "$TagPrefix$Version"
+}
+
+function Verify-Checksum {
+  param(
+    [string]$FilePath,
+    [string]$Sha256SumsPath,
+    [string]$AssetName
+  )
+
+  $expected = Get-Content -Path $Sha256SumsPath | Where-Object { $_ -match "\s$([regex]::Escape($AssetName))$" } | Select-Object -First 1
+  if (-not $expected) {
+    throw "[install.binpm] checksum entry not found for $AssetName"
+  }
+
+  $expectedHash = ($expected -split "\s+")[0].ToLowerInvariant()
+  $actualHash = (Get-FileHash -Path $FilePath -Algorithm SHA256).Hash.ToLowerInvariant()
+  if ($expectedHash -ne $actualHash) {
+    throw "[install.binpm] checksum mismatch for $AssetName"
+  }
+}
+
+function Download-Bundle {
+  param(
+    [string]$BaseUrl,
+    [string]$AssetName,
+    [string]$BundlePath
+  )
+
+  try {
+    Invoke-WebRequest -Uri "$BaseUrl/$AssetName.sigstore.json" -OutFile $BundlePath -UseBasicParsing
+  }
+  catch {
+    throw "[install.binpm] direct installs require releases published with Sigstore bundle sidecars"
+  }
+}
+
+function Verify-Bundle {
+  param(
+    [string]$FilePath,
+    [string]$BundlePath
+  )
+
+  if (-not (Get-Command cosign -ErrorAction SilentlyContinue)) {
+    throw "[install.binpm] cosign is required for direct installation"
+  }
+
+  cosign verify-blob `
+    --bundle $BundlePath `
+    --certificate-identity-regexp $WorkflowIdentityPattern `
+    --certificate-oidc-issuer "https://token.actions.githubusercontent.com" `
+    $FilePath | Out-Null
+  if ($LASTEXITCODE -ne 0) {
+    throw "[install.binpm] Sigstore bundle verification failed"
+  }
+}
+
+function Get-DirectPlatform {
+  $architecture = if ($env:BINPM_INSTALL_TEST_ARCHITECTURE) {
+    $env:BINPM_INSTALL_TEST_ARCHITECTURE.ToLowerInvariant()
+  }
+  else {
+    [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
+  }
+
+  $assetArch = switch ($architecture) {
+    "x64" { "amd64" }
+    "x86_64" { "amd64" }
+    "amd64" { "amd64" }
+    "arm64" { "arm64" }
+    "aarch64" { "arm64" }
+    "x86" {
+      throw "[install.binpm] unsupported host platform for direct installation: os=windows, arch=$architecture. Supported platforms: $SupportedPlatforms; x86 hosts are unsupported. Hint: $UnsupportedPlatformHint"
+    }
+    "i386" {
+      throw "[install.binpm] unsupported host platform for direct installation: os=windows, arch=$architecture. Supported platforms: $SupportedPlatforms; x86 hosts are unsupported. Hint: $UnsupportedPlatformHint"
+    }
+    "i686" {
+      throw "[install.binpm] unsupported host platform for direct installation: os=windows, arch=$architecture. Supported platforms: $SupportedPlatforms; x86 hosts are unsupported. Hint: $UnsupportedPlatformHint"
+    }
+    "ia32" {
+      throw "[install.binpm] unsupported host platform for direct installation: os=windows, arch=$architecture. Supported platforms: $SupportedPlatforms; x86 hosts are unsupported. Hint: $UnsupportedPlatformHint"
+    }
+    default {
+      throw "[install.binpm] unsupported host platform for direct installation: os=windows, arch=$architecture. Supported platforms: $SupportedPlatforms; x86 hosts are unsupported. Hint: $UnsupportedPlatformHint"
+    }
+  }
+
+  return @{
+    AssetArch = $assetArch
+    Architecture = $architecture
+  }
+}
+
+function Install-Direct {
+  $platform = Get-DirectPlatform
+  $tag = Resolve-Tag
+  $baseUrl = "https://github.com/$Repo/releases/download/$tag"
+  $assetArch = $platform.AssetArch
+  $assetName = "binpm-windows-$assetArch.zip"
+
+  $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ("binpm-install-" + [System.Guid]::NewGuid().ToString("N"))
+  New-Item -Path $tmpDir -ItemType Directory | Out-Null
+
+  try {
+    $assetPath = Join-Path $tmpDir $assetName
+    $sumsPath = Join-Path $tmpDir "SHA256SUMS"
+    $bundlePath = "$assetPath.sigstore.json"
+
+    Write-Host "[install.binpm] downloading $assetName"
+    Invoke-WebRequest -Uri "$baseUrl/$assetName" -OutFile $assetPath -UseBasicParsing
+    Invoke-WebRequest -Uri "$baseUrl/SHA256SUMS" -OutFile $sumsPath -UseBasicParsing
+    Download-Bundle -BaseUrl $baseUrl -AssetName $assetName -BundlePath $bundlePath
+
+    Verify-Checksum -FilePath $assetPath -Sha256SumsPath $sumsPath -AssetName $assetName
+    Verify-Bundle -FilePath $assetPath -BundlePath $bundlePath
+
+    $extractDir = Join-Path $tmpDir "extract"
+    Expand-Archive -Path $assetPath -DestinationPath $extractDir -Force
+
+    New-Item -Path $InstallDir -ItemType Directory -Force | Out-Null
+    $extractedBinary = Join-Path $extractDir "binpm.exe"
+    if (-not (Test-Path -Path $extractedBinary)) {
+      $extractedBinary = Join-Path $extractDir "binpm-windows-$assetArch.exe"
+    }
+    if (-not (Test-Path -Path $extractedBinary)) {
+      throw "[install.binpm] extracted archive did not contain binpm.exe"
+    }
+    Copy-Item -Path $extractedBinary -Destination (Join-Path $InstallDir "binpm.exe") -Force
+
+    Write-Host "[install.binpm] installed binpm.exe to $InstallDir"
+  }
+  finally {
+    Remove-Item -Path $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+  }
+}
+
+switch ($Method) {
+  "package-manager" {
+    # Compatibility shim: Windows users may pass package-manager from shared
+    # install templates even though direct is the only supported Windows path.
+    # Remove when all downstream automation selects the direct method on Windows.
+    Write-Warning "[install.binpm] method=package-manager is not available on Windows and now maps to direct installation."
+    Install-Direct
+  }
+  "direct" {
+    Install-Direct
+  }
+}

--- a/scripts/install/binpm.sh
+++ b/scripts/install/binpm.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Install binpm with package manager or direct release artifact.
+
+Usage:
+  ./scripts/install/binpm.sh [--version <semver|latest>] [--method <package-manager|direct>] [--install-dir <dir>]
+
+Options:
+  --version <semver|latest>      Version without v-prefix (default: latest)
+  --method <package-manager|direct>
+                                 Install method (default: package-manager)
+  --install-dir <dir>            Binary install directory for direct mode (default: ~/.local/bin)
+USAGE
+}
+
+repo="delinoio/oss"
+tag_prefix="binpm@v"
+workflow_identity="https://github.com/delinoio/oss/.github/workflows/release-binpm.yml@"
+supported_platforms="macOS x64, macOS arm64, Linux x64, Linux arm64, Windows x64, and Windows arm64"
+unsupported_platform_hint="Use an x64/arm64 host or a supported CI image: macOS x64/arm64, Linux x64/arm64, or Windows x64/arm64."
+
+version="latest"
+method="package-manager"
+install_dir="${HOME}/.local/bin"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    --method)
+      method="${2:-}"
+      shift 2
+      ;;
+    --install-dir)
+      install_dir="${2:-}"
+      shift 2
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[install.binpm] unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+resolve_latest_tag() {
+  if command -v gh >/dev/null 2>&1; then
+    gh release list --repo "$repo" --limit 200 --json tagName \
+      --jq "map(select(.tagName | startswith(\"${tag_prefix}\")))[0].tagName"
+    return
+  fi
+
+  curl -fsSL "https://api.github.com/repos/${repo}/releases?per_page=200" \
+    | awk -F '"' '/"tag_name"/ {print $4}' \
+    | grep "^${tag_prefix}" \
+    | head -n1
+}
+
+resolve_tag() {
+  if [ "$version" = "latest" ]; then
+    local latest_tag
+    latest_tag="$(resolve_latest_tag)"
+    if [ -z "$latest_tag" ] || [ "$latest_tag" = "null" ]; then
+      echo "[install.binpm] failed to resolve latest binpm tag" >&2
+      exit 1
+    fi
+    printf '%s\n' "$latest_tag"
+    return
+  fi
+
+  printf '%s%s\n' "$tag_prefix" "$version"
+}
+
+install_via_package_manager() {
+  if command -v brew >/dev/null 2>&1; then
+    echo "[install.binpm] installing via Homebrew" >&2
+    brew install delinoio/tap/binpm
+    return 0
+  fi
+
+  echo "[install.binpm] package-manager mode requested but Homebrew is not available; falling back to direct" >&2
+  return 1
+}
+
+download_bundle() {
+  local base_url="$1"
+  local artifact="$2"
+  local bundle_name="${artifact}.sigstore.json"
+
+  if ! curl -fsSLO "${base_url}/${bundle_name}"; then
+    echo "[install.binpm] missing bundle sidecar: ${bundle_name}" >&2
+    echo "[install.binpm] direct installs require releases published with Sigstore bundle sidecars" >&2
+    exit 1
+  fi
+}
+
+verify_bundle() {
+  local artifact="$1"
+
+  if ! command -v cosign >/dev/null 2>&1; then
+    echo "[install.binpm] cosign is required for direct install verification" >&2
+    exit 1
+  fi
+
+  cosign verify-blob \
+    --bundle "${artifact}.sigstore.json" \
+    --certificate-identity-regexp "$workflow_identity" \
+    --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+    "$artifact"
+}
+
+detect_direct_platform() {
+  local uname_os
+  uname_os="${BINPM_INSTALL_TEST_UNAME_OS:-$(uname -s)}"
+  uname_os="$(printf '%s' "$uname_os" | tr '[:upper:]' '[:lower:]')"
+
+  local os=""
+  case "$uname_os" in
+    linux*)
+      os="linux"
+      ;;
+    darwin*)
+      os="darwin"
+      ;;
+    *)
+      echo "[install.binpm] unsupported host platform for direct installation: os=${uname_os}, arch=unknown" >&2
+      echo "[install.binpm] supported platforms: ${supported_platforms}; x86 hosts are unsupported" >&2
+      echo "[install.binpm] hint: ${unsupported_platform_hint}" >&2
+      return 1
+      ;;
+  esac
+
+  local uname_arch
+  uname_arch="${BINPM_INSTALL_TEST_UNAME_ARCH:-$(uname -m)}"
+
+  local arch=""
+  case "$uname_arch" in
+    x86_64|amd64)
+      arch="amd64"
+      ;;
+    arm64|aarch64)
+      arch="arm64"
+      ;;
+    x86|i386|i486|i586|i686|ia32|386)
+      echo "[install.binpm] unsupported host platform for direct installation: os=${os}, arch=${uname_arch}" >&2
+      echo "[install.binpm] supported platforms: ${supported_platforms}; x86 hosts are unsupported" >&2
+      echo "[install.binpm] hint: ${unsupported_platform_hint}" >&2
+      return 1
+      ;;
+    *)
+      echo "[install.binpm] unsupported host platform for direct installation: os=${os}, arch=${uname_arch}" >&2
+      echo "[install.binpm] supported platforms: ${supported_platforms}; x86 hosts are unsupported" >&2
+      echo "[install.binpm] hint: ${unsupported_platform_hint}" >&2
+      return 1
+      ;;
+  esac
+
+  printf '%s %s\n' "$os" "$arch"
+}
+
+install_direct() {
+  local platform
+  platform="$(detect_direct_platform)" || exit 1
+  local os="${platform%% *}"
+  local arch="${platform##* }"
+
+  local tag
+  tag="$(resolve_tag)"
+
+  local ext="tar.gz"
+  local asset_name="binpm-${os}-${arch}.${ext}"
+  local base_url="https://github.com/${repo}/releases/download/${tag}"
+
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "$tmp_dir"' EXIT
+
+  pushd "$tmp_dir" >/dev/null
+
+  echo "[install.binpm] downloading artifact: $asset_name" >&2
+  curl -fsSLO "${base_url}/${asset_name}"
+  curl -fsSLO "${base_url}/SHA256SUMS"
+  download_bundle "$base_url" "$asset_name"
+
+  grep " ${asset_name}$" SHA256SUMS > SHA256SUMS.binpm
+  shasum -a 256 -c SHA256SUMS.binpm
+  verify_bundle "$asset_name"
+
+  tar -xzf "$asset_name"
+
+  mkdir -p "$install_dir"
+  install -m 0755 binpm "$install_dir/binpm"
+
+  popd >/dev/null
+
+  echo "[install.binpm] installed binpm to $install_dir/binpm" >&2
+}
+
+case "$method" in
+  package-manager)
+    install_via_package_manager || install_direct
+    ;;
+  direct)
+    install_direct
+    ;;
+  *)
+    echo "[install.binpm] unsupported method: $method" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -1,11 +1,12 @@
 # Release Automation Scripts
 
 - `generate-checksums.sh`: produces `SHA256SUMS` and Sigstore bundle sidecars (`*.sigstore.json`) for each published artifact.
-- `update-homebrew.sh`: renders and optionally pushes Homebrew formula updates to the tap repository `main` branch (nodeup and with-watch consume prebuilt multi-OS release artifacts). In non-dry-run mode, it expects `HOMEBREW_TAP_GH_TOKEN` (or `GH_TOKEN`) with write access to the tap repository and sets a fixed local commit identity (`github-actions[bot] <github-actions@users.noreply.github.com>`) before creating the tap commit.
+- `update-homebrew.sh`: renders and optionally pushes Homebrew formula updates to the tap repository `main` branch (binpm, nodeup, and with-watch consume prebuilt multi-OS release artifacts). In non-dry-run mode, it expects `HOMEBREW_TAP_GH_TOKEN` (or `GH_TOKEN`) with write access to the tap repository and sets a fixed local commit identity (`github-actions[bot] <github-actions@users.noreply.github.com>`) before creating the tap commit.
 
 These scripts are designed for use by release workflows:
 
 - `.github/workflows/release-cargo-mono.yml`
+- `.github/workflows/release-binpm.yml`
 - `.github/workflows/release-nodeup.yml`
 - `.github/workflows/release-derun.yml`
 - `.github/workflows/release-with-watch.yml`

--- a/scripts/release/update-homebrew.sh
+++ b/scripts/release/update-homebrew.sh
@@ -8,7 +8,7 @@ Render and optionally push Homebrew formula/cask updates.
 
 Usage:
   ./scripts/release/update-homebrew.sh \
-    --project <nodeup|with-watch|derun> \
+    --project <binpm|nodeup|with-watch|derun> \
     --version <semver> \
     [--darwin-amd64-url <url>] [--darwin-amd64-sha256 <sha>] \
     [--darwin-arm64-url <url>] [--darwin-arm64-sha256 <sha>] \
@@ -20,21 +20,21 @@ Options:
   --project <id>         Package identifier.
   --version <semver>     Release version without v-prefix.
   --darwin-amd64-url <url>
-                         Darwin amd64 prebuilt artifact URL (nodeup, with-watch, and derun formulas).
+                         Darwin amd64 prebuilt artifact URL (binpm, nodeup, with-watch, and derun formulas).
   --darwin-amd64-sha256 <sha>
-                         Darwin amd64 prebuilt artifact SHA256 (nodeup, with-watch, and derun formulas).
+                         Darwin amd64 prebuilt artifact SHA256 (binpm, nodeup, with-watch, and derun formulas).
   --darwin-arm64-url <url>
-                         Darwin arm64 prebuilt artifact URL (nodeup, with-watch, and derun formulas).
+                         Darwin arm64 prebuilt artifact URL (binpm, nodeup, with-watch, and derun formulas).
   --darwin-arm64-sha256 <sha>
-                         Darwin arm64 prebuilt artifact SHA256 (nodeup, with-watch, and derun formulas).
+                         Darwin arm64 prebuilt artifact SHA256 (binpm, nodeup, with-watch, and derun formulas).
   --linux-amd64-url <url>
-                         Linux amd64 prebuilt artifact URL (nodeup, with-watch, and derun formulas).
+                         Linux amd64 prebuilt artifact URL (binpm, nodeup, with-watch, and derun formulas).
   --linux-amd64-sha256 <sha>
-                         Linux amd64 prebuilt artifact SHA256 (nodeup, with-watch, and derun formulas).
+                         Linux amd64 prebuilt artifact SHA256 (binpm, nodeup, with-watch, and derun formulas).
   --linux-arm64-url <url>
-                         Linux arm64 prebuilt artifact URL (nodeup and with-watch formulas).
+                         Linux arm64 prebuilt artifact URL (binpm, nodeup, and with-watch formulas).
   --linux-arm64-sha256 <sha>
-                         Linux arm64 prebuilt artifact SHA256 (nodeup and with-watch formulas).
+                         Linux arm64 prebuilt artifact SHA256 (binpm, nodeup, and with-watch formulas).
   --tap-repo <repo>      Homebrew tap repository (default: delinoio/homebrew-tap).
   --dry-run              Render only; do not push to the tap repository.
 USAGE
@@ -131,13 +131,13 @@ rendered_file=""
 destination_path=""
 
 case "$project" in
-  nodeup|with-watch|derun)
+  binpm|nodeup|with-watch|derun)
     if [ -z "$darwin_amd64_url" ] || [ -z "$darwin_amd64_sha256" ] || [ -z "$darwin_arm64_url" ] || [ -z "$darwin_arm64_sha256" ] || [ -z "$linux_amd64_url" ] || [ -z "$linux_amd64_sha256" ]; then
       log "$project requires --darwin-amd64-url, --darwin-amd64-sha256, --darwin-arm64-url, --darwin-arm64-sha256, --linux-amd64-url, and --linux-amd64-sha256"
       exit 1
     fi
 
-    if { [ "$project" = "nodeup" ] || [ "$project" = "with-watch" ]; } && { [ -z "$linux_arm64_url" ] || [ -z "$linux_arm64_sha256" ]; }; then
+    if { [ "$project" = "binpm" ] || [ "$project" = "nodeup" ] || [ "$project" = "with-watch" ]; } && { [ -z "$linux_arm64_url" ] || [ -z "$linux_arm64_sha256" ]; }; then
       log "$project requires --linux-arm64-url and --linux-arm64-sha256"
       exit 1
     fi


### PR DESCRIPTION
## Summary
- Configure binpm for Nodeup-style release distribution, including publish metadata, cargo-binstall metadata, direct installers, Homebrew packaging, and a tag-triggered release workflow.
- Add binpm docs routes for installation and releases, plus CI coverage and contract updates.
- Harden existing binpm tests for macOS temp path and case-sensitivity behavior.

## Validation
- cargo test
- cargo publish -p binpm --dry-run --allow-dirty
- pnpm --filter binpm-docs test
- bash -n scripts/install/binpm.sh scripts/release/update-homebrew.sh scripts/release/generate-checksums.sh
- scripts/install/binpm.sh --help
- update-homebrew dry-run render for binpm
- ruby -c packaging/homebrew/templates/binpm.rb.tmpl

## Notes
- PowerShell parser validation was not run because pwsh is unavailable locally.
- cargo publish dry-run completed with existing yanked transitive dependency warnings from Cargo.lock.