### PR TITLE
fix(binpm-docs): stop accessibility sync loop

### DIFF
--- a/apps/binpm-docs/theme/index.tsx
+++ b/apps/binpm-docs/theme/index.tsx
@@ -87,7 +87,10 @@ function setMobileDrawerState() {
 
 function syncAccessibleControls() {
   const searchButton = document.querySelector(".rp-search-button");
-  if (searchButton instanceof HTMLButtonElement) {
+  if (
+    searchButton instanceof HTMLButtonElement &&
+    searchButton.getAttribute("type") !== "button"
+  ) {
     searchButton.type = "button";
   }
   setButtonName(searchButton, SEARCH_LABEL);


### PR DESCRIPTION
## Summary
- Fix the binpm docs accessibility sync loop that can freeze the page after hydration.
- Keep the search button type normalization idempotent so the MutationObserver does not repeatedly retrigger itself.

## Root Cause
The accessibility sync effect observed broad DOM attribute changes and always reassigned `.rp-search-button.type = "button"`. In Chrome, that assignment produced a `type` attribute mutation even when the value was already correct, causing the observer callback to run again in a tight loop.

## Impact
The production docs HTML rendered, but the browser main thread could become busy after client-side hydration, making https://binpm.delino.io/ appear stuck or unloaded.

## Validation
- Reproduced the production freeze with headless Chrome and MutationObserver instrumentation.
- Verified the local preview remains responsive after hydration; DOM evaluation returned immediately after a 3 second wait.
- Ran `pnpm test` from `apps/binpm-docs`.
