### PR TITLE
feat(skills): add write-prd workflow

### DIFF
--- a/.agents/skills/write-prd/SKILL.md
+++ b/.agents/skills/write-prd/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: write-prd
+description: Decision-complete PRD drafting and GitHub issue filing for repository features. Use only when a human explicitly invokes `$write-prd`; never select this skill automatically for similar feature, planning, PRD, or issue tasks. When invoked, ground a feature request in repository contracts, close a decision ledger, prepare an implementation-ready PRD, and file it in the current GitHub repository without labels or other issue metadata.
+---
+
+# Write PRD
+
+## Goal
+
+Turn a feature request into a decision-complete PRD and GitHub issue. Do not invent product or operational defaults. Close every required decision with a user answer, an explicit user-approved `not applicable`, or direct repository-contract evidence before filing the issue.
+
+## Required References
+
+Read both references before asking questions or drafting the issue:
+
+- `references/question-ledger.md` defines the required decisions and ledger states.
+- `references/issue-template.md` defines the issue title, body, and filing checks.
+
+## Operating Rules
+
+- Follow all active system, developer, repository, and scoped `AGENTS.md` instructions.
+- At the start of the task, list `docs/`, then read the root and applicable scoped `AGENTS.md` files and the relevant `docs/` contracts.
+- Resolve discoverable repository facts before asking the user. Record direct evidence as `contract-determined`; ask only when product intent or a genuine tradeoff remains open.
+- Ask focused questions in small batches. Reconcile conflicting answers immediately.
+- Keep facts, user decisions, and remaining questions distinct in the ledger.
+- Resolve the current GitHub repository with `gh repo view --json nameWithOwner -q .nameWithOwner`. If it cannot be resolved unambiguously, ask for the target before continuing.
+- Search the current repository for duplicate or overlapping issues before finalizing the PRD.
+- Do not set labels, assignees, milestones, project fields, issue types, or any other issue metadata. If an applicable repository contract requires metadata, report the conflict and stop before filing.
+- Do not file while any required ledger row is `open` or while answers contradict repository contracts.
+
+## Workflow
+
+1. Ground the feature.
+   - Identify the requested outcome, affected project and domain, target users, and current repository.
+   - Inspect applicable contracts, nearby implementation, schemas, APIs, routes, and existing issues.
+   - Initialize a visible ledger from `references/question-ledger.md`, recording contract evidence immediately.
+
+2. Close the ledger.
+   - Ask only questions that materially close one or more open rows.
+   - Accept `not applicable` only when the user explicitly chooses it and provides enough context to preserve the boundary.
+   - Repeat discovery and questioning until every required row is closed and internally consistent.
+
+3. Handle Plan Mode.
+   - When Plan Mode is active, do not create an issue or mutate external state.
+   - Produce a complete plan containing the exact issue title, full body, resolved repository name, and the later `gh issue create` action without metadata flags.
+   - When executing a complete prior plan outside Plan Mode, file the issue without requesting an additional confirmation.
+
+4. Draft the issue.
+   - Follow `references/issue-template.md` and the current repository's issue contract.
+   - Translate closed ledger decisions into concrete scope, observable acceptance criteria, test scenarios, and explicit exclusions.
+   - Omit unsupported claims and implementation details that remain undecided.
+
+5. File the issue.
+   - Outside Plan Mode, write the multiline body to a safely created temporary file.
+   - Run `gh issue create` against the resolved repository with only `--repo`, `--title`, and `--body-file`.
+   - Report the issue URL, title, repository, and any unresolved follow-up risk.
+
+## Useful Commands
+
+```bash
+gh repo view --json nameWithOwner -q .nameWithOwner
+gh issue list --repo "$OWNER_REPO" --search "$SEARCH_TERMS" --state open
+gh issue create --repo "$OWNER_REPO" --title "$TITLE" --body-file "$BODY_FILE"
+```
+
+Quote shell variables and paths. Use a safely created temporary file for multiline Markdown and remove it after the command completes.

--- a/.agents/skills/write-prd/agents/openai.yaml
+++ b/.agents/skills/write-prd/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Write PRD"
+  short_description: "Turn explicit feature decisions into PRD issues"
+  default_prompt: "Use $write-prd to define a feature completely and prepare its GitHub issue."
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/write-prd/references/issue-template.md
+++ b/.agents/skills/write-prd/references/issue-template.md
@@ -1,0 +1,67 @@
+# PRD GitHub Issue Template
+
+Create one issue for one coherent feature or implementation slice. Apply the current repository's issue contract if it is stricter than this reference.
+
+## Title
+
+Use this shape:
+
+```text
+<domain>: <description>
+```
+
+- Select `<domain>` from a stable lowercase project or domain identifier in repository contracts.
+- Keep `<description>` concise and specific, starting with a lowercase verb phrase when natural.
+- Do not use bracketed project prefixes.
+
+## Body
+
+Use these sections in this exact order:
+
+```markdown
+## Summary
+Describe the feature, intended users, core value, and observable success in one or two concise paragraphs.
+
+## Evidence
+- Request or evidence source:
+- Current gap:
+- Users or actors affected:
+- Repository or contract evidence:
+- Duplicate issue search:
+
+## Current Gap
+Explain the current behavior or missing capability that motivates the change.
+
+## Proposed Scope
+Define the agreed functional and operational behavior. Cover applicable interfaces, data and state, UX, authorization, security and privacy, integrations, rollout and rollback, observability, documentation, and support decisions.
+
+## Acceptance Criteria
+- A user, operator, or system can ...
+- Interface, authorization, ownership, validation, and error behavior are ...
+- Operational controls and observability are ...
+- Required documentation and support artifacts are ...
+
+## Test Scenarios
+- Verify the primary happy path.
+- Verify validation, authorization, error, and recovery behavior.
+- Verify applicable interface, data, migration, integration, and compatibility behavior.
+- Verify applicable rollout, rollback, observability, and support behavior.
+- Verify preserved behavior does not regress.
+
+## Out of Scope
+- List adjacent work, migrations, redesigns, compatibility promises, or operational changes that were explicitly excluded.
+```
+
+Append `## Additional Notes` only when useful links or context do not fit the required sections.
+
+## Filing Checklist
+
+Before filing, verify that:
+
+- Every required decision-ledger row is closed without an inferred default.
+- The title uses a contract-backed domain identifier and follows the repository issue contract.
+- The body contains every required section in order.
+- Acceptance criteria and test scenarios are observable and implementation-ready.
+- Out-of-scope boundaries are explicit.
+- The duplicate search and relevant contract evidence are recorded.
+- The create command sets no label or other issue metadata.

--- a/.agents/skills/write-prd/references/question-ledger.md
+++ b/.agents/skills/write-prd/references/question-ledger.md
@@ -1,0 +1,109 @@
+# PRD Decision Ledger
+
+Use this ledger to make product and operational decisions explicit before drafting or filing an issue.
+
+## Contents
+
+- [Ledger Rules](#ledger-rules)
+- [Product Intent](#product-intent)
+- [Scope and Experience](#scope-and-experience)
+- [Interfaces and Data](#interfaces-and-data)
+- [Security and Integrations](#security-and-integrations)
+- [Operations and Observability](#operations-and-observability)
+- [Failure Modes](#failure-modes)
+- [Documentation and Testing](#documentation-and-testing)
+- [Issue Filing](#issue-filing)
+
+## Ledger Rules
+
+- Keep a row for every decision below, duplicating rows when multiple products, actors, services, or rollout paths need different answers.
+- Use only `open`, `answered`, `not applicable`, or `contract-determined` as row states.
+- Never close a row with a conventional default, best practice, or agent preference.
+- For `answered`, record the user's explicit decision.
+- For `not applicable`, record the user's explicit boundary and reason.
+- For `contract-determined`, cite a repository path, issue, command result, schema, or API definition that directly decides the row.
+- Reopen a row when later evidence or answers create a contradiction.
+
+Use this compact shape while working:
+
+```markdown
+| Decision | Status | Result | Evidence or user answer |
+| --- | --- | --- | --- |
+| Goal | open |  |  |
+```
+
+## Product Intent
+
+- Goal and user-visible outcome.
+- Problem evidence or current-gap source.
+- Primary, secondary, operator, system, and excluded actors.
+- Observable or measurable success criteria.
+- Priority, deadline, release driver, and urgency, including an explicit absence of timing constraints.
+
+## Scope and Experience
+
+- Exact capabilities, flows, commands, screens, APIs, jobs, or documents in scope.
+- Adjacent work, future ideas, migrations, redesigns, and other exclusions.
+- Non-goals and behavior the feature must not introduce.
+- Upstream and downstream dependencies.
+- Existing behavior, data, and contracts that must remain unchanged.
+- Entry points and ordered happy path.
+- Empty, loading, validation, error, permission, cancellation, and recovery states.
+- User-facing terminology, messages, and naming.
+- Accessibility, localization, and supported web, mobile, desktop, CLI, API, or operator surfaces.
+
+## Interfaces and Data
+
+- Public interfaces: Connect RPC, permitted REST exceptions, CLI flags, routes, events, streams, files, or webhooks.
+- Request, response, event, stream, and error shapes.
+- Identifier formats and externally visible references.
+- Authorization, tenancy, and ownership at every interface.
+- Backward compatibility, breaking-change intent, and client migration expectations.
+- Contract documents that must change.
+- Data model, source of truth, persistence, retention, deletion, and archival.
+- Read models, caches, denormalized state, and invalidation.
+- Idempotency, concurrency, ordering, replay, and retry semantics.
+- Import, export, backfill, migration, and rollback data handling.
+
+## Security and Integrations
+
+- Authentication, authorization, and tenant, workspace, project, or user isolation.
+- Secret, token, credential, and key handling.
+- PII, sensitive data, audit, privacy, retention, and deletion requirements.
+- Abuse prevention, rate limits, quotas, fraud controls, and required review gates.
+- Internal services, external APIs, queues, databases, object stores, email, billing, or AI providers.
+- Failure, timeout, retry, duplicate-delivery, and delivery-guarantee behavior for each integration.
+- Environment variables, credentials, and configuration requirements.
+
+## Operations and Observability
+
+- Deployment units and infrastructure changes.
+- Feature flags, staged rollout, cohorts, kill switch, rollback, and deployment compatibility.
+- Latency, throughput, SLO, capacity, scaling, and cost expectations.
+- Runbooks, operator actions, support workflows, and escalation paths.
+- Structured logs needed for debugging and incident analysis.
+- Metrics, traces, dashboards, alerts, audit events, and thresholds.
+- Error classifications and correlation or debug identifiers exposed to users and operators.
+
+## Failure Modes
+
+- Malformed input and validation failure.
+- Partial success, timeout, cancellation, duplicate submission, stale state, and races.
+- Offline clients, degraded dependencies, rate limits, permission changes, and deleted resources.
+- Cross-tenant, cross-workspace, cross-region, and high-volume behavior.
+
+## Documentation and Testing
+
+- Repository contracts, project docs, public docs, API docs, changelog, and release notes to update.
+- Support tooling, administration, FAQ, troubleshooting, training, and migration communication.
+- Observable acceptance criteria.
+- Unit, integration, contract, end-to-end, migration, load, security, accessibility, and manual scenarios that apply.
+- Fixtures, seeded data, mocks, and test environments.
+- Explicit non-regression coverage.
+
+## Issue Filing
+
+- Current GitHub repository resolved from the active worktree.
+- Contract-backed domain prefix and concise title description.
+- Duplicate issue search terms and result.
+- No labels, assignees, milestones, project fields, issue types, or other issue metadata.


### PR DESCRIPTION
## Summary

- add a workspace-local `write-prd` skill adapted for this repository
- require explicit invocation and close a contract-backed decision ledger before drafting or filing a PRD issue
- use the current GitHub repository while keeping issue creation free of labels and other metadata

## Why

This gives Codex a repeatable, repository-aware workflow for turning feature requests into decision-complete PRD issues without inventing product or operational defaults.

## Validation

- ran the skill creator `quick_validate.py` validator successfully
- ran whitespace and static policy checks
- completed a safe plan-only forward test against a realistic `binpm` feature request
- confirmed the diff contains only the four planned skill files