### PR TITLE
fix(dev): restore local DevHud startup

### DIFF
--- a/scripts/dev-environment/compose.oss.yaml
+++ b/scripts/dev-environment/compose.oss.yaml
@@ -35,7 +35,7 @@ services:
 
   logto-init:
     image: svhd/logto:1.41.0@sha256:7f79547e3d1fe569a3ecae757968a7cfc579687aa8164eec35113c0adc983c5b
-    command: ["npm", "run", "cli", "db", "seed", "--", "--swe"]
+    command: ["cli", "db", "seed", "--", "--swe"]
     environment:
       DB_URL: postgres://devhud:devhud@postgres:5432/logto
     depends_on:
@@ -45,7 +45,7 @@ services:
 
   logto:
     image: svhd/logto:1.41.0@sha256:7f79547e3d1fe569a3ecae757968a7cfc579687aa8164eec35113c0adc983c5b
-    command: ["npm", "start"]
+    command: ["start"]
     environment:
       ADMIN_ENDPOINT: http://localhost:3002
       DB_URL: postgres://devhud:devhud@postgres:5432/logto

--- a/scripts/dev-environment/environment.test.mjs
+++ b/scripts/dev-environment/environment.test.mjs
@@ -1417,6 +1417,9 @@ test("repository policy is immutable, orchestration-only, and free of first-part
     compose,
     /logto-database-init:[\s\S]*condition: service_healthy[\s\S]*logto-init:[\s\S]*logto-database-init:[\s\S]*condition: service_completed_successfully/u,
   );
+  assert.match(compose, /command: \["cli", "db", "seed", "--", "--swe"\]/u);
+  assert.match(compose, /command: \["start"\]/u);
+  assert.doesNotMatch(compose, /command: \["npm",/u);
   assert.match(postgresInit, /WHERE NOT EXISTS[\s\S]*\\gexec/u);
 
   const turbo = JSON.parse(await readFile(resolve(repositoryRoot, "turbo.json"), "utf8"));

--- a/servers/devhud-api/internal/telemetry/telemetry.go
+++ b/servers/devhud-api/internal/telemetry/telemetry.go
@@ -14,7 +14,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.43.0"
 )
 
 type Providers struct {

--- a/servers/devhud-api/internal/telemetry/telemetry_test.go
+++ b/servers/devhud-api/internal/telemetry/telemetry_test.go
@@ -1,6 +1,9 @@
 package telemetry
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestTraceExportConfiguredForGenericAndSignalSpecificEndpoints(t *testing.T) {
 	for name, endpoints := range map[string]struct {
@@ -20,5 +23,18 @@ func TestTraceExportConfiguredForGenericAndSignalSpecificEndpoints(t *testing.T)
 				t.Fatalf("traceExportConfigured() = %v, want %v", got, endpoints.want)
 			}
 		})
+	}
+}
+
+func TestNewUsesSDKSemanticConventionSchema(t *testing.T) {
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+
+	providers, err := New(context.Background(), "devhud-api", "test")
+	if err != nil {
+		t.Fatalf("create telemetry providers: %v", err)
+	}
+	if err := providers.Shutdown(context.Background()); err != nil {
+		t.Fatalf("shut down telemetry providers: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- honor the pinned Logto image npm run entrypoint in OSS Compose
- align the DevHud API semantic-convention schema with the current OpenTelemetry SDK default resource
- add regression coverage for both startup failures

## Validation

- `pnpm test:dev-environment`
- `go test ./servers/devhud-api/...`
- `pnpm --filter @delinoio/devhud-api-client build`
- `pnpm --filter devhud-admin build`
- `pnpm dev:oss` (frontend, administrator, API, PostgreSQL, Logto, and the Tauri CEF app started successfully)